### PR TITLE
Add size logging and bootinfo mmap checks

### DIFF
--- a/bootloader/src/NitrOBoot.c
+++ b/bootloader/src/NitrOBoot.c
@@ -131,6 +131,7 @@ EFI_STATUS efi_main(EFI_HANDLE ImageHandle, struct EFI_SYSTEM_TABLE *SystemTable
     print_hex(ConOut, L"bootinfo ptr: ", (UINTN)info);
     print_hex(ConOut, L"bootinfo size: ", info->size);
     print_hex(ConOut, L"bootinfo magic:", info->magic);
+    print_hex(ConOut, L"bootinfo_memory_t size: ", sizeof(bootinfo_memory_t));
 
     // --- 2. UEFI Memory map (copy & print) ---
     UINTN mmap_size = 0, map_key, desc_size;


### PR DESCRIPTION
## Summary
- print bootinfo_memory_t size in bootloader and kernel
- add guard for oversized mmap_entries
- only print first two and last two mmap entries in kernel to verify array bounds

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_b_688b83884a608333a041c9ecc0807215