### PR TITLE
Add basic ACPI initialization

### DIFF
--- a/ACPI/acpi.c
+++ b/ACPI/acpi.c
@@ -1,0 +1,70 @@
+#include "acpi.h"
+#include "../IO/serial.h"
+#include "../src/libc.h"
+
+struct rsdp {
+    char     signature[8];
+    uint8_t  checksum;
+    char     oemid[6];
+    uint8_t  revision;
+    uint32_t rsdt_addr;
+    uint32_t length;
+    uint64_t xsdt_addr;
+    uint8_t  extended_checksum;
+    uint8_t  reserved[3];
+} __attribute__((packed));
+
+struct sdt_header {
+    char     signature[4];
+    uint32_t length;
+    uint8_t  revision;
+    uint8_t  checksum;
+    char     oemid[6];
+    char     oemtableid[8];
+    uint32_t oem_revision;
+    uint32_t creator_id;
+    uint32_t creator_revision;
+} __attribute__((packed));
+
+static uint8_t sum(const uint8_t *p, size_t len) {
+    uint8_t v = 0; for (size_t i = 0; i < len; ++i) v += p[i]; return v;
+}
+
+static void print_sig(const char *s) {
+    char buf[5];
+    buf[0] = s[0]; buf[1] = s[1]; buf[2] = s[2]; buf[3] = s[3]; buf[4] = 0;
+    serial_puts(buf);
+}
+
+void acpi_init(const bootinfo_t *bootinfo) {
+    serial_puts("[acpi] init\n");
+    if (!bootinfo || !bootinfo->acpi_rsdp) {
+        serial_puts("[acpi] no RSDP\n");
+        return;
+    }
+    struct rsdp *rsdp = (struct rsdp*)(uintptr_t)bootinfo->acpi_rsdp;
+    if (memcmp(rsdp->signature, "RSD PTR ", 8) != 0) {
+        serial_puts("[acpi] bad signature\n");
+        return;
+    }
+    size_t len = (rsdp->revision < 2) ? 20 : rsdp->length;
+    if (sum((const uint8_t*)rsdp, len)) {
+        serial_puts("[acpi] checksum fail\n");
+        return;
+    }
+    serial_puts("[acpi] RSDP ok\n");
+    struct sdt_header *rsdt = (struct sdt_header*)(uintptr_t)rsdp->rsdt_addr;
+    if (!rsdt) { serial_puts("[acpi] no RSDT\n"); return; }
+    if (sum((const uint8_t*)rsdt, rsdt->length)) {
+        serial_puts("[acpi] RSDT checksum fail\n");
+        return;
+    }
+    int entries = (rsdt->length - sizeof(*rsdt)) / 4;
+    uint32_t *ptrs = (uint32_t*)((uintptr_t)rsdt + sizeof(*rsdt));
+    for (int i = 0; i < entries && i < 8; ++i) {
+        struct sdt_header *hdr = (struct sdt_header*)(uintptr_t)ptrs[i];
+        serial_puts("[acpi] table ");
+        print_sig(hdr->signature);
+        serial_puts("\n");
+    }
+}

--- a/ACPI/acpi.h
+++ b/ACPI/acpi.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <stdint.h>
+#include "../bootloader/include/bootinfo.h"
+
+void acpi_init(const bootinfo_t *bootinfo);

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -33,6 +33,7 @@ OBJS = \
     ../servers/shell/shell.o \
     ../IPC/ipc.o \
     ../CPU/cpu.o \
+    ../ACPI/acpi.o \
     ../libc.o
 
 all: kernel.bin

--- a/Kernel/kernel.c
+++ b/Kernel/kernel.c
@@ -10,6 +10,7 @@
 #include "../VM/pmm.h"
 #include "../VM/paging.h"
 #include "../CPU/cpu.h"
+#include "../ACPI/acpi.h"
 
 #define VGA_TEXT_BUF 0xB8000
 #define VGA_COLS 80
@@ -189,6 +190,7 @@ void kernel_main(bootinfo_t *bootinfo) {
         bootinfo->cpus[0].flags = 1;
     }
     print_bootinfo(bootinfo);
+    acpi_init(bootinfo);
     log_line("[Stage 2] Init memory management");
     pmm_init(bootinfo);
     paging_init();

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * Full paging and memory protection
 * Modular, timer-driven preemptive multitasking
 * Interrupt handling (IDT, PIT, PIC)
+* Early ACPI table parsing for basic hardware enumeration
 * Basic thread and task abstractions
 * Mach-style IPC message passing (prototype queue implementation)
 * NitrFS secure in-memory filesystem server with optional block storage


### PR DESCRIPTION
## Summary
- implement ACPI module that validates the RSDP and lists RSDT tables
- compile ACPI module as part of kernel
- initialize ACPI in kernel startup
- note ACPI support in README

## Testing
- `make` *(fails: clang missing)*

------
https://chatgpt.com/codex/tasks/task_b_688bff5e634c83339f605ec0b99a6fc5