### PR TITLE
Add prototype shell server and integrate with thread scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ OBJS = \
   GDT/gdt.o \
   GDT/gdt_flush.o \
   GDT/user.o \
+  servers/nitrfs/nitrfs.o \
+  servers/nitrfs/server.o \
+  servers/shell/shell.o \
   IPC/ipc.o \
   libc.o
 
@@ -66,10 +69,19 @@ GDT/gdt.o: GDT/gdt.c
 
 GDT/gdt_flush.o: GDT/gdt.asm
 	$(NASM) -f elf64 $< -o $@
-
+	
 GDT/user.o: GDT/user.c
 	$(CC) $(CFLAGS) -c $< -o $@
-
+	
+servers/nitrfs/nitrfs.o: servers/nitrfs/nitrfs.c servers/nitrfs/nitrfs.h
+	$(CC) $(CFLAGS) -c $< -o $@
+	
+servers/nitrfs/server.o: servers/nitrfs/server.c servers/nitrfs/nitrfs.h IPC/ipc.h
+	$(CC) $(CFLAGS) -IIPC -Isrc -c $< -o $@
+	
+servers/shell/shell.o: servers/shell/shell.c servers/nitrfs/nitrfs.h IPC/ipc.h
+	$(CC) $(CFLAGS) -IIPC -Isrc -c $< -o $@
+	
 IPC/ipc.o: IPC/ipc.c IPC/ipc.h
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 /Bootloader    # UEFI bootloader source (main.c, Makefile)
 /kernel        # Kernel sources (kernel.c, idt.c, gdt.c, ...)
 /servers/nitrfs # NitrFS filesystem server
+/servers/shell  # Simple demonstration shell
 /agents        # Reference docs and AGENTS.md
 /              # Root: Makefile, linker scripts, README.md
 ```
@@ -88,7 +89,7 @@ See [AGENTS.md](./AGENTS.md) for a detailed breakdown of all core system agents 
 * [x] Basic IPC primitives (prototype)
 * [x] NitrFS filesystem server (block storage capable)
 * [ ] Window server and networking agents
-* [ ] Shell and developer tools
+* [x] Shell and developer tools (prototype shell)
 
 ---
 

--- a/servers/nitrfs/server.h
+++ b/servers/nitrfs/server.h
@@ -1,0 +1,5 @@
+#ifndef NITRFS_SERVER_H
+#define NITRFS_SERVER_H
+#include "../../IPC/ipc.h"
+void nitrfs_server(ipc_queue_t *q);
+#endif

--- a/servers/shell/Makefile
+++ b/servers/shell/Makefile
@@ -1,0 +1,14 @@
+CC      = /opt/cross/bin/x86_64-elf-gcc
+CFLAGS  = -ffreestanding -O2 -Wall -Wextra -nostdlib -mno-red-zone
+OBJS    = shell.o ../../IPC/ipc.o ../../src/libc.o ../nitrfs/nitrfs.o ../nitrfs/server.o
+
+all: shell.bin
+
+shell.o: shell.c ../../IPC/ipc.h ../nitrfs/nitrfs.h
+	$(CC) $(CFLAGS) -I../../IPC -I../../src -c shell.c -o shell.o
+
+shell.bin: $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) -o shell.bin
+
+clean:
+	rm -f *.o shell.bin

--- a/servers/shell/shell.c
+++ b/servers/shell/shell.c
@@ -1,0 +1,65 @@
+#include "../../IPC/ipc.h"
+#include "../../src/libc.h"
+#include "../nitrfs/nitrfs.h"
+#include "../../Task/thread.h"
+
+#define VGA_TEXT_BUF 0xB8000
+static int row = 12; // start lower on the screen
+
+static void puts_vga(const char *s) {
+    volatile uint16_t *vga = (uint16_t *)VGA_TEXT_BUF;
+    int col = 0;
+    while (s[col]) {
+        vga[row * 80 + col] = (0x0F << 8) | s[col];
+        col++;
+    }
+    row++;
+}
+
+enum {
+    NITRFS_MSG_CREATE = 1,
+    NITRFS_MSG_WRITE,
+    NITRFS_MSG_READ,
+    NITRFS_MSG_DELETE,
+    NITRFS_MSG_LIST
+};
+
+void shell_main(ipc_queue_t *q) {
+    ipc_message_t msg, reply;
+    const char *fname = "hello.txt";
+    const char *content = "Hello from shell";
+
+    puts_vga("[shell] create file");
+    msg.type = NITRFS_MSG_CREATE;
+    msg.arg1 = 128;
+    msg.arg2 = NITRFS_PERM_READ | NITRFS_PERM_WRITE;
+    memset(msg.data, 0, IPC_MSG_DATA_MAX);
+    memcpy(msg.data, fname, strlen(fname)+1);
+    ipc_send(q, &msg);
+    ipc_receive(q, &reply);
+    int handle = reply.arg1;
+
+    puts_vga("[shell] write file");
+    msg.type = NITRFS_MSG_WRITE;
+    msg.arg1 = handle;
+    msg.arg2 = strlen(content);
+    memset(msg.data, 0, IPC_MSG_DATA_MAX);
+    memcpy(msg.data, content, msg.arg2);
+    ipc_send(q, &msg);
+    ipc_receive(q, &reply);
+
+    puts_vga("[shell] list files");
+    msg.type = NITRFS_MSG_LIST;
+    ipc_send(q, &msg);
+    ipc_receive(q, &reply);
+    int count = reply.arg1;
+    for (int i = 0; i < count; ++i) {
+        puts_vga((char *)reply.data + i * NITRFS_NAME_LEN);
+    }
+
+    while (1) {
+        // Halt this thread
+        for (volatile int i = 0; i < 1000000; ++i);
+        schedule();
+    }
+}

--- a/servers/shell/shell.h
+++ b/servers/shell/shell.h
@@ -1,0 +1,5 @@
+#ifndef SHELL_H
+#define SHELL_H
+#include "../../IPC/ipc.h"
+void shell_main(ipc_queue_t *q);
+#endif


### PR DESCRIPTION
## Summary
- add a simple shell example under `servers/shell`
- expose `nitrfs_server` and new `shell_main` via headers
- launch the shell and NitrFS server as cooperative threads
- update build system and docs for the shell

## Testing
- `make` *(fails: `/opt/cross/bin/x86_64-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_b_688918a17bc88333b6987e64463a1786