### PR TITLE
Improve build system and bootloader

### DIFF
--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -6,12 +6,45 @@ NASM = nasm
 CFLAGS = -ffreestanding -O2 -Wall -Wextra -mno-red-zone -nostdlib
 LDFLAGS = -T kernel.ld -nostdlib
 
-OBJS = kernel_entry.o kernel.o idt.o interrupt.o isr_stub.o
+OBJS = \
+    kernel_entry.o \
+    kernel.o \
+    ../IDT/idt.o \
+    ../IDT/interrupt.o \
+    ../IDT/isr_stub.o \
+    ../IO/pic.o \
+    ../IO/pit.o \
+    ../IO/keyboard.o \
+    ../IO/mouse.o \
+    ../IO/pci.o \
+    ../Net/e1000.o \
+    ../VM/paging.o \
+    ../Task/thread.o \
+    ../Task/context_switch.o \
+    ../Task/user_mode.o \
+    ../GDT/gdt.o \
+    ../GDT/gdt_flush.o \
+    ../GDT/user.o \
+    syscall.o \
+    ../servers/nitrfs/nitrfs.o \
+    ../servers/nitrfs/server.o \
+    ../servers/shell/shell.o \
+    ../IPC/ipc.o \
+    ../libc.o
 
 all: kernel.bin
 
 kernel.o: kernel.c
 	$(CC) $(CFLAGS) -c $< -o $@
+
+../%.o: ../%.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+../%.o: ../%.asm
+	$(NASM) -f elf64 $< -o $@
+
+../GDT/gdt_flush.o: ../GDT/gdt.asm
+	$(NASM) -f elf64 $< -o $@
 
 idt.o: idt.c
 	$(CC) $(CFLAGS) -c $< -o $@
@@ -29,4 +62,6 @@ kernel.bin: $(OBJS) kernel.ld
 	$(LD) $(LDFLAGS) $(OBJS) -o $@
 
 clean:
-	rm -f *.o kernel.bin
+	rm -f *.o kernel.bin \
+../IDT/*.o ../IO/*.o ../Net/*.o ../VM/*.o \
+../Task/*.o ../GDT/*.o ../servers/*/*.o ../IPC/*.o ../libc.o

--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -3,9 +3,11 @@
 TARGET = NitrOBoot.efi
 OBJS = src/NitrOBoot.o
 
+CC ?= clang
+
 CFLAGS = \
-	-target x86_64-pc-win32-coff \
-	-ffreestanding \
+        -target x86_64-pc-win32-coff \
+        -ffreestanding \
 	-fshort-wchar \
 	-mno-red-zone \
 	-fno-stack-protector \
@@ -17,23 +19,23 @@ CFLAGS = \
 	-c
 
 LDFLAGS = \
-	-target x86_64-pc-win32-coff \
-	-nostdlib \
-	-Wl,-entry:efi_main \
-	-Wl,-subsystem:efi_application \
-	-Wl,-dll \
-	-fuse-ld=lld-link \
-	-Wl,-nodefaultlib \
-	-Wl,-align:4096 \
-	-Wl,-filealign:4096
+        -target x86_64-pc-win32-coff \
+        -nostdlib \
+        -Wl,-entry:efi_main \
+        -Wl,-subsystem:efi_application \
+        -Wl,-dll \
+        -fuse-ld=lld-link \
+        -Wl,-nodefaultlib \
+        -Wl,-align:4096 \
+        -Wl,-filealign:4096
 
 all: $(TARGET)
 
 %.o: %.c
-	clang $(CFLAGS) -o $@ $<
+	$(CC) $(CFLAGS) -o $@ $<
 
 $(TARGET): $(OBJS)
-	clang $(LDFLAGS) -o $@ $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $(OBJS)
 
 clean:
-	rm -f $(TARGET) $(OBJS)
+		rm -f $(TARGET) $(OBJS)

--- a/bootloader/include/efi.h
+++ b/bootloader/include/efi.h
@@ -9,11 +9,21 @@ typedef void VOID;
 typedef unsigned long long EFI_PHYSICAL_ADDRESS;
 typedef unsigned int UINT32;
 
+// Allocation types
+#define EFI_ALLOCATE_ANY_PAGES   0
+#define EFI_ALLOCATE_MAX_ADDRESS 1
+#define EFI_ALLOCATE_ADDRESS     2
+
+// Memory types
+#define EfiLoaderCode   1
+#define EfiLoaderData   2
+
 #define EFI_SUCCESS           0
 #define EFI_LOAD_ERROR        (EFI_STATUS)(1 | (1ULL << 63))
 
 typedef struct EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL;
 typedef struct EFI_BOOT_SERVICES EFI_BOOT_SERVICES;
+typedef struct EFI_MEMORY_DESCRIPTOR EFI_MEMORY_DESCRIPTOR;
 
 struct EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL {
     VOID *dummy; // unused
@@ -25,22 +35,40 @@ struct EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL {
 };
 
 struct EFI_BOOT_SERVICES {
-    char _pad1[24];  // Skip initial table fields (header and some functions)
-    
-    // Add AllocatePages at the correct offset (simplified version)
+    char _pad1[40];  // Skip EFI table header and TPL services
+
     EFI_STATUS (*AllocatePages)(
         UINT32 Type,
         UINT32 MemoryType,
         UINTN Pages,
         EFI_PHYSICAL_ADDRESS *Memory
     );
+    EFI_STATUS (*FreePages)(
+        EFI_PHYSICAL_ADDRESS Memory,
+        UINTN Pages
+    );
+    EFI_STATUS (*GetMemoryMap)(
+        UINTN *MemoryMapSize,
+        EFI_MEMORY_DESCRIPTOR *MemoryMap,
+        UINTN *MapKey,
+        UINTN *DescriptorSize,
+        UINT32 *DescriptorVersion
+    );
 
-    char _pad2[64];  // Placeholder padding, adjust if more functions are used
+    char _pad2[48];  // Skip to ExitBootServices
 
     EFI_STATUS (*ExitBootServices)(
         EFI_HANDLE ImageHandle,
         UINTN MapKey
     );
+};
+
+struct EFI_MEMORY_DESCRIPTOR {
+    UINT32 Type;
+    EFI_PHYSICAL_ADDRESS PhysicalStart;
+    EFI_PHYSICAL_ADDRESS VirtualStart;
+    UINTN NumberOfPages;
+    UINT64 Attribute;
 };
 
 typedef struct {


### PR DESCRIPTION
## Summary
- add EFI allocation and memory descriptor helpers
- retrieve memory map before ExitBootServices
- make bootloader Makefile portable and tab-correct
- delegate kernel build to `Kernel/Makefile`
- clean up kernel objects from subdirectories

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_b_688ad0a38f948333b179e9345fc26e2b