### PR TITLE
Fix PIC masks so shell runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Build artifacts
+*.o
+kernel.bin
+libc.o
+disk.img
+bootloader/*.efi
+bootloader/src/*.obj
+Kernel/*.bin
+Kernel/*.o
+qemu.log
+qemu_output.txt
+*.img
+

--- a/IO/pic.c
+++ b/IO/pic.c
@@ -33,6 +33,8 @@ void pic_remap(void) {
     outb(PIC2_DATA, 0x01);
     io_wait();
 
-    outb(PIC1_DATA, a1);   // restore saved masks
-    outb(PIC2_DATA, a2);
+    // Unmask timer (IRQ0) and keyboard (IRQ1) while masking others
+    // This allows scheduling preemption via PIT and keyboard input
+    outb(PIC1_DATA, 0xFC); // 11111100b -> IRQ0 and IRQ1 enabled
+    outb(PIC2_DATA, 0xFF); // mask all IRQs on the slave PIC for now
 }


### PR DESCRIPTION
## Summary
- fix `pic_remap` to enable timer and keyboard IRQs
- ignore build artefacts

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_b_688be0bbff608333a528d0bd57fcf654