### PR TITLE
Fix PMM bitmap allocation

### DIFF
--- a/VM/pmm.c
+++ b/VM/pmm.c
@@ -18,6 +18,8 @@ static inline int bit_test(uint64_t bit) {
 void pmm_init(const bootinfo_t *bootinfo) {
     uint64_t max_addr = 0;
     for (uint32_t i = 0; i < bootinfo->mmap_entries; ++i) {
+        if (bootinfo->mmap[i].type != 7)
+            continue;
         uint64_t end = bootinfo->mmap[i].addr + bootinfo->mmap[i].len;
         if (end > max_addr)
             max_addr = end;


### PR DESCRIPTION
## Summary
- fix physical memory manager to size bitmap based only on usable RAM

## Testing
- `make CROSS_COMPILE=x86_64-linux-gnu-`

------
https://chatgpt.com/codex/tasks/task_b_688bdab26b2c8333ab94611c3eeaea6e