### PR TITLE
Implement block image export for NitrFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 * Interrupt handling (IDT, PIT, PIC)
 * Basic thread and task abstractions
 * Mach-style IPC message passing (foundation for future servers)
-* NitrFS secure in-memory filesystem server
+* NitrFS secure in-memory filesystem server with optional block storage
 * All device drivers, filesystems, and networking to run as user-mode agents
 
 ---
@@ -86,7 +86,7 @@ See [AGENTS.md](./AGENTS.md) for a detailed breakdown of all core system agents 
 * [ ] System call interface (done)
 * [ ] Minimal user task/server demo (done)
 * [ ] Basic IPC primitives (in progress)
-* [ ] NitrFS filesystem server (in progress)
+* [x] NitrFS filesystem server (block storage capable)
 * [ ] Window server and networking agents
 * [ ] Shell and developer tools
 

--- a/servers/nitrfs/README.md
+++ b/servers/nitrfs/README.md
@@ -3,7 +3,10 @@
 NitrFS is the reference filesystem server for NitrOS. It aims to provide a
 small but secure storage implementation for early user space. The current
 implementation is a simple RAM-based filesystem that demonstrates the
-message-passing design.
+message-passing design. The API now includes helpers to list and delete files so
+that higher level servers can manage storage without directly accessing the file
+table. In addition, NitrFS can export and import its contents as a block image,
+laying the groundwork for persistent storage.
 
 ## Design Goals
 

--- a/servers/nitrfs/nitrfs.c
+++ b/servers/nitrfs/nitrfs.c
@@ -73,3 +73,94 @@ int nitrfs_verify(nitrfs_fs_t *fs, int handle) {
     nitrfs_file_t *f = &fs->files[handle];
     return f->crc32 == crc32_compute(f->data, f->size) ? 0 : -1;
 }
+
+int nitrfs_delete(nitrfs_fs_t *fs, int handle) {
+    if (handle < 0 || (size_t)handle >= fs->file_count)
+        return -1;
+    nitrfs_file_t *f = &fs->files[handle];
+    free(f->data);
+    for (size_t i = handle; i + 1 < fs->file_count; ++i)
+        fs->files[i] = fs->files[i + 1];
+    fs->file_count--;
+    return 0;
+}
+
+size_t nitrfs_list(nitrfs_fs_t *fs, char names[][NITRFS_NAME_LEN], size_t max) {
+    size_t count = fs->file_count < max ? fs->file_count : max;
+    for (size_t i = 0; i < count; ++i)
+        strncpy(names[i], fs->files[i].name, NITRFS_NAME_LEN);
+    return count;
+}
+
+typedef struct __attribute__((packed)) {
+    uint32_t magic;
+    uint16_t version;
+    uint16_t file_count;
+} disk_header_t;
+
+typedef struct __attribute__((packed)) {
+    char     name[NITRFS_NAME_LEN];
+    uint32_t size;
+    uint32_t perm;
+    uint32_t crc32;
+} disk_entry_t;
+
+int nitrfs_save_blocks(nitrfs_fs_t *fs, uint8_t *blocks, size_t max_blocks) {
+    disk_header_t hdr = { NITRFS_MAGIC, 1, fs->file_count };
+    size_t bytes = sizeof(hdr) + fs->file_count * sizeof(disk_entry_t);
+    for (size_t i = 0; i < fs->file_count; ++i)
+        bytes += fs->files[i].size;
+    size_t need_blocks = (bytes + NITRFS_BLOCK_SIZE - 1) / NITRFS_BLOCK_SIZE;
+    if (need_blocks > max_blocks)
+        return -1;
+
+    uint8_t *p = blocks;
+    memcpy(p, &hdr, sizeof(hdr));
+    p += sizeof(hdr);
+    for (size_t i = 0; i < fs->file_count; ++i) {
+        disk_entry_t e;
+        strncpy(e.name, fs->files[i].name, NITRFS_NAME_LEN);
+        e.size  = fs->files[i].size;
+        e.perm  = fs->files[i].perm;
+        e.crc32 = fs->files[i].crc32;
+        memcpy(p, &e, sizeof(e));
+        p += sizeof(e);
+    }
+    for (size_t i = 0; i < fs->file_count; ++i) {
+        memcpy(p, fs->files[i].data, fs->files[i].size);
+        p += fs->files[i].size;
+    }
+    return need_blocks;
+}
+
+int nitrfs_load_blocks(nitrfs_fs_t *fs, const uint8_t *blocks, size_t blocks_cnt) {
+    nitrfs_init(fs);
+    const uint8_t *p = blocks;
+    size_t bytes = blocks_cnt * NITRFS_BLOCK_SIZE;
+    if (bytes < sizeof(disk_header_t))
+        return -1;
+    disk_header_t hdr;
+    memcpy(&hdr, p, sizeof(hdr));
+    if (hdr.magic != NITRFS_MAGIC || hdr.file_count > NITRFS_MAX_FILES)
+        return -1;
+    p += sizeof(hdr);
+    if (bytes < sizeof(hdr) + hdr.file_count * sizeof(disk_entry_t))
+        return -1;
+    for (size_t i = 0; i < hdr.file_count; ++i) {
+        disk_entry_t e;
+        memcpy(&e, p, sizeof(e));
+        p += sizeof(e);
+        int h = nitrfs_create(fs, e.name, e.size, e.perm);
+        if (h < 0)
+            return -1;
+        fs->files[h].size = e.size;
+        fs->files[h].crc32 = e.crc32;
+    }
+    for (size_t i = 0; i < fs->file_count; ++i) {
+        if ((p - blocks) + fs->files[i].size > bytes)
+            return -1;
+        memcpy(fs->files[i].data, p, fs->files[i].size);
+        p += fs->files[i].size;
+    }
+    return 0;
+}

--- a/servers/nitrfs/nitrfs.h
+++ b/servers/nitrfs/nitrfs.h
@@ -6,6 +6,8 @@
 
 #define NITRFS_MAX_FILES 16
 #define NITRFS_NAME_LEN  32
+#define NITRFS_BLOCK_SIZE 512
+#define NITRFS_MAGIC      0x4652544E /* 'NTRF' */
 
 #define NITRFS_PERM_READ  0x1
 #define NITRFS_PERM_WRITE 0x2
@@ -30,5 +32,10 @@ int  nitrfs_write(nitrfs_fs_t *fs, int handle, uint32_t offset, const void *buf,
 int  nitrfs_read(nitrfs_fs_t *fs, int handle, uint32_t offset, void *buf, uint32_t len);
 int  nitrfs_compute_crc(nitrfs_fs_t *fs, int handle);
 int  nitrfs_verify(nitrfs_fs_t *fs, int handle);
+int  nitrfs_delete(nitrfs_fs_t *fs, int handle);
+size_t nitrfs_list(nitrfs_fs_t *fs, char names[][NITRFS_NAME_LEN], size_t max);
+/* Export/import the entire filesystem as a simple block image. */
+int  nitrfs_save_blocks(nitrfs_fs_t *fs, uint8_t *blocks, size_t max_blocks);
+int  nitrfs_load_blocks(nitrfs_fs_t *fs, const uint8_t *blocks, size_t blocks);
 
 #endif // NITRFS_H


### PR DESCRIPTION
## Summary
- document optional block storage for NitrFS
- note filesystem progress in the root roadmap
- add NitrFS constants and APIs for saving/loading block images

## Testing
- `make clean`
- `make` *(fails: `/opt/cross/bin/x86_64-elf-gcc` missing)*

------
https://chatgpt.com/codex/tasks/task_b_68890f37583c8333951c7158bbe48fa9