### PR TITLE
Zero bootloader BSS before loading kernel

### DIFF
--- a/bootloader/linker.ld
+++ b/bootloader/linker.ld
@@ -15,7 +15,9 @@ SECTIONS
     }
 
     .bss : {
+        __bss_start = .;
         *(.bss*)
+        __bss_end = .;
     }
 
     /DISCARD/ : { *(.note.gnu.*) *(.eh_frame*) }

--- a/bootloader/src/NitrOBoot.c
+++ b/bootloader/src/NitrOBoot.c
@@ -2,6 +2,13 @@
 #include "../include/bootinfo.h"
 #include "kernel_loader.h"
 
+extern char __bss_start, __bss_end;
+
+static void zero_bss(void) {
+    for (char *p = &__bss_start; p < &__bss_end; ++p)
+        *p = 0;
+}
+
 #define KERNEL_PATH L"\\kernel.bin"
 #define KERNEL_MAX_SIZE (2 * 1024 * 1024)
 #define BOOTINFO_MAX_MMAP 128
@@ -115,6 +122,7 @@ EFI_STATUS efi_main(EFI_HANDLE ImageHandle, struct EFI_SYSTEM_TABLE *SystemTable
     EFI_STATUS status;
     struct EFI_BOOT_SERVICES *BS = SystemTable->BootServices;
     struct EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *ConOut = SystemTable->ConOut;
+    zero_bss();
     ConOut->SetAttribute(ConOut, EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLUE));
     ConOut->ClearScreen(ConOut);
     ConOut->OutputString(ConOut, L"NitrOBoot UEFI Loader starting...\r\n");


### PR DESCRIPTION
## Summary
- zero `.bss` in bootloader before performing any allocations
- expose `__bss_start` and `__bss_end` in the bootloader linker script

## Testing
- `make all` *(fails: `clang` missing)*

------
https://chatgpt.com/codex/tasks/task_b_688b734ce18483338b42ffff6f40a391