### PR TITLE
Add bootinfo debug guards

### DIFF
--- a/Kernel/kernel.c
+++ b/Kernel/kernel.c
@@ -104,6 +104,10 @@ static void fb_demo_bar(const bootinfo_framebuffer_t *fb) {
 static void print_bootinfo(const bootinfo_t *bi) {
     char buf[80];
     if (!bi) { log_warn("No bootinfo struct."); return; }
+    ptoa((uint64_t)bi, buf); log_line("[boot] bootinfo ptr:"); log_line(buf);
+    ptoa((uint64_t)bi->mmap, buf); log_line("[boot] mmap ptr:"); log_line(buf);
+    utoa(bi->mmap_entries, buf, 10); log_line("[boot] mmap entries:"); log_line(buf);
+    ptoa((uint64_t)bi->framebuffer, buf); log_line("[boot] framebuffer ptr:"); log_line(buf);
     if (bi->magic == BOOTINFO_MAGIC_UEFI) log_good("[boot] UEFI detected.");
     else if (bi->magic == BOOTINFO_MAGIC_MB2) log_good("[boot] Multiboot2 detected.");
     else log_warn("[boot] Unknown boot magic!");
@@ -138,6 +142,9 @@ void kernel_main(bootinfo_t *bootinfo) {
     vga_clear();
     log_good("Mach Microkernel: Boot OK");
     log_line("");
+    if (!bootinfo || !bootinfo->framebuffer) log_line("No framebuffer!");
+    if (!bootinfo || !bootinfo->mmap) log_line("No mmap!");
+    if (bootinfo && bootinfo->mmap_entries > 64) log_warn("Warning: suspiciously large mmap_entries");
     print_bootinfo(bootinfo);
     // Initialize core subsystems and start userland services
     gdt_install();

--- a/bootloader/src/NitrOBoot.c
+++ b/bootloader/src/NitrOBoot.c
@@ -129,6 +129,9 @@ EFI_STATUS efi_main(EFI_HANDLE ImageHandle, struct EFI_SYSTEM_TABLE *SystemTable
     info->magic = BOOTINFO_MAGIC_UEFI;
     info->size = sizeof(bootinfo_t);
     info->bootloader_name = "NitrOBoot UEFI";
+    print_hex(ConOut, L"bootinfo ptr: ", (UINTN)info);
+    print_hex(ConOut, L"bootinfo size: ", info->size);
+    print_hex(ConOut, L"bootinfo magic:", info->magic);
 
     // --- 2. UEFI Memory map (copy & print) ---
     UINTN mmap_size = 0, map_key, desc_size;
@@ -163,6 +166,8 @@ EFI_STATUS efi_main(EFI_HANDLE ImageHandle, struct EFI_SYSTEM_TABLE *SystemTable
     }
     info->mmap = mmap;
     info->mmap_entries = mmap_count;
+    print_hex(ConOut, L"mmap struct ptr: ", (UINTN)mmap);
+    print_hex(ConOut, L"mmap entries : ", mmap_count);
 
     // --- 3. Framebuffer info + fill screen ---
     EFI_GRAPHICS_OUTPUT_PROTOCOL *gop = NULL;
@@ -180,6 +185,11 @@ EFI_STATUS efi_main(EFI_HANDLE ImageHandle, struct EFI_SYSTEM_TABLE *SystemTable
             fb->bpp     = 32;
             fb->type    = 0;
             info->framebuffer = fb;
+            print_hex(ConOut, L"fb struct ptr: ", (UINTN)fb);
+            print_hex(ConOut, L"fb addr     : ", fb->address);
+            print_hex(ConOut, L"fb width    : ", fb->width);
+            print_hex(ConOut, L"fb height   : ", fb->height);
+            print_hex(ConOut, L"fb pitch    : ", fb->pitch);
             // Fill framebuffer with color
             UINT32 *pixels = (UINT32*)(UINTN)fb->address;
             for (UINT32 y = 0; y < fb->height; ++y)


### PR DESCRIPTION
## Summary
- print boot info addresses during bootloader setup
- add pointer logging in kernel boot info printer
- guard bootinfo pointers in `kernel_main`

## Testing
- `make -C Kernel` *(fails: `/opt/cross/bin/x86_64-elf-gcc` not found)*
- `make -C bootloader` *(fails: `clang` not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b7a46580483339846d09df61e14b6