### PR TITLE
Make cross toolchains configurable

### DIFF
--- a/IO/pic.h
+++ b/IO/pic.h
@@ -2,3 +2,4 @@
 #include <stdint.h>
 
 void pic_remap(void);
+

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -1,5 +1,6 @@
-CC = x86_64-elf-gcc
-LD = x86_64-elf-ld
+CROSS_COMPILE ?= /opt/cross/bin/x86_64-elf-
+CC = $(CROSS_COMPILE)gcc
+LD = $(CROSS_COMPILE)ld
 NASM = nasm
 
 CFLAGS = -ffreestanding -O2 -Wall -Wextra -mno-red-zone -nostdlib

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-CC      = /opt/cross/bin/x86_64-elf-gcc
-LD      = /opt/cross/bin/x86_64-elf-ld
+CROSS_COMPILE ?= /opt/cross/bin/x86_64-elf-
+CC      = $(CROSS_COMPILE)gcc
+LD      = $(CROSS_COMPILE)ld
 NASM    = nasm
 
 CFLAGS  = -ffreestanding -O2 -Wall -Wextra -mno-red-zone -nostdlib

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@
    * `x86_64-elf-gcc`, `nasm`, `qemu`, `make`, `mtools`
    * For UEFI boot: FAT image tools (`mkfs.vfat`, `mcopy`)
    * For gnu-efi bootloader: `gnu-efi` (for bootloader only)
+   * Optionally set the `CROSS_COMPILE` environment variable if your
+     cross compiler prefix differs from the default `/opt/cross/bin/x86_64-elf-`.
 2. **Build the kernel:**
 
    ```sh
-   make
+   make        # use CROSS_COMPILE if your toolchain uses a different prefix
    ```
 3. **Prepare boot image:**
 

--- a/Task/thread.h
+++ b/Task/thread.h
@@ -15,3 +15,4 @@ void threads_init(void);
 void context_switch(uint64_t *old_rsp, uint64_t new_rsp);
 void enter_user_mode(uint64_t entry, uint64_t user_stack);
 void schedule(void);
+

--- a/servers/nitrfs/Makefile
+++ b/servers/nitrfs/Makefile
@@ -1,4 +1,5 @@
-CC      = /opt/cross/bin/x86_64-elf-gcc
+CROSS_COMPILE ?= /opt/cross/bin/x86_64-elf-
+CC      = $(CROSS_COMPILE)gcc
 CFLAGS  = -ffreestanding -O2 -Wall -Wextra -nostdlib -mno-red-zone
 OBJS    = nitrfs.o server.o ../../IPC/ipc.o ../../src/libc.o
 

--- a/servers/shell/Makefile
+++ b/servers/shell/Makefile
@@ -1,4 +1,5 @@
-CC      = /opt/cross/bin/x86_64-elf-gcc
+CROSS_COMPILE ?= /opt/cross/bin/x86_64-elf-
+CC      = $(CROSS_COMPILE)gcc
 CFLAGS  = -ffreestanding -O2 -Wall -Wextra -nostdlib -mno-red-zone
 OBJS    = shell.o ../../IPC/ipc.o ../../src/libc.o ../nitrfs/nitrfs.o ../nitrfs/server.o
 


### PR DESCRIPTION
## Summary
- make cross compiler prefix configurable via `CROSS_COMPILE`
- document `CROSS_COMPILE` usage in README
- ensure header files end with a newline

## Testing
- `make clean`
- `make` *(fails: `/opt/cross/bin/x86_64-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68891de5d74c83339c62b2b374173db5