### PR TITLE
Document shell commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ This file is intended as a high-level guide and technical reference for all cont
 * **Examples:**
 
   * **NitrFS server:** Secure in-memory filesystem via IPC
+  * **Shell server:** Simple command interpreter using IPC
   * **Device driver server:** Handles input/output to actual hardware, passes events/data to other agents
   * **Demo tasks:** Print to VGA, test syscalls, simple multi-threaded demos
 * **Interactions:**

--- a/README.md
+++ b/README.md
@@ -68,6 +68,34 @@
 
 ---
 
+## User Environment
+
+NitrOS boots directly into a minimal set of user-mode services. A small
+shell task communicates with the **NitrFS** filesystem server purely
+through IPC to showcase how higher level applications will interact with
+the kernel and each other.
+
+### Shell Commands
+
+When the shell starts it prints:
+
+```
+NOS shell ready
+1:create 2:write 3:read 4:list 5:crc 6:verify
+```
+
+The single-character commands provide a very small interface for testing
+NitrFS:
+
+1. `1` – create a file called `file.txt` with read/write permissions
+2. `2` – write the string `data` to the file
+3. `3` – read back the file contents
+4. `4` – list all files stored in NitrFS
+5. `5` – compute and store a CRC32 checksum for the file
+6. `6` – verify the stored checksum against the file data
+
+---
+
 ## How It Works
 
 1. **UEFI bootloader** loads the kernel from `/EFI/BOOT/kernel.bin` into RAM and jumps to its entry point in long mode.

--- a/servers/nitrfs/README.md
+++ b/servers/nitrfs/README.md
@@ -25,3 +25,17 @@ The `server.c` file implements a minimal message-driven server built on top of
 the generic IPC queue. Each request is delivered as an `ipc_message_t` and the
 server replies on the same queue. This design is extremely small and intended
 only as a demonstration of how future user-mode services might operate.
+
+### Message Types
+
+The filesystem server understands the following request types:
+
+| Type              | Description                          |
+| ----------------- | ------------------------------------ |
+| `NITRFS_MSG_CREATE` | Create a new file with a given size and permissions |
+| `NITRFS_MSG_WRITE`  | Write data to an open file           |
+| `NITRFS_MSG_READ`   | Read data from an open file          |
+| `NITRFS_MSG_DELETE` | Delete a file by handle              |
+| `NITRFS_MSG_LIST`   | List all file names                  |
+| `NITRFS_MSG_CRC`    | Compute CRC32 of a file              |
+| `NITRFS_MSG_VERIFY` | Verify stored CRC against data       |


### PR DESCRIPTION
## Summary
- describe shell commands in README
- expand NitrFS server documentation with supported message types
- list shell server role in AGENTS

## Testing
- `make` *(fails: x86_64-elf-gcc missing)*

------
https://chatgpt.com/codex/tasks/task_b_688957dd83248333811881d6f37a07b7