### PR TITLE
Implement prototype IPC queue and NitrFS server

### DIFF
--- a/IPC/ipc.c
+++ b/IPC/ipc.c
@@ -1,0 +1,23 @@
+#include "ipc.h"
+#include "../src/libc.h"
+
+void ipc_init(ipc_queue_t *q) {
+    memset(q, 0, sizeof(*q));
+}
+
+int ipc_send(ipc_queue_t *q, const ipc_message_t *msg) {
+    size_t next = (q->head + 1) % IPC_QUEUE_SIZE;
+    if (next == q->tail)
+        return -1; // full
+    q->msgs[q->head] = *msg;
+    q->head = next;
+    return 0;
+}
+
+int ipc_receive(ipc_queue_t *q, ipc_message_t *msg) {
+    if (q->tail == q->head)
+        return -1; // empty
+    *msg = q->msgs[q->tail];
+    q->tail = (q->tail + 1) % IPC_QUEUE_SIZE;
+    return 0;
+}

--- a/IPC/ipc.h
+++ b/IPC/ipc.h
@@ -1,0 +1,27 @@
+#ifndef IPC_H
+#define IPC_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define IPC_MSG_DATA_MAX 64
+#define IPC_QUEUE_SIZE   16
+
+typedef struct {
+    uint32_t type;
+    uint32_t arg1;
+    uint32_t arg2;
+    uint8_t  data[IPC_MSG_DATA_MAX];
+} ipc_message_t;
+
+typedef struct {
+    ipc_message_t msgs[IPC_QUEUE_SIZE];
+    size_t head;
+    size_t tail;
+} ipc_queue_t;
+
+void ipc_init(ipc_queue_t *q);
+int  ipc_send(ipc_queue_t *q, const ipc_message_t *msg);
+int  ipc_receive(ipc_queue_t *q, ipc_message_t *msg);
+
+#endif // IPC_H

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ OBJS = \
   GDT/gdt.o \
   GDT/gdt_flush.o \
   GDT/user.o \
+  IPC/ipc.o \
   libc.o
 
 all: kernel.bin bootloader
@@ -67,6 +68,9 @@ GDT/gdt_flush.o: GDT/gdt.asm
 	$(NASM) -f elf64 $< -o $@
 
 GDT/user.o: GDT/user.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+IPC/ipc.o: IPC/ipc.c IPC/ipc.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 libc.o: src/libc.c src/libc.h

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 * Modular, timer-driven preemptive multitasking
 * Interrupt handling (IDT, PIT, PIC)
 * Basic thread and task abstractions
-* Mach-style IPC message passing (foundation for future servers)
+* Mach-style IPC message passing (prototype queue implementation)
 * NitrFS secure in-memory filesystem server with optional block storage
 * All device drivers, filesystems, and networking to run as user-mode agents
 
@@ -85,7 +85,7 @@ See [AGENTS.md](./AGENTS.md) for a detailed breakdown of all core system agents 
 * [ ] User/kernel context switching (done)
 * [ ] System call interface (done)
 * [ ] Minimal user task/server demo (done)
-* [ ] Basic IPC primitives (in progress)
+* [x] Basic IPC primitives (prototype)
 * [x] NitrFS filesystem server (block storage capable)
 * [ ] Window server and networking agents
 * [ ] Shell and developer tools

--- a/servers/nitrfs/Makefile
+++ b/servers/nitrfs/Makefile
@@ -1,0 +1,17 @@
+CC      = /opt/cross/bin/x86_64-elf-gcc
+CFLAGS  = -ffreestanding -O2 -Wall -Wextra -nostdlib -mno-red-zone
+OBJS    = nitrfs.o server.o ../../IPC/ipc.o ../../src/libc.o
+
+all: nitrfs_server.bin
+
+nitrfs.o: nitrfs.c nitrfs.h
+	$(CC) $(CFLAGS) -c nitrfs.c -o nitrfs.o
+
+server.o: server.c nitrfs.h ../../IPC/ipc.h
+	$(CC) $(CFLAGS) -I../../IPC -I../../src -c server.c -o server.o
+
+nitrfs_server.bin: $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) -o nitrfs_server.bin
+
+clean:
+		rm -f *.o nitrfs_server.bin

--- a/servers/nitrfs/README.md
+++ b/servers/nitrfs/README.md
@@ -18,3 +18,10 @@ laying the groundwork for persistent storage.
 
 Future versions may support persistent block devices and a hierarchical
 on-disk layout, but the initial focus is a minimal, auditable core.
+
+## Server Usage
+
+The `server.c` file implements a minimal message-driven server built on top of
+the generic IPC queue. Each request is delivered as an `ipc_message_t` and the
+server replies on the same queue. This design is extremely small and intended
+only as a demonstration of how future user-mode services might operate.

--- a/servers/nitrfs/server.c
+++ b/servers/nitrfs/server.c
@@ -1,0 +1,62 @@
+#include "nitrfs.h"
+#include "../../IPC/ipc.h"
+#include "../../src/libc.h"
+
+enum {
+    NITRFS_MSG_CREATE = 1,
+    NITRFS_MSG_WRITE,
+    NITRFS_MSG_READ,
+    NITRFS_MSG_DELETE,
+    NITRFS_MSG_LIST
+};
+
+void nitrfs_server(ipc_queue_t *q) {
+    nitrfs_fs_t fs;
+    nitrfs_init(&fs);
+    ipc_message_t msg;
+    ipc_message_t reply;
+    for (;;) {
+        if (ipc_receive(q, &msg) != 0)
+            continue;
+        int handle;
+        int ret;
+        switch (msg.type) {
+        case NITRFS_MSG_CREATE:
+            ret = nitrfs_create(&fs, (const char*)msg.data, msg.arg1, msg.arg2);
+            reply.type = msg.type;
+            reply.arg1 = ret;
+            ipc_send(q, &reply);
+            break;
+        case NITRFS_MSG_WRITE:
+            handle = msg.arg1;
+            ret = nitrfs_write(&fs, handle, 0, msg.data, msg.arg2);
+            reply.type = msg.type;
+            reply.arg1 = ret;
+            ipc_send(q, &reply);
+            break;
+        case NITRFS_MSG_READ:
+            handle = msg.arg1;
+            ret = nitrfs_read(&fs, handle, 0, reply.data, msg.arg2);
+            reply.type = msg.type;
+            reply.arg1 = ret;
+            reply.arg2 = msg.arg2;
+            ipc_send(q, &reply);
+            break;
+        case NITRFS_MSG_DELETE:
+            handle = msg.arg1;
+            ret = nitrfs_delete(&fs, handle);
+            reply.type = msg.type;
+            reply.arg1 = ret;
+            ipc_send(q, &reply);
+            break;
+        case NITRFS_MSG_LIST:
+            reply.arg1 = nitrfs_list(&fs, (char (*)[NITRFS_NAME_LEN])reply.data,
+                                     IPC_MSG_DATA_MAX / NITRFS_NAME_LEN);
+            reply.type = msg.type;
+            ipc_send(q, &reply);
+            break;
+        default:
+            break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add small queue based IPC subsystem
- implement a minimal NitrFS message server
- update build system and documentation

## Testing
- `make` *(fails: `/opt/cross/bin/x86_64-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_688913f0d92c8333ae7509128c75cd50