### PR TITLE
Fix warnings in kernel and shell

### DIFF
--- a/IDT/interrupt.c
+++ b/IDT/interrupt.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include "../Task/thread.h"
 void isr_default_handler(uint64_t *rsp) {
+    (void)rsp; // unused in default handler
     // You could output to serial here or VGA
     volatile char *vga = (char*)0xB8000 + 160; // Line 2
     const char *msg = "INTERRUPT!";

--- a/Net/e1000.c
+++ b/Net/e1000.c
@@ -23,7 +23,6 @@ int e1000_init(void) {
             if (ven_dev == 0xFFFFFFFF)
                 continue;
             uint16_t vendor = ven_dev & 0xFFFF;
-            uint16_t device = (ven_dev >> 16) & 0xFFFF;
 
             if (vendor == INTEL_VENDOR_ID) {
                 uint32_t classcode = pci_config_read(bus, slot, 0, 0x08);

--- a/VM/pmm.c
+++ b/VM/pmm.c
@@ -2,8 +2,6 @@
 #include "paging.h"
 #include "../src/libc.h"
 
-#define PAGE_SIZE 4096ULL
-
 static uint8_t *bitmap = NULL;
 static uint64_t total_frames = 0;
 

--- a/servers/shell/shell.c
+++ b/servers/shell/shell.c
@@ -161,10 +161,15 @@ static void cmd_create(ipc_queue_t *q, uint32_t self_id, const char *name) {
     ipc_message_t msg = {0}, reply = {0};
     msg.type = NITRFS_MSG_CREATE; msg.arg1 = IPC_MSG_DATA_MAX;
     msg.arg2 = NITRFS_PERM_READ | NITRFS_PERM_WRITE;
-    strncpy((char *)msg.data, name, IPC_MSG_DATA_MAX); msg.len = strlen(name);
+    size_t len = strlen(name);
+    if (len > IPC_MSG_DATA_MAX - 1)
+        len = IPC_MSG_DATA_MAX - 1;
+    strncpy((char *)msg.data, name, len);
+    msg.data[len] = '\0';
+    msg.len = len;
     ipc_send(q, self_id, &msg);
     ipc_receive(q, self_id, &reply);
-    puts_vga(reply.arg1 >= 0 ? "created\n" : "error\n");
+    puts_vga(reply.arg1 == 0 ? "created\n" : "error\n");
 }
 static void cmd_write(ipc_queue_t *q, uint32_t self_id, const char *name, const char *data) {
     int h = find_handle(q, self_id, name);
@@ -191,8 +196,12 @@ static void cmd_mv(ipc_queue_t *q, uint32_t self_id, const char *old, const char
     ipc_message_t msg = {0}, reply = {0};
     msg.type = NITRFS_MSG_RENAME;
     msg.arg1 = h;
-    strncpy((char *)msg.data, new, IPC_MSG_DATA_MAX);
-    msg.len = strlen(new);
+    size_t len = strlen(new);
+    if (len > IPC_MSG_DATA_MAX - 1)
+        len = IPC_MSG_DATA_MAX - 1;
+    strncpy((char *)msg.data, new, len);
+    msg.data[len] = '\0';
+    msg.len = len;
     ipc_send(q, self_id, &msg);
     ipc_receive(q, self_id, &reply);
     puts_vga(reply.arg1 == 0 ? "moved\n" : "error\n");

--- a/src/libc.c
+++ b/src/libc.c
@@ -155,9 +155,11 @@ void free(void *ptr) {
     }
 }
 void *__memcpy_chk(void *dest, const void *src, size_t n, size_t destlen) {
-    // Simply ignore destlen and call memcpy
+    (void)destlen; // parameter not used in this stub
     return memcpy(dest, src, n);
 }
+
 char *__strncpy_chk(char *dest, const char *src, size_t n, size_t destlen) {
+    (void)destlen; // parameter not used in this stub
     return strncpy(dest, src, n);
 }


### PR DESCRIPTION
## Summary
- silence unused parameter warnings in libc and interrupt handler
- drop unused variable from NIC driver
- use paging macros from headers and avoid redefinitions
- fix buffer handling and comparison in shell

## Testing
- `make kernel` *(fails: No rule to make target '../libc.o', needed by 'kernel.bin')*
- `make -C servers/shell` *(fails: `/opt/cross/bin/x86_64-elf-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_b_688bcaef2df883338870574af4a5e098