### PR TITLE
Refactor IPC API and drop stdlib

### DIFF
--- a/IPC/ipc.c
+++ b/IPC/ipc.c
@@ -1,6 +1,5 @@
 #include "ipc.h"
 #include "../src/libc.h"
-#include "../Task/thread.h"
 
 void ipc_init(ipc_queue_t *q, uint32_t send_mask, uint32_t recv_mask) {
     memset(q, 0, sizeof(*q));
@@ -8,22 +7,22 @@ void ipc_init(ipc_queue_t *q, uint32_t send_mask, uint32_t recv_mask) {
     q->recv_mask = recv_mask;
 }
 
-int ipc_send(ipc_queue_t *q, ipc_message_t *msg) {
-    if (!(q->send_mask & (1u << current->id)))
+int ipc_send(ipc_queue_t *q, uint32_t sender_id, ipc_message_t *msg) {
+    if (!(q->send_mask & (1u << sender_id)))
         return -2; /* unauthorized */
     if (msg->len > IPC_MSG_DATA_MAX)
         return -3; /* invalid length */
     size_t next = (q->head + 1) % IPC_QUEUE_SIZE;
     if (next == q->tail)
         return -1; /* full */
-    msg->sender = current->id;
+    msg->sender = sender_id;
     q->msgs[q->head] = *msg;
     q->head = next;
     return 0;
 }
 
-int ipc_receive(ipc_queue_t *q, ipc_message_t *msg) {
-    if (!(q->recv_mask & (1u << current->id)))
+int ipc_receive(ipc_queue_t *q, uint32_t receiver_id, ipc_message_t *msg) {
+    if (!(q->recv_mask & (1u << receiver_id)))
         return -2; /* unauthorized */
     if (q->tail == q->head)
         return -1; /* empty */

--- a/IPC/ipc.h
+++ b/IPC/ipc.h
@@ -25,7 +25,7 @@ typedef struct {
 } ipc_queue_t;
 
 void ipc_init(ipc_queue_t *q, uint32_t send_mask, uint32_t recv_mask);
-int  ipc_send(ipc_queue_t *q, ipc_message_t *msg);
-int  ipc_receive(ipc_queue_t *q, ipc_message_t *msg);
+int  ipc_send(ipc_queue_t *q, uint32_t sender_id, ipc_message_t *msg);
+int  ipc_receive(ipc_queue_t *q, uint32_t receiver_id, ipc_message_t *msg);
 
 #endif // IPC_H

--- a/Task/thread.c
+++ b/Task/thread.c
@@ -14,11 +14,11 @@ static int next_id = 1;
 ipc_queue_t fs_queue;
 
 static void thread_fs_func(void) {
-    nitrfs_server(&fs_queue);
+    nitrfs_server(&fs_queue, current->id);
 }
 
 static void thread_shell_func(void) {
-    shell_main(&fs_queue);
+    shell_main(&fs_queue, current->id);
 }
 
 thread_t *thread_create(void (*func)(void)) {

--- a/servers/nitrfs/nitrfs.c
+++ b/servers/nitrfs/nitrfs.c
@@ -1,6 +1,5 @@
 #include "nitrfs.h"
-#include <string.h>
-#include <stdlib.h>
+#include "../../src/libc.h"
 
 static uint32_t crc32_compute(const uint8_t *data, uint32_t len) {
     uint32_t crc = ~0u;

--- a/servers/nitrfs/server.c
+++ b/servers/nitrfs/server.c
@@ -3,13 +3,13 @@
 #include "../../src/libc.h"
 #include "server.h"
 
-void nitrfs_server(ipc_queue_t *q) {
+void nitrfs_server(ipc_queue_t *q, uint32_t self_id) {
     nitrfs_fs_t fs;
     nitrfs_init(&fs);
     ipc_message_t msg;
     ipc_message_t reply;
     for (;;) {
-        if (ipc_receive(q, &msg) != 0)
+        if (ipc_receive(q, self_id, &msg) != 0)
             continue;
         if (msg.len > IPC_MSG_DATA_MAX)
             continue; /* ignore bogus message */
@@ -21,7 +21,7 @@ void nitrfs_server(ipc_queue_t *q) {
             reply.type = msg.type;
             reply.arg1 = ret;
             reply.len  = 0;
-            ipc_send(q, &reply);
+            ipc_send(q, self_id, &reply);
             break;
         case NITRFS_MSG_WRITE:
             handle = msg.arg1;
@@ -29,7 +29,7 @@ void nitrfs_server(ipc_queue_t *q) {
             reply.type = msg.type;
             reply.arg1 = ret;
             reply.len  = 0;
-            ipc_send(q, &reply);
+            ipc_send(q, self_id, &reply);
             break;
         case NITRFS_MSG_READ:
             handle = msg.arg1;
@@ -38,7 +38,7 @@ void nitrfs_server(ipc_queue_t *q) {
             reply.arg1 = ret;
             reply.arg2 = msg.arg2;
             reply.len  = (ret==0)? msg.arg2 : 0;
-            ipc_send(q, &reply);
+            ipc_send(q, self_id, &reply);
             break;
         case NITRFS_MSG_DELETE:
             handle = msg.arg1;
@@ -46,14 +46,14 @@ void nitrfs_server(ipc_queue_t *q) {
             reply.type = msg.type;
             reply.arg1 = ret;
             reply.len  = 0;
-            ipc_send(q, &reply);
+            ipc_send(q, self_id, &reply);
             break;
         case NITRFS_MSG_LIST:
             reply.arg1 = nitrfs_list(&fs, (char (*)[NITRFS_NAME_LEN])reply.data,
                                      IPC_MSG_DATA_MAX / NITRFS_NAME_LEN);
             reply.type = msg.type;
             reply.len  = reply.arg1 * NITRFS_NAME_LEN;
-            ipc_send(q, &reply);
+            ipc_send(q, self_id, &reply);
             break;
         case NITRFS_MSG_CRC:
             handle = msg.arg1;
@@ -63,7 +63,7 @@ void nitrfs_server(ipc_queue_t *q) {
             if (ret == 0)
                 reply.arg2 = fs.files[handle].crc32;
             reply.len  = 0;
-            ipc_send(q, &reply);
+            ipc_send(q, self_id, &reply);
             break;
         case NITRFS_MSG_VERIFY:
             handle = msg.arg1;
@@ -71,7 +71,7 @@ void nitrfs_server(ipc_queue_t *q) {
             reply.type = msg.type;
             reply.arg1 = ret;
             reply.len  = 0;
-            ipc_send(q, &reply);
+            ipc_send(q, self_id, &reply);
             break;
         default:
             break;

--- a/servers/nitrfs/server.h
+++ b/servers/nitrfs/server.h
@@ -12,5 +12,5 @@ enum {
     NITRFS_MSG_VERIFY
 };
 
-void nitrfs_server(ipc_queue_t *q);
+void nitrfs_server(ipc_queue_t *q, uint32_t self_id);
 #endif

--- a/servers/shell/shell.h
+++ b/servers/shell/shell.h
@@ -1,5 +1,5 @@
 #ifndef SHELL_H
 #define SHELL_H
 #include "../../IPC/ipc.h"
-void shell_main(ipc_queue_t *q);
+void shell_main(ipc_queue_t *q, uint32_t self_id);
 #endif


### PR DESCRIPTION
## Summary
- stop including `thread.h` in user code and add syscall-based yield helper
- switch IPC functions to require explicit sender/receiver IDs
- remove standard headers from NitrFS server and use project libc
- adjust thread startup to pass thread IDs to servers

## Testing
- `make` *(fails: x86_64-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_b_68894d9a8a8083338c2969301b019d3b