### PR TITLE
Fix scheduler start ordering

### DIFF
--- a/Kernel/kernel.c
+++ b/Kernel/kernel.c
@@ -212,8 +212,8 @@ void kernel_main(bootinfo_t *bootinfo) {
     threads_init();
 
     log_line("[Stage 5] Scheduler start");
-    schedule();               // start first thread before enabling IRQs
-    asm volatile("sti");      // enable interrupts after scheduler is active
+    asm volatile("sti");      // enable interrupts before scheduling threads
+    schedule();               // start first thread now that IRQs are enabled
 
     for (;;) {
         schedule();


### PR DESCRIPTION
## Summary
- enable interrupts before scheduling threads

## Testing
- `make kernel`
- `make bootloader` *(fails: `clang` missing)*

------
https://chatgpt.com/codex/tasks/task_b_688c4e961ba083339e4490b8abab6112