### PR TITLE
Fix run target indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ clean:
 	rm -f kernel.bin libc.o disk.img
 	
 run: disk.img
-qemu-system-x86_64 \
--bios OVMF.fd \
--drive file=disk.img,format=raw \
--m 512M \
--serial stdio -display sdl
+	qemu-system-x86_64 \
+		-bios OVMF.fd \
+		-drive file=disk.img,format=raw \
+		-m 512M \
+		-serial stdio -display sdl
 
 .PHONY: all libc kernel bootloader clean run


### PR DESCRIPTION
## Summary
- properly indent the `run` target recipe in root Makefile

## Testing
- `make run` *(fails: No rule to make target '../libc.o')*

------
https://chatgpt.com/codex/tasks/task_b_688c454e0e8c8333b42c0814cf570670