### PR TITLE
Fix bootloader simple filesystem protocol

### DIFF
--- a/bootloader/include/efi.h
+++ b/bootloader/include/efi.h
@@ -341,8 +341,18 @@ static const EFI_GUID gEfiAcpi20TableGuid =
 static const EFI_GUID gEfiAcpi10TableGuid =
     { 0xeb9d2d30, 0x2d88, 0x11d3, { 0x9a, 0x16, 0x0, 0x0, 0x9c, 0x00, 0x83, 0x0b } };
 
-static const EFI_GUID gEfiSimpleFileSystemProtocolGuid = 
-    { 0x0964e5b2, 0x6459, 0x11d2, { 0x8e, 0x39, 0x0, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+static const EFI_GUID gEfiSimpleFileSystemProtocolGuid =
+    { 0x964e5b22, 0x6459, 0x11d2, { 0x8e, 0x39, 0x0, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+static const EFI_GUID gEfiLoadedImageProtocolGuid =
+    { 0x5b1b31a1, 0x9562, 0x11d2, { 0x8e, 0x3f, 0x0, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+typedef struct EFI_LOADED_IMAGE_PROTOCOL {
+    UINT32     Revision;
+    EFI_HANDLE ParentHandle;
+    struct EFI_SYSTEM_TABLE *SystemTable;
+    EFI_HANDLE DeviceHandle;
+} EFI_LOADED_IMAGE_PROTOCOL;
 
 // ====================
 // EFI_MEMORY_DESCRIPTOR

--- a/bootloader/src/NitrOBoot.c
+++ b/bootloader/src/NitrOBoot.c
@@ -2,7 +2,7 @@
 #include "../include/bootinfo.h"
 #include "kernel_loader.h"
 
-#define KERNEL_PATH L"\\EFI\\BOOT\\kernel.bin"
+#define KERNEL_PATH L"\\kernel.bin"
 #define KERNEL_MAX_SIZE (2 * 1024 * 1024)
 #define BOOTINFO_MAX_MMAP 128
 
@@ -193,8 +193,10 @@ EFI_STATUS efi_main(EFI_HANDLE ImageHandle, struct EFI_SYSTEM_TABLE *SystemTable
         ConOut->OutputString(ConOut, L"No ACPI RSDP found.\r\n");
 
     // --- 5. Kernel ELF load ---
+    // Locate the simple filesystem protocol in the system
     struct EFI_SIMPLE_FILE_SYSTEM_PROTOCOL *FileSystem;
-    status = BS->HandleProtocol(ImageHandle, (EFI_GUID*)&gEfiSimpleFileSystemProtocolGuid, (VOID**)&FileSystem);
+    status = BS->LocateProtocol((EFI_GUID*)&gEfiSimpleFileSystemProtocolGuid,
+                                NULL, (VOID**)&FileSystem);
     if (status != EFI_SUCCESS) { ConOut->OutputString(ConOut, L"FS protocol failed.\r\n"); for(;;); }
     struct EFI_FILE_PROTOCOL *Root;
     status = FileSystem->OpenVolume(FileSystem, &Root);


### PR DESCRIPTION
## Summary
- correct GUID for EFI simple file system protocol
- use LocateProtocol to acquire the filesystem
- load kernel from the disk root

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_b_688b5ec2b31483339d247ff8c20588e3