### PR TITLE
Improve IPC with message metadata and access control

### DIFF
--- a/IPC/ipc.c
+++ b/IPC/ipc.c
@@ -1,22 +1,32 @@
 #include "ipc.h"
 #include "../src/libc.h"
+#include "../Task/thread.h"
 
-void ipc_init(ipc_queue_t *q) {
+void ipc_init(ipc_queue_t *q, uint32_t send_mask, uint32_t recv_mask) {
     memset(q, 0, sizeof(*q));
+    q->send_mask = send_mask;
+    q->recv_mask = recv_mask;
 }
 
-int ipc_send(ipc_queue_t *q, const ipc_message_t *msg) {
+int ipc_send(ipc_queue_t *q, ipc_message_t *msg) {
+    if (!(q->send_mask & (1u << current->id)))
+        return -2; /* unauthorized */
+    if (msg->len > IPC_MSG_DATA_MAX)
+        return -3; /* invalid length */
     size_t next = (q->head + 1) % IPC_QUEUE_SIZE;
     if (next == q->tail)
-        return -1; // full
+        return -1; /* full */
+    msg->sender = current->id;
     q->msgs[q->head] = *msg;
     q->head = next;
     return 0;
 }
 
 int ipc_receive(ipc_queue_t *q, ipc_message_t *msg) {
+    if (!(q->recv_mask & (1u << current->id)))
+        return -2; /* unauthorized */
     if (q->tail == q->head)
-        return -1; // empty
+        return -1; /* empty */
     *msg = q->msgs[q->tail];
     q->tail = (q->tail + 1) % IPC_QUEUE_SIZE;
     return 0;

--- a/IPC/ipc.h
+++ b/IPC/ipc.h
@@ -9,8 +9,10 @@
 
 typedef struct {
     uint32_t type;
+    uint32_t sender;   /* thread id of sender */
     uint32_t arg1;
     uint32_t arg2;
+    uint32_t len;      /* valid bytes in data */
     uint8_t  data[IPC_MSG_DATA_MAX];
 } ipc_message_t;
 
@@ -18,10 +20,12 @@ typedef struct {
     ipc_message_t msgs[IPC_QUEUE_SIZE];
     size_t head;
     size_t tail;
+    uint32_t send_mask; /* bitmask of allowed senders */
+    uint32_t recv_mask; /* bitmask of allowed receivers */
 } ipc_queue_t;
 
-void ipc_init(ipc_queue_t *q);
-int  ipc_send(ipc_queue_t *q, const ipc_message_t *msg);
+void ipc_init(ipc_queue_t *q, uint32_t send_mask, uint32_t recv_mask);
+int  ipc_send(ipc_queue_t *q, ipc_message_t *msg);
 int  ipc_receive(ipc_queue_t *q, ipc_message_t *msg);
 
 #endif // IPC_H

--- a/Task/thread.c
+++ b/Task/thread.c
@@ -24,7 +24,8 @@ static void thread_shell_func(void) {
 }
 
 void threads_init(void) {
-    ipc_init(&fs_queue);
+    uint32_t mask = (1u << 1) | (1u << 2);
+    ipc_init(&fs_queue, mask, mask);
 
     // Filesystem server thread
     thread_fs.stack = stack_fs;

--- a/servers/nitrfs/server.c
+++ b/servers/nitrfs/server.c
@@ -11,6 +11,8 @@ void nitrfs_server(ipc_queue_t *q) {
     for (;;) {
         if (ipc_receive(q, &msg) != 0)
             continue;
+        if (msg.len > IPC_MSG_DATA_MAX)
+            continue; /* ignore bogus message */
         int handle;
         int ret;
         switch (msg.type) {
@@ -18,6 +20,7 @@ void nitrfs_server(ipc_queue_t *q) {
             ret = nitrfs_create(&fs, (const char*)msg.data, msg.arg1, msg.arg2);
             reply.type = msg.type;
             reply.arg1 = ret;
+            reply.len  = 0;
             ipc_send(q, &reply);
             break;
         case NITRFS_MSG_WRITE:
@@ -25,6 +28,7 @@ void nitrfs_server(ipc_queue_t *q) {
             ret = nitrfs_write(&fs, handle, 0, msg.data, msg.arg2);
             reply.type = msg.type;
             reply.arg1 = ret;
+            reply.len  = 0;
             ipc_send(q, &reply);
             break;
         case NITRFS_MSG_READ:
@@ -33,6 +37,7 @@ void nitrfs_server(ipc_queue_t *q) {
             reply.type = msg.type;
             reply.arg1 = ret;
             reply.arg2 = msg.arg2;
+            reply.len  = (ret==0)? msg.arg2 : 0;
             ipc_send(q, &reply);
             break;
         case NITRFS_MSG_DELETE:
@@ -40,12 +45,14 @@ void nitrfs_server(ipc_queue_t *q) {
             ret = nitrfs_delete(&fs, handle);
             reply.type = msg.type;
             reply.arg1 = ret;
+            reply.len  = 0;
             ipc_send(q, &reply);
             break;
         case NITRFS_MSG_LIST:
             reply.arg1 = nitrfs_list(&fs, (char (*)[NITRFS_NAME_LEN])reply.data,
                                      IPC_MSG_DATA_MAX / NITRFS_NAME_LEN);
             reply.type = msg.type;
+            reply.len  = reply.arg1 * NITRFS_NAME_LEN;
             ipc_send(q, &reply);
             break;
         case NITRFS_MSG_CRC:
@@ -55,6 +62,7 @@ void nitrfs_server(ipc_queue_t *q) {
             reply.arg1 = ret;
             if (ret == 0)
                 reply.arg2 = fs.files[handle].crc32;
+            reply.len  = 0;
             ipc_send(q, &reply);
             break;
         case NITRFS_MSG_VERIFY:
@@ -62,6 +70,7 @@ void nitrfs_server(ipc_queue_t *q) {
             ret = nitrfs_verify(&fs, handle);
             reply.type = msg.type;
             reply.arg1 = ret;
+            reply.len  = 0;
             ipc_send(q, &reply);
             break;
         default:

--- a/servers/shell/shell.c
+++ b/servers/shell/shell.c
@@ -63,6 +63,7 @@ void shell_main(ipc_queue_t *q) {
         putc_vga('>'); putc_vga(' ');
         char cmd = getchar_block();
         putc_vga(cmd); putc_vga('\n');
+        msg.len = 0;
 
         switch (cmd) {
         case '1':
@@ -70,6 +71,7 @@ void shell_main(ipc_queue_t *q) {
             msg.arg1 = 128;
             msg.arg2 = NITRFS_PERM_READ | NITRFS_PERM_WRITE;
             strncpy((char *)msg.data, "file.txt", IPC_MSG_DATA_MAX);
+            msg.len = strlen("file.txt");
             ipc_send(q, &msg);
             ipc_receive(q, &reply);
             handle = reply.arg1;
@@ -81,6 +83,7 @@ void shell_main(ipc_queue_t *q) {
             msg.arg1 = handle;
             strncpy((char *)msg.data, "data", IPC_MSG_DATA_MAX);
             msg.arg2 = 4;
+            msg.len  = 4;
             ipc_send(q, &msg);
             ipc_receive(q, &reply);
             puts_vga("wrote\n");
@@ -90,16 +93,18 @@ void shell_main(ipc_queue_t *q) {
             msg.type = NITRFS_MSG_READ;
             msg.arg1 = handle;
             msg.arg2 = IPC_MSG_DATA_MAX;
+            msg.len  = 0;
             ipc_send(q, &msg);
             ipc_receive(q, &reply);
             if (reply.arg1 == 0) {
-                reply.data[reply.arg2] = '\0';
+                reply.data[reply.len] = '\0';
                 puts_vga((char *)reply.data);
                 putc_vga('\n');
             }
             break;
         case '4':
             msg.type = NITRFS_MSG_LIST;
+            msg.len  = 0;
             ipc_send(q, &msg);
             ipc_receive(q, &reply);
             for (int i=0;i<reply.arg1;i++) {
@@ -111,6 +116,7 @@ void shell_main(ipc_queue_t *q) {
             if (handle < 0) { puts_vga("no file\n"); break; }
             msg.type = NITRFS_MSG_CRC;
             msg.arg1 = handle;
+            msg.len  = 0;
             ipc_send(q, &msg);
             ipc_receive(q, &reply);
             if (reply.arg1==0) {
@@ -123,6 +129,7 @@ void shell_main(ipc_queue_t *q) {
             if (handle < 0) { puts_vga("no file\n"); break; }
             msg.type = NITRFS_MSG_VERIFY;
             msg.arg1 = handle;
+            msg.len  = 0;
             ipc_send(q, &msg);
             ipc_receive(q, &reply);
             puts_vga(reply.arg1==0?"verify ok\n":"verify bad\n");


### PR DESCRIPTION
## Summary
- expand IPC headers with sender, length, and access masks
- enforce send/receive permissions and data length checks
- initialise IPC queue with explicit masks
- ensure filesystem server validates message length
- update shell to set message lengths

## Testing
- `make` *(fails: `/opt/cross/bin/x86_64-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6889266cf9fc8333a2851e0fb157100b