### PR TITLE
Add verbose boot logging

### DIFF
--- a/Kernel/kernel.c
+++ b/Kernel/kernel.c
@@ -12,13 +12,27 @@
 
 #define VGA_TEXT_BUF 0xB8000
 
-void vga_write(const char* s) {
+static void vga_write(const char* s) {
     volatile uint16_t* vga = (uint16_t*)VGA_TEXT_BUF;
     int i = 0;
     while (s[i]) {
         vga[i] = (0x0F << 8) | s[i]; // White on black
         i++;
     }
+}
+
+static int log_row = 1;
+
+static void log_line(const char *s)
+{
+    volatile uint16_t *vga = (uint16_t *)VGA_TEXT_BUF + log_row * 80;
+    int i = 0;
+    while (s[i]) {
+        vga[i] = (0x0F << 8) | s[i];
+        i++;
+    }
+    if (log_row < 24)
+        log_row++;
 }
 
 // System call dispatcher for int $0x80
@@ -34,15 +48,25 @@ void isr_syscall_handler(void) {
 
 void kernel_main(void) {
     vga_write("Mach Microkernel: Boot OK");
+    log_line("[init] IDT");
     idt_install();
+    log_line("[init] PIC");
     pic_remap();
+    log_line("[init] PIT");
     pit_init(100);
+    log_line("[init] Keyboard");
     keyboard_init();
+    log_line("[init] Mouse");
     mouse_init();
+    log_line("[init] NIC");
     e1000_init();
+    log_line("[init] Paging");
     paging_init();
+    log_line("[init] Threads");
     threads_init();
+    log_line("[init] GDT");
     gdt_install();
+    log_line("[init] start first thread");
 
     // Start first thread
     asm volatile(


### PR DESCRIPTION
## Summary
- add a simple kernel log function writing to VGA
- emit debug lines for each boot step

## Testing
- `make` *(fails: x86_64-elf-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68899670763c8333a00c4629344fb892