### PR TITLE
Fix QEMU display instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ clean:
 	rm -f kernel.bin libc.o disk.img
 	
 run: disk.img
-	qemu-system-x86_64 \
-	-bios OVMF.fd \
-	-drive file=disk.img,format=raw \
-	-m 512M \
-	-serial stdio -display none
+qemu-system-x86_64 \
+-bios OVMF.fd \
+-drive file=disk.img,format=raw \
+-m 512M \
+-serial stdio -display sdl
 
 .PHONY: all libc kernel bootloader clean run

--- a/docs/SERIAL_CONSOLE.md
+++ b/docs/SERIAL_CONSOLE.md
@@ -16,11 +16,15 @@ The simplest approach is to print serial output directly to your terminal:
 ```sh
 qemu-system-x86_64 -drive format=raw,file=disk.img \
   -bios /usr/share/OVMF/OVMF_CODE.fd \
-  -serial stdio -display none
+  -serial stdio -display sdl
 ```
 
 All boot messages will appear in the terminal window. You can also log to a
 file instead by using `-serial file:boot.log`.
+
+Note: Omitting the graphical window with `-display none` disables the VGA
+output and PS/2 keyboard. The system will appear to hang after "[Stage 5]
+Scheduler start" because the shell only prints to VGA.
 
 ## Real Hardware
 


### PR DESCRIPTION
## Summary
- update serial console guide with SDL display
- ensure `make run` opens an SDL window

## Testing
- `make run` *(fails: clang missing)*

------
https://chatgpt.com/codex/tasks/task_b_688c41c8101c8333a4ae449665f78f1c