### PR TITLE
Improve libc and clean PIC init

### DIFF
--- a/IO/pic.c
+++ b/IO/pic.c
@@ -10,10 +10,9 @@
 #define PIC2_DATA   (PIC2+1)
 
 void pic_remap(void) {
-    uint8_t a1, a2;
-
-    a1 = inb(PIC1_DATA); // Save masks
-    a2 = inb(PIC2_DATA);
+    /* Save current masks - not used since we set new masks explicitly */
+    (void)inb(PIC1_DATA);
+    (void)inb(PIC2_DATA);
 
     outb(PIC1_COMMAND, 0x11); // starts the init
     io_wait();

--- a/servers/shell/shell.c
+++ b/servers/shell/shell.c
@@ -270,7 +270,7 @@ static void cmd_cd(ipc_queue_t *q, uint32_t self_id, const char *path) {
         new[len] = '/'; new[len+1] = '\0';
     }
     if (find_handle(q, self_id, new) < 0) { puts_vga("no such dir\n"); return; }
-    strncpy(cwd, new, sizeof(cwd)-1); cwd[sizeof(cwd)-1] = '\0';
+    strlcpy(cwd, new, sizeof(cwd));
 }
 
 static void cmd_mkdir(ipc_queue_t *q, uint32_t self_id, const char *name) {
@@ -282,8 +282,7 @@ static void cmd_mkdir(ipc_queue_t *q, uint32_t self_id, const char *name) {
     ipc_message_t msg = {0}, reply = {0};
     msg.type = NITRFS_MSG_CREATE; msg.arg1 = 0; // zero capacity
     msg.arg2 = NITRFS_PERM_READ | NITRFS_PERM_WRITE;
-    strncpy((char *)msg.data, path, NITRFS_NAME_LEN-1);
-    msg.data[NITRFS_NAME_LEN-1] = '\0';
+    strlcpy((char *)msg.data, path, NITRFS_NAME_LEN);
     msg.len = strlen((char *)msg.data);
     ipc_send(q, self_id, &msg); ipc_receive(q, self_id, &reply);
     puts_vga(reply.arg1 == 0 ? "created\n" : "error\n");

--- a/src/libc.c
+++ b/src/libc.c
@@ -51,6 +51,16 @@ char *strncpy(char *dest, const char *src, size_t n) {
     return dest;
 }
 
+size_t strlcpy(char *dst, const char *src, size_t size) {
+    size_t srclen = strlen(src);
+    if (size) {
+        size_t copylen = (srclen >= size) ? size - 1 : srclen;
+        memcpy(dst, src, copylen);
+        dst[copylen] = '\0';
+    }
+    return srclen;
+}
+
 int strcmp(const char *s1, const char *s2) {
     while (*s1 && (*s1 == *s2)) { s1++; s2++; }
     return *(const unsigned char *)s1 - *(const unsigned char *)s2;

--- a/src/libc.h
+++ b/src/libc.h
@@ -7,6 +7,7 @@ void *memmove(void *dest, const void *src, size_t n);
 int memcmp(const void *s1, const void *s2, size_t n);
 size_t strlen(const char *s);
 char *strncpy(char *dest, const char *src, size_t n);
+size_t strlcpy(char *dst, const char *src, size_t size);
 int strcmp(const char *s1, const char *s2);
 int strncmp(const char *s1, const char *s2, size_t n);
 


### PR DESCRIPTION
## Summary
- remove unused variables in `pic_remap`
- implement `strlcpy` in libc and expose it via header
- use `strlcpy` in shell for safer string copying

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_b_688bfa09f0988333af20c86fec78430a