### PR TITLE
Add FTP LIST support and expand heap

### DIFF
--- a/Task/thread.c
+++ b/Task/thread.c
@@ -34,7 +34,7 @@ static void thread_fs_func(void)   { nitrfs_server(&fs_queue, current->id); }
 static void thread_shell_func(void){ shell_main(&fs_queue, current->id); }
 static void thread_vnc_func(void)  { vnc_server(NULL, current->id); }
 static void thread_ssh_func(void)  { ssh_server(NULL, current->id); }
-static void thread_ftp_func(void)  { ftp_server(NULL, current->id); }
+static void thread_ftp_func(void)  { ftp_server(&fs_queue, current->id); }
 
 // --- THREAD CREATION ---
 
@@ -107,7 +107,7 @@ void thread_yield(void) {
 // --- THREAD SYSTEM INIT ---
 
 void threads_init(void) {
-    uint32_t mask = (1u << 1) | (1u << 2);
+    uint32_t mask = (1u << 1) | (1u << 2) | (1u << 5);
     ipc_init(&fs_queue, mask, mask);
     thread_create(thread_fs_func);
     thread_create(thread_shell_func);

--- a/docs/NETWORK_SERVERS.md
+++ b/docs/NETWORK_SERVERS.md
@@ -17,7 +17,7 @@ This document outlines the network services for NitrOS. A very small network sta
 ## FTP Server
 
 - **Purpose**: Provide file transfer capabilities for legacy clients.
-- **Status**: Replies to simple commands using the loopback stack. Real file transfer and TCP/IP remain TODO.
+- **Status**: Handles `LIST` over the loopback stack using NitrFS. Real file transfer and TCP/IP remain TODO.
 - **Future work**: Build on the NitrFS filesystem once a TCP/IP stack is available.
 
 Each of these services is started as a kernel thread during system initialization. They use the loopback network stack for testing but remain placeholders until true network drivers and protocols are added.

--- a/servers/ftp/ftp.c
+++ b/servers/ftp/ftp.c
@@ -2,10 +2,11 @@
 #include "../../IO/serial.h"
 #include "../../Task/thread.h"
 #include "../../Net/netstack.h"
+#include "../nitrfs/server.h"
+#include "../nitrfs/nitrfs.h"
 #include <string.h>
 
 void ftp_server(ipc_queue_t *q, uint32_t self_id) {
-    (void)q; (void)self_id;
     serial_puts("[ftp] FTP server starting\n");
     const char hello[] = "220 NOS FTP\r\n";
     net_send(hello, strlen(hello));
@@ -18,6 +19,23 @@ void ftp_server(ipc_queue_t *q, uint32_t self_id) {
                 const char bye[] = "221 Bye\r\n";
                 net_send(bye, strlen(bye));
                 break;
+            }
+            if (q && !strncmp(buf, "LIST", 4)) {
+                ipc_message_t msg = {0}, reply = {0};
+                msg.type = NITRFS_MSG_LIST;
+                msg.len = 0;
+                ipc_send(q, self_id, &msg);
+                if (ipc_receive(q, self_id, &reply) == 0) {
+                    for (int i = 0; i < (int)reply.arg1; i++) {
+                        char *name = (char *)reply.data + i * NITRFS_NAME_LEN;
+                        net_send(name, strlen(name));
+                        net_send("\r\n", 2);
+                    }
+                } else {
+                    const char err[] = "550 LIST failed\r\n";
+                    net_send(err, strlen(err));
+                }
+                continue;
             }
             const char ok[] = "200 OK\r\n";
             net_send(ok, strlen(ok));

--- a/src/libc.c
+++ b/src/libc.c
@@ -74,7 +74,7 @@ int strncmp(const char *s1, const char *s2, size_t n) {
     return 0;
 }
 
-#define HEAP_SIZE (16 * 1024)
+#define HEAP_SIZE (64 * 1024)
 #define HEAP_MAGIC 0xC0DECAFE
 
 typedef struct block_header {


### PR DESCRIPTION
## Summary
- enlarge heap to 64 KB in libc
- allow ftp thread to access filesystem queue
- handle `LIST` command in ftp server using NitrFS
- document updated ftp status

## Testing
- `make libc`
- `make kernel`
- `make bootloader`

------
https://chatgpt.com/codex/tasks/task_b_688caef49a2c83339e656cf160b47e61