### PR TITLE
Add input and basic network drivers

### DIFF
--- a/IDT/idt.c
+++ b/IDT/idt.c
@@ -9,6 +9,8 @@ static struct idt_ptr idtp;
 extern void isr_default_stub(void); // Assembly default ISR handler
 extern void isr_timer_stub(void);   // Timer IRQ0 handler
 extern void isr_syscall_stub(void); // Syscall handler (int 0x80)
+extern void isr_keyboard_stub(void); // Keyboard IRQ1 handler
+extern void isr_mouse_stub(void);    // Mouse IRQ12 handler
 
 void set_idt_entry(int vec, void* isr, uint8_t type_attr) {
     uintptr_t addr = (uintptr_t)isr;
@@ -27,9 +29,11 @@ void idt_install(void) {
     for (int i = 0; i < IDT_ENTRIES; ++i)
         set_idt_entry(i, isr_default_stub, 0x8E); // Present, DPL=0, 64-bit int gate
 
-    // Override with actual handlers for timer and syscall
-    set_idt_entry(32, isr_timer_stub, 0x8E);   // IRQ0
-    set_idt_entry(0x80, isr_syscall_stub, 0xEE); // Ring 3 syscall (DPL=3)
+    // Override with actual handlers for timer, keyboard, mouse and syscall
+    set_idt_entry(32, isr_timer_stub, 0x8E);      // IRQ0
+    set_idt_entry(33, isr_keyboard_stub, 0x8E);   // IRQ1
+    set_idt_entry(44, isr_mouse_stub, 0x8E);      // IRQ12
+    set_idt_entry(0x80, isr_syscall_stub, 0xEE);  // Ring 3 syscall (DPL=3)
 
     idtp.limit = sizeof(idt) - 1;
     idtp.base  = (uintptr_t)&idt;

--- a/IDT/isr_stub.asm
+++ b/IDT/isr_stub.asm
@@ -32,3 +32,27 @@ isr_default_stub:
     call isr_default_handler
     leave
     iretq
+
+global isr_keyboard_stub
+isr_keyboard_stub:
+    push rbp
+    mov rbp, rsp
+    cli
+    extern isr_keyboard_handler
+    call isr_keyboard_handler
+    mov al, 0x20
+    out 0x20, al
+    leave
+    iretq
+
+global isr_mouse_stub
+isr_mouse_stub:
+    push rbp
+    mov rbp, rsp
+    cli
+    extern isr_mouse_handler
+    call isr_mouse_handler
+    mov al, 0x20
+    out 0x20, al
+    leave
+    iretq

--- a/IO/keyboard.c
+++ b/IO/keyboard.c
@@ -1,0 +1,37 @@
+#include "io.h"
+#include "keyboard.h"
+#include <stddef.h>
+
+#define KEYBUF_SIZE 16
+static uint8_t keybuf[KEYBUF_SIZE];
+static volatile int head = 0, tail = 0;
+
+static void keyboard_isr(void);
+
+void keyboard_init(void) {
+    // Nothing special for PS/2 keyboard
+    // Handler installed via IDT in idt_install()
+}
+
+int keyboard_read_scancode(void) {
+    if (tail == head) return -1;
+    uint8_t sc = keybuf[tail];
+    tail = (tail + 1) % KEYBUF_SIZE;
+    return sc;
+}
+
+void keyboard_isr(void) {
+    uint8_t sc = inb(0x60);
+    int next = (head + 1) % KEYBUF_SIZE;
+    if (next != tail) {
+        keybuf[head] = sc;
+        head = next;
+    }
+    outb(0x20, 0x20); // EOI
+}
+
+// Expose handler symbol for assembly stub
+void isr_keyboard_handler(void);
+void isr_keyboard_handler(void) {
+    keyboard_isr();
+}

--- a/IO/keyboard.h
+++ b/IO/keyboard.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <stdint.h>
+
+void keyboard_init(void);
+int keyboard_read_scancode(void); // returns -1 if none

--- a/IO/mouse.c
+++ b/IO/mouse.c
@@ -1,0 +1,61 @@
+#include "io.h"
+#include "mouse.h"
+#include <stddef.h>
+
+#define MOUSEBUF_SIZE 8
+static struct mouse_packet buf[MOUSEBUF_SIZE];
+static volatile int head = 0, tail = 0;
+
+static uint8_t packet[3];
+static int packet_index = 0;
+
+static void mouse_isr(void);
+
+void mouse_init(void) {
+    // Enable auxiliary device
+    outb(0x64, 0xA8);
+    io_wait();
+    // Enable interrupts
+    outb(0x64, 0x20);
+    io_wait();
+    uint8_t status = inb(0x60) | 2;
+    outb(0x64, 0x60);
+    io_wait();
+    outb(0x60, status);
+    // Use default settings
+    outb(0x64, 0xD4);
+    io_wait();
+    outb(0x60, 0xF4);
+    io_wait();
+    inb(0x60); // Ack
+}
+
+int mouse_read_packet(struct mouse_packet *p) {
+    if (tail == head) return -1;
+    *p = buf[tail];
+    tail = (tail + 1) % MOUSEBUF_SIZE;
+    return 0;
+}
+
+void mouse_isr(void) {
+    uint8_t data = inb(0x60);
+    packet[packet_index++] = data;
+    if (packet_index == 3) {
+        struct mouse_packet mp;
+        mp.buttons = packet[0] & 0x07;
+        mp.dx = packet[1];
+        mp.dy = packet[2];
+        int next = (head + 1) % MOUSEBUF_SIZE;
+        if (next != tail) {
+            buf[head] = mp;
+            head = next;
+        }
+        packet_index = 0;
+    }
+    outb(0x20, 0x20); // EOI
+}
+
+void isr_mouse_handler(void);
+void isr_mouse_handler(void) {
+    mouse_isr();
+}

--- a/IO/mouse.h
+++ b/IO/mouse.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <stdint.h>
+
+struct mouse_packet {
+    int8_t dx;
+    int8_t dy;
+    uint8_t buttons;
+};
+
+void mouse_init(void);
+int mouse_read_packet(struct mouse_packet *p); // returns 0 if packet read

--- a/IO/pci.c
+++ b/IO/pci.c
@@ -1,0 +1,20 @@
+#include "io.h"
+#include "pci.h"
+
+#define PCI_ADDRESS_PORT 0xCF8
+#define PCI_DATA_PORT    0xCFC
+
+uint32_t pci_config_read(uint8_t bus, uint8_t slot, uint8_t func, uint8_t offset) {
+    uint32_t address = (uint32_t)((bus << 16) | (slot << 11) |
+                           (func << 8) | (offset & 0xfc) | ((uint32_t)0x80000000));
+    outb(PCI_ADDRESS_PORT, address & 0xFF);
+    outb(PCI_ADDRESS_PORT + 1, (address >> 8) & 0xFF);
+    outb(PCI_ADDRESS_PORT + 2, (address >> 16) & 0xFF);
+    outb(PCI_ADDRESS_PORT + 3, (address >> 24) & 0xFF);
+    uint32_t value = 0;
+    value |= inb(PCI_DATA_PORT);
+    value |= inb(PCI_DATA_PORT + 1) << 8;
+    value |= inb(PCI_DATA_PORT + 2) << 16;
+    value |= inb(PCI_DATA_PORT + 3) << 24;
+    return value;
+}

--- a/IO/pci.h
+++ b/IO/pci.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <stdint.h>
+
+uint32_t pci_config_read(uint8_t bus, uint8_t slot, uint8_t func, uint8_t offset);

--- a/Kernel/kernel.c
+++ b/Kernel/kernel.c
@@ -5,6 +5,9 @@
 #include "../GDT/gdt.h"
 #include "../IO/pic.h"
 #include "../IO/pit.h"
+#include "../IO/keyboard.h"
+#include "../IO/mouse.h"
+#include "../Net/e1000.h"
 
 #define VGA_TEXT_BUF 0xB8000
 
@@ -31,6 +34,9 @@ void kernel_main(void) {
     idt_install();
     pic_remap();
     pit_init(100);
+    keyboard_init();
+    mouse_init();
+    e1000_init();
     paging_init();
     threads_init();
     gdt_install();

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ OBJS = \
   IDT/isr_stub.o \
   IO/pic.o \
   IO/pit.o \
+  IO/keyboard.o \
+  IO/mouse.o \
+  IO/pci.o \
+  Net/e1000.o \
   VM/paging.o \
   Task/thread.o \
   Task/context_switch.o \
@@ -50,6 +54,18 @@ IO/pic.o: IO/pic.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 IO/pit.o: IO/pit.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+IO/keyboard.o: IO/keyboard.c IO/keyboard.h IO/io.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+IO/mouse.o: IO/mouse.c IO/mouse.h IO/io.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+IO/pci.o: IO/pci.c IO/pci.h IO/io.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+Net/e1000.o: Net/e1000.c Net/e1000.h IO/pci.h src/libc.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 VM/paging.o: VM/paging.c

--- a/Net/e1000.c
+++ b/Net/e1000.c
@@ -1,0 +1,32 @@
+#include "../IO/io.h"
+#include "../IO/pci.h"
+#include "e1000.h"
+#include "../src/libc.h"
+
+static void puts_vga(const char *s) {
+    volatile uint16_t *vga = (uint16_t *)0xB8000 + 80*4; // row 4
+    while (*s) {
+        *vga++ = (0x0F << 8) | *s++;
+    }
+}
+
+void e1000_init(void) {
+    for (uint8_t bus = 0; bus < 8; ++bus) {
+        for (uint8_t slot = 0; slot < 32; ++slot) {
+            uint32_t ven_dev = pci_config_read(bus, slot, 0, 0);
+            if (ven_dev == 0xFFFFFFFF)
+                continue;
+            uint16_t vendor = ven_dev & 0xFFFF;
+            uint16_t device = (ven_dev >> 16) & 0xFFFF;
+            if (vendor == 0x8086) {
+                uint32_t classcode = pci_config_read(bus, slot, 0, 0x08);
+                uint8_t class = (classcode >> 24) & 0xFF;
+                uint8_t subclass = (classcode >> 16) & 0xFF;
+                if (class == 0x02 && subclass == 0x00) {
+                    puts_vga("[net] Intel NIC detected\n");
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/Net/e1000.h
+++ b/Net/e1000.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <stdint.h>
+
+void e1000_init(void);


### PR DESCRIPTION
## Summary
- add IDT entries for keyboard and mouse IRQs
- implement PS/2 keyboard and mouse handlers
- add simple PCI access and e1000 detection
- integrate new drivers during kernel initialization

## Testing
- `make` *(fails: `/opt/cross/bin/x86_64-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_68891b8f6118833385486b4e5cee5abc