### PR TITLE
Update build defaults and QEMU args

### DIFF
--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -1,4 +1,4 @@
-CROSS_COMPILE ?= /opt/cross/bin/x86_64-elf-
+CROSS_COMPILE ?= x86_64-linux-gnu-
 CC = $(CROSS_COMPILE)gcc
 LD = $(CROSS_COMPILE)ld
 NASM = nasm

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CROSS_COMPILE ?= /opt/cross/bin/x86_64-elf-
+CROSS_COMPILE ?= x86_64-linux-gnu-
 
 all: libc kernel bootloader disk.img
 
@@ -20,16 +20,17 @@ disk.img: bootloader kernel
 	mcopy -i disk.img bootloader/NitrOBoot.efi ::/EFI/BOOT/BOOTX64.EFI
 	mcopy -i disk.img kernel.bin ::/
 
+
 clean:
 	make -C Kernel clean
 	make -C bootloader clean
 	rm -f kernel.bin libc.o disk.img
-
+	
 run: disk.img
 	qemu-system-x86_64 \
-		-bios OVMF.fd \
-		-drive file=disk.img,format=raw \
-		-m 512M \
-		-enable-kvm
+	-bios OVMF.fd \
+	-drive file=disk.img,format=raw \
+	-m 512M \
+	-serial stdio -display none
 
 .PHONY: all libc kernel bootloader clean run

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@
 
    * `x86_64-elf-gcc`, `nasm`, `clang`, `lld`, `qemu`, `make`, `mtools`, `dosfstools`
    * FAT image tools (`mkfs.vfat`, `mcopy`) for creating the boot disk
-   * Optionally set the `CROSS_COMPILE` environment variable if your
-     cross compiler prefix differs from the default `/opt/cross/bin/x86_64-elf-`.
-     For example, Ubuntu packages typically use `x86_64-linux-gnu-`:
+  * Optionally set the `CROSS_COMPILE` environment variable if your
+    cross compiler prefix differs from the default `x86_64-linux-gnu-`.
+    For example:
 
-     ```sh
-     make CROSS_COMPILE=x86_64-linux-gnu-
-     ```
+    ```sh
+    make CROSS_COMPILE=/opt/cross/bin/x86_64-elf-
+    ```
 2. **Build the kernel:**
 
    ```sh


### PR DESCRIPTION
## Summary
- default cross compiler to `x86_64-linux-gnu-`
- run QEMU in headless mode for CI
- document new prefix in README

## Testing
- `make clean`
- `make`
- `make run` (booted in QEMU, printed boot info)

------
https://chatgpt.com/codex/tasks/task_b_688bf3271ccc8333a325ebac9918be16