### PR TITLE
Add verbose bootloader logging

### DIFF
--- a/bootloader/include/efi.h
+++ b/bootloader/include/efi.h
@@ -35,6 +35,26 @@ typedef struct {
 #define EFI_BUFFER_TOO_SMALL      (EFI_STATUS)(5ULL | (1ULL << 63))
 #define EFI_NOT_FOUND             (EFI_STATUS)(14ULL | (1ULL << 63))
 
+// Text output colors and attributes
+#define EFI_BLACK        0x0
+#define EFI_BLUE         0x1
+#define EFI_GREEN        0x2
+#define EFI_CYAN         0x3
+#define EFI_RED          0x4
+#define EFI_MAGENTA      0x5
+#define EFI_BROWN        0x6
+#define EFI_LIGHTGRAY    0x7
+#define EFI_DARKGRAY     0x8
+#define EFI_LIGHTBLUE    0x9
+#define EFI_LIGHTGREEN   0xA
+#define EFI_LIGHTCYAN    0xB
+#define EFI_LIGHTRED     0xC
+#define EFI_LIGHTMAGENTA 0xD
+#define EFI_YELLOW       0xE
+#define EFI_WHITE        0xF
+
+#define EFI_TEXT_ATTR(fg, bg) ((fg) | ((bg) << 4))
+
 // Page Allocation Types
 #define EFI_ALLOCATE_ANY_PAGES      0
 #define EFI_ALLOCATE_MAX_ADDRESS    1

--- a/bootloader/src/NitrOBoot.c
+++ b/bootloader/src/NitrOBoot.c
@@ -5,84 +5,119 @@
 #define KERNEL_BASE_ADDR 0x100000
 #define KERNEL_MAX_SIZE (2 * 1024 * 1024)
 
+static void print_step(EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *ConOut, CHAR16 *msg) {
+    ConOut->SetAttribute(ConOut, EFI_TEXT_ATTR(EFI_YELLOW, EFI_BLACK));
+    ConOut->OutputString(ConOut, msg);
+    ConOut->SetAttribute(ConOut, EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK));
+}
+
+static void print_ok(EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *ConOut) {
+    ConOut->SetAttribute(ConOut, EFI_TEXT_ATTR(EFI_LIGHTGREEN, EFI_BLACK));
+    ConOut->OutputString(ConOut, L" [OK]\r\n");
+    ConOut->SetAttribute(ConOut, EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK));
+}
+
+static void print_fail(EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *ConOut, CHAR16 *msg) {
+    ConOut->SetAttribute(ConOut, EFI_TEXT_ATTR(EFI_LIGHTRED, EFI_BLACK));
+    ConOut->OutputString(ConOut, L" [FAIL]\r\n");
+    if (msg) ConOut->OutputString(ConOut, msg);
+    ConOut->SetAttribute(ConOut, EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK));
+}
+
 EFI_STATUS efi_main(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable) {
     EFI_STATUS status;
     EFI_BOOT_SERVICES *BS = SystemTable->BootServices;
     EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *ConOut = SystemTable->ConOut;
 
+    ConOut->SetAttribute(ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_BLUE));
+    ConOut->ClearScreen(ConOut);
     ConOut->OutputString(ConOut, L"NitrOBoot Loader Starting...\r\n");
+    ConOut->SetAttribute(ConOut, EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLACK));
 
     // (1) Locate Simple FileSystem Protocol
     EFI_SIMPLE_FILE_SYSTEM_PROTOCOL *FileSystem;
+    print_step(ConOut, L"[1] Locate FileSystem protocol...");
     status = BS->HandleProtocol(ImageHandle, &gEfiSimpleFileSystemProtocolGuid, (VOID**)&FileSystem);
     if (status != EFI_SUCCESS) {
-        ConOut->OutputString(ConOut, L"Error: Can't locate FileSystem protocol\r\n");
+        print_fail(ConOut, L"Error: Can't locate FileSystem protocol\r\n");
         return status;
     }
+    print_ok(ConOut);
 
     EFI_FILE_PROTOCOL *Root;
+    print_step(ConOut, L"[2] Open root volume...");
     status = FileSystem->OpenVolume(FileSystem, &Root);
     if (status != EFI_SUCCESS) {
-        ConOut->OutputString(ConOut, L"Error: Can't open root directory\r\n");
+        print_fail(ConOut, L"Error: Can't open root directory\r\n");
         return status;
     }
+    print_ok(ConOut);
 
     EFI_FILE_PROTOCOL *KernelFile;
+    print_step(ConOut, L"[3] Open kernel file...");
     status = Root->Open(Root, &KernelFile, KERNEL_PATH, EFI_FILE_MODE_READ, 0);
     if (status != EFI_SUCCESS) {
-        ConOut->OutputString(ConOut, L"Error: Can't open kernel.bin\r\n");
+        print_fail(ConOut, L"Error: Can't open kernel.bin\r\n");
         return status;
     }
+    print_ok(ConOut);
 
     // (2) Allocate pages for kernel
     EFI_PHYSICAL_ADDRESS kernel_base = KERNEL_BASE_ADDR;
     UINTN kernel_pages = (KERNEL_MAX_SIZE + 4095) / 4096;
+    print_step(ConOut, L"[4] Allocate pages for kernel...");
     status = BS->AllocatePages(EFI_ALLOCATE_ADDRESS, EfiLoaderData, kernel_pages, &kernel_base);
     if (status != EFI_SUCCESS) {
-        ConOut->OutputString(ConOut, L"Error: Allocation failed\r\n");
+        print_fail(ConOut, L"Error: Allocation failed\r\n");
         return status;
     }
+    print_ok(ConOut);
 
     // (3) Read kernel file into memory
     UINTN kernel_size = KERNEL_MAX_SIZE;
+    print_step(ConOut, L"[5] Read kernel into memory...");
     status = KernelFile->Read(KernelFile, &kernel_size, (VOID*)kernel_base);
     KernelFile->Close(KernelFile);
 
     if (status != EFI_SUCCESS || kernel_size == 0) {
-        ConOut->OutputString(ConOut, L"Error: Failed to read kernel.bin\r\n");
+        print_fail(ConOut, L"Error: Failed to read kernel.bin\r\n");
         return EFI_LOAD_ERROR;
     }
-
-    ConOut->OutputString(ConOut, L"Kernel loaded successfully\r\n");
+    print_ok(ConOut);
 
     // (4) Get memory map for ExitBootServices
     UINTN mmap_size = 0, map_key, desc_size;
     UINT32 desc_ver;
+    print_step(ConOut, L"[6] Obtain memory map...");
     BS->GetMemoryMap(&mmap_size, NULL, &map_key, &desc_size, &desc_ver);
     mmap_size += desc_size * 8;
 
     EFI_PHYSICAL_ADDRESS mmap_addr;
     status = BS->AllocatePages(EFI_ALLOCATE_ANY_PAGES, EfiLoaderData, (mmap_size + 4095) / 4096, &mmap_addr);
     if (status != EFI_SUCCESS) {
-        ConOut->OutputString(ConOut, L"Error: Can't allocate memory for memory map\r\n");
+        print_fail(ConOut, L"Error: Can't allocate memory for memory map\r\n");
         return status;
     }
 
     EFI_MEMORY_DESCRIPTOR *memory_map = (EFI_MEMORY_DESCRIPTOR*)(UINTN)mmap_addr;
     status = BS->GetMemoryMap(&mmap_size, memory_map, &map_key, &desc_size, &desc_ver);
     if (status != EFI_SUCCESS) {
-        ConOut->OutputString(ConOut, L"Error: GetMemoryMap failed\r\n");
+        print_fail(ConOut, L"Error: GetMemoryMap failed\r\n");
         return status;
     }
+    print_ok(ConOut);
 
     // (5) Exit Boot Services
+    print_step(ConOut, L"[7] Exit boot services...");
     status = BS->ExitBootServices(ImageHandle, map_key);
     if (status != EFI_SUCCESS) {
-        ConOut->OutputString(ConOut, L"Error: ExitBootServices failed\r\n");
+        print_fail(ConOut, L"Error: ExitBootServices failed\r\n");
         return status;
     }
+    print_ok(ConOut);
 
     // (6) Jump to kernel entry point
+    print_step(ConOut, L"[8] Jumping to kernel...\r\n");
     void (*kernel_entry)(void *) = (void (*)(void *))kernel_base;
     kernel_entry(NULL); // Pass a structure here if needed
 


### PR DESCRIPTION
## Summary
- add text color defines for boot output
- print progress messages in the bootloader with colors

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_b_688ae05f4de48333a7ca014220b04779