### PR TITLE
Fix bootinfo layout mismatch

### DIFF
--- a/Kernel/kernel.c
+++ b/Kernel/kernel.c
@@ -163,8 +163,12 @@ void kernel_main(bootinfo_t *bootinfo) {
     vga_clear();
     log_good("Mach Microkernel: Boot OK");
     log_line("");
-    if (!bootinfo || !bootinfo->framebuffer) log_line("No framebuffer!");
-    if (!bootinfo || !bootinfo->mmap) log_line("No mmap!");
+    if (!bootinfo || bootinfo->size != sizeof(bootinfo_t)) {
+        log_err("bootinfo size mismatch");
+        for(;;) __asm__("hlt");
+    }
+    if (!bootinfo->framebuffer) log_line("No framebuffer!");
+    if (!bootinfo->mmap) log_line("No mmap!");
     if (bootinfo && bootinfo->mmap_entries > 128) {
         log_err("BUG: mmap_entries too high, halting.");
         for(;;) __asm__("hlt");

--- a/bootloader/include/bootinfo.h
+++ b/bootloader/include/bootinfo.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <stdint.h>
+#include <stddef.h>
+
+#pragma pack(push,1)
 #define BOOTINFO_MAGIC_UEFI 0x55454649
 #define BOOTINFO_MAGIC_MB2  0x36d76289
 #define BOOTINFO_MAX_MMAP    128
@@ -36,3 +39,11 @@ typedef struct bootinfo {
     uint64_t reserved[8];
     void *kernel_entry;
 } bootinfo_t;
+
+#pragma pack(pop)
+
+_Static_assert(sizeof(bootinfo_memory_t) == 24, "bootinfo_memory_t size mismatch");
+_Static_assert(sizeof(bootinfo_framebuffer_t) == 32, "bootinfo_framebuffer_t size mismatch");
+_Static_assert(sizeof(bootinfo_cpu_t) == 16, "bootinfo_cpu_t size mismatch");
+_Static_assert(sizeof(bootinfo_t) == 648 || sizeof(bootinfo_t) == 656,
+               "bootinfo_t unexpected size");


### PR DESCRIPTION
## Summary
- ensure boot info structures share identical packing
- detect bootinfo struct size mismatch in the kernel

## Testing
- `make clean`
- `make all` *(fails: clang missing)*
- `make -C Kernel` *(fails: cross compiler missing)*

------
https://chatgpt.com/codex/tasks/task_b_688b913eaed88333ae30fb075a8aaf7c