### PR TITLE
Add basic ACPI DSDT and input/video drivers

### DIFF
--- a/ACPI/acpi.c
+++ b/ACPI/acpi.c
@@ -26,6 +26,10 @@ struct sdt_header {
     uint32_t creator_revision;
 } __attribute__((packed));
 
+static const struct sdt_header *g_dsdt = NULL;
+
+const void *acpi_get_dsdt(void) { return g_dsdt; }
+
 static uint8_t sum(const uint8_t *p, size_t len) {
     uint8_t v = 0; for (size_t i = 0; i < len; ++i) v += p[i]; return v;
 }
@@ -61,10 +65,29 @@ void acpi_init(const bootinfo_t *bootinfo) {
     }
     int entries = (rsdt->length - sizeof(*rsdt)) / 4;
     uint32_t *ptrs = (uint32_t*)((uintptr_t)rsdt + sizeof(*rsdt));
-    for (int i = 0; i < entries && i < 8; ++i) {
+    g_dsdt = NULL;
+    for (int i = 0; i < entries && i < 16; ++i) {
         struct sdt_header *hdr = (struct sdt_header*)(uintptr_t)ptrs[i];
         serial_puts("[acpi] table ");
         print_sig(hdr->signature);
         serial_puts("\n");
+        if (!memcmp(hdr->signature, "FACP", 4)) {
+            serial_puts("[acpi] FADT found\n");
+            if (hdr->length >= 44) {
+                uint32_t dsdt32 = *(uint32_t*)((uint8_t*)hdr + 40);
+                uint64_t dsdt = dsdt32;
+                if (hdr->length >= 148) {
+                    uint64_t dsdt64 = *(uint64_t*)((uint8_t*)hdr + 140);
+                    if (dsdt64) dsdt = dsdt64;
+                }
+                struct sdt_header *d = (struct sdt_header*)(uintptr_t)dsdt;
+                if (d && sum((const uint8_t*)d, d->length) == 0 && !memcmp(d->signature, "DSDT", 4)) {
+                    g_dsdt = d;
+                    serial_puts("[acpi] DSDT loaded\n");
+                } else {
+                    serial_puts("[acpi] DSDT invalid\n");
+                }
+            }
+        }
     }
 }

--- a/ACPI/acpi.h
+++ b/ACPI/acpi.h
@@ -3,3 +3,4 @@
 #include "../bootloader/include/bootinfo.h"
 
 void acpi_init(const bootinfo_t *bootinfo);
+const void *acpi_get_dsdt(void);

--- a/IO/keyboard.c
+++ b/IO/keyboard.c
@@ -1,5 +1,6 @@
 #include "io.h"
 #include "keyboard.h"
+#include "pic.h"
 #include <stddef.h>
 
 #define KEYBUF_SIZE 32
@@ -29,7 +30,8 @@ static const char keymap_shift[128] = {
 static void keyboard_isr(void);
 
 void keyboard_init(void) {
-    // Nothing special for PS/2 keyboard
+    // Enable keyboard IRQ1 on PIC
+    pic_set_mask(1, 1);
     // Handler installed via IDT in idt_install()
 }
 

--- a/IO/mouse.c
+++ b/IO/mouse.c
@@ -1,5 +1,6 @@
 #include "io.h"
 #include "mouse.h"
+#include "pic.h"
 #include <stddef.h>
 
 #define MOUSEBUF_SIZE 8
@@ -28,6 +29,7 @@ void mouse_init(void) {
     outb(0x60, 0xF4);
     io_wait();
     inb(0x60); // Ack
+    pic_set_mask(12, 1); // enable IRQ12
 }
 
 int mouse_read_packet(struct mouse_packet *p) {

--- a/IO/pic.h
+++ b/IO/pic.h
@@ -2,4 +2,5 @@
 #include <stdint.h>
 
 void pic_remap(void);
+void pic_set_mask(uint8_t irq, int enable);
 

--- a/IO/pit.c
+++ b/IO/pit.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include "io.h"
 #include "pit.h"
+#include "pic.h"
 
 #define PIT_FREQ 1193182
 #define PIT_CMD 0x43
@@ -13,4 +14,5 @@ void pit_init(uint32_t hz) {
     outb(PIT_CH0, divisor & 0xFF); // Low byte
     io_wait();
     outb(PIT_CH0, (divisor >> 8) & 0xFF); // High byte
+    pic_set_mask(0, 1); // enable IRQ0
 }

--- a/IO/video.c
+++ b/IO/video.c
@@ -1,0 +1,33 @@
+#include "video.h"
+#include <string.h>
+
+static bootinfo_framebuffer_t fb_info;
+
+void video_init(const bootinfo_framebuffer_t *fb) {
+    if (fb) fb_info = *fb; else memset(&fb_info, 0, sizeof(fb_info));
+}
+
+const bootinfo_framebuffer_t *video_get_info(void) { return fb_info.address ? &fb_info : NULL; }
+
+void video_clear(uint32_t color) {
+    if (!fb_info.address) return;
+    uint32_t *pixels = (uint32_t*)(uintptr_t)fb_info.address;
+    for (uint32_t y = 0; y < fb_info.height; ++y) {
+        for (uint32_t x = 0; x < fb_info.width; ++x)
+            pixels[y * (fb_info.pitch / 4) + x] = color;
+    }
+}
+
+void video_draw_pixel(uint32_t x, uint32_t y, uint32_t color) {
+    if (!fb_info.address) return;
+    if (x >= fb_info.width || y >= fb_info.height) return;
+    uint32_t *pixels = (uint32_t*)(uintptr_t)fb_info.address;
+    pixels[y * (fb_info.pitch / 4) + x] = color;
+}
+
+void video_fill_rect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color) {
+    if (!fb_info.address) return;
+    for (uint32_t yy = y; yy < y + h && yy < fb_info.height; ++yy)
+        for (uint32_t xx = x; xx < x + w && xx < fb_info.width; ++xx)
+            video_draw_pixel(xx, yy, color);
+}

--- a/IO/video.h
+++ b/IO/video.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <stdint.h>
+#include "../bootloader/include/bootinfo.h"
+
+void video_init(const bootinfo_framebuffer_t *fb);
+void video_clear(uint32_t color);
+void video_draw_pixel(uint32_t x, uint32_t y, uint32_t color);
+void video_fill_rect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color);
+const bootinfo_framebuffer_t *video_get_info(void);

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -34,6 +34,7 @@ OBJS = \
     ../IPC/ipc.o \
     ../CPU/cpu.o \
     ../ACPI/acpi.o \
+    ../IO/video.o \
     ../libc.o
 
 all: kernel.bin

--- a/Kernel/kernel.c
+++ b/Kernel/kernel.c
@@ -5,7 +5,9 @@
 #include "../IO/pic.h"
 #include "../IO/pit.h"
 #include "../IO/keyboard.h"
+#include "../IO/mouse.h"
 #include "../IO/serial.h"
+#include "../IO/video.h"
 #include "../Task/thread.h"
 #include "../VM/pmm.h"
 #include "../VM/paging.h"
@@ -168,6 +170,7 @@ static void print_bootinfo(const bootinfo_t *bi) {
 
 void kernel_main(bootinfo_t *bootinfo) {
     serial_init();
+    video_init(bootinfo ? bootinfo->framebuffer : NULL);
     vga_clear();
     log_good("Mach Microkernel: Boot OK");
     log_line("[Stage 1] Validate bootinfo");
@@ -202,6 +205,8 @@ void kernel_main(bootinfo_t *bootinfo) {
     pit_init(100);
     keyboard_init();
     log_good("[kbd] Keyboard initialized");
+    mouse_init();
+    log_good("[mou] Mouse initialized");
 
     log_line("[Stage 4] Launch servers");
     threads_init();


### PR DESCRIPTION
## Summary
- parse FADT to locate the DSDT table
- expose `acpi_get_dsdt()`
- add simple linear framebuffer driver
- enable keyboard and mouse IRQs via PIC helper
- provide PIC IRQ mask helper and unmask timer
- hook new drivers in the kernel

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_b_688c013d67a48333a9bfe796a474609a