### PR TITLE
Fix UEFI loader crash after ExitBootServices

### DIFF
--- a/bootloader/src/NitrOBoot.c
+++ b/bootloader/src/NitrOBoot.c
@@ -258,10 +258,10 @@ EFI_STATUS efi_main(EFI_HANDLE ImageHandle, struct EFI_SYSTEM_TABLE *SystemTable
         status = BS->GetMemoryMap(&mmap_size, efi_mmap, &map_key, &desc_size, &desc_ver);
     }
     if (status != EFI_SUCCESS) { ConOut->OutputString(ConOut, L"GetMemoryMap before ExitBootServices failed.\r\n"); for(;;); }
+    ConOut->OutputString(ConOut, L"Exiting boot services.\r\n");
+
     status = BS->ExitBootServices(ImageHandle, map_key);
     if (status != EFI_SUCCESS) { ConOut->OutputString(ConOut, L"ExitBootServices failed.\r\n"); for(;;); }
-
-    ConOut->OutputString(ConOut, L"Exiting boot services.\r\n");
 
     g_info = info;
     g_entry = entry_fn;


### PR DESCRIPTION
## Summary
- print "Exiting boot services" before calling `ExitBootServices`
- avoid using UEFI console services after the boot services have been shut down

## Testing
- `make bootloader`
- `make -C Kernel`


------
https://chatgpt.com/codex/tasks/task_b_688bb52ade3083339f348a5bf440a506