### PR TITLE
Fix kernel boot info handling

### DIFF
--- a/Kernel/kernel_entry.asm
+++ b/Kernel/kernel_entry.asm
@@ -1,36 +1,28 @@
+section .bss
+align 16
+kernel_stack:
+    resb 16384            ; 16 KiB kernel stack
+kernel_stack_top:
+
 section .text
 global _start
 
-; Symbols for kernel_main and optional stack end
+; Kernel entry symbol implemented in C
 extern kernel_main
-
-; Multiboot2 magic as per the spec
-%define MULTIBOOT2_BOOTLOADER_MAGIC 0x36d76289
 
 _start:
     cld
 
-    ; Set up stack
-    mov     rsp, 0x200000
-    xor     rbp, rbp
+    ; rdi contains the bootinfo pointer from the bootloader
+    mov rax, rdi          ; preserve bootinfo pointer
 
-    ; Detect Multiboot2: GRUB sets eax == MULTIBOOT2_BOOTLOADER_MAGIC, rbx = info ptr
-    mov     rax, [rsp+8]    ; get the return address pushed by the bootloader (multiboot2 puts magic in rax/eax at entry)
-    cmp     eax, MULTIBOOT2_BOOTLOADER_MAGIC
-    jne     .not_multiboot2
+    ; Set up a small kernel stack
+    lea rsp, [kernel_stack_top]
+    xor rbp, rbp
 
-    ; --- Multiboot2 detected ---
-    mov     rdi, rbx                  ; boot info pointer
-    mov     esi, 2                    ; boot_type = 2 (Multiboot2)
-    jmp     .enter_kernel
-
-.not_multiboot2:
-    ; UEFI or unknown (called by efi stub, etc.)
-    xor     rdi, rdi                  ; boot info pointer = NULL or your EFI struct if available
-    mov     esi, 1                    ; boot_type = 1 (UEFI)
-
-.enter_kernel:
-    call    kernel_main               ; void kernel_main(void* bootinfo, uint32_t boot_type)
+    ; Pass bootinfo pointer to kernel_main in rdi
+    mov rdi, rax
+    call kernel_main
 
 .hang:
     cli


### PR DESCRIPTION
## Summary
- fix kernel bootstrap assembly
- allocate a stack and forward the bootinfo pointer from the bootloader

## Testing
- `make libc`
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_688b3f7a919c8333bb2d6db98ca52073