### PR TITLE
Complete libc safety checks and enhance VNC server

### DIFF
--- a/servers/vnc/vnc.c
+++ b/servers/vnc/vnc.c
@@ -7,8 +7,21 @@
 void vnc_server(ipc_queue_t *q, uint32_t self_id) {
     (void)q; (void)self_id;
     serial_puts("[vnc] VNC server starting\n");
-    const char msg[] = "NOS VNC not implemented\r\n";
-    net_send(msg, strlen(msg));
-    while (1)
+    const char hello[] = "NOS VNC ready\r\n";
+    net_send(hello, strlen(hello));
+    char buf[64];
+    for (;;) {
+        int n = net_receive(buf, sizeof(buf) - 1);
+        if (n > 0) {
+            buf[n] = '\0';
+            if (!strncmp(buf, "ping", 4)) {
+                const char pong[] = "pong\r\n";
+                net_send(pong, strlen(pong));
+            } else {
+                const char unk[] = "unknown\r\n";
+                net_send(unk, strlen(unk));
+            }
+        }
         thread_yield();
+    }
 }

--- a/src/libc.c
+++ b/src/libc.c
@@ -174,11 +174,17 @@ void free(void *ptr) {
     }
 }
 void *__memcpy_chk(void *dest, const void *src, size_t n, size_t destlen) {
-    (void)destlen; // parameter not used in this stub
+    if (n > destlen)
+        n = destlen;
     return memcpy(dest, src, n);
 }
 
 char *__strncpy_chk(char *dest, const char *src, size_t n, size_t destlen) {
-    (void)destlen; // parameter not used in this stub
-    return strncpy(dest, src, n);
+    if (destlen == 0)
+        return dest;
+    if (n >= destlen)
+        n = destlen - 1;
+    strncpy(dest, src, n);
+    dest[n] = '\0';
+    return dest;
 }


### PR DESCRIPTION
## Summary
- implement actual bounds checks in `__memcpy_chk` and `__strncpy_chk`
- add a simple interactive loop to the VNC server responding to `ping`

## Testing
- `make libc`
- `make kernel`

------
https://chatgpt.com/codex/tasks/task_b_688cb27470ac83339d9f5c6956e3e932