### PR TITLE
Enhance NIC driver and PCI access

### DIFF
--- a/IO/pci.c
+++ b/IO/pci.c
@@ -18,3 +18,16 @@ uint32_t pci_config_read(uint8_t bus, uint8_t slot, uint8_t func, uint8_t offset
     value |= inb(PCI_DATA_PORT + 3) << 24;
     return value;
 }
+
+void pci_config_write(uint8_t bus, uint8_t slot, uint8_t func, uint8_t offset, uint32_t value) {
+    uint32_t address = (uint32_t)((bus << 16) | (slot << 11) |
+                           (func << 8) | (offset & 0xfc) | ((uint32_t)0x80000000));
+    outb(PCI_ADDRESS_PORT, address & 0xFF);
+    outb(PCI_ADDRESS_PORT + 1, (address >> 8) & 0xFF);
+    outb(PCI_ADDRESS_PORT + 2, (address >> 16) & 0xFF);
+    outb(PCI_ADDRESS_PORT + 3, (address >> 24) & 0xFF);
+    outb(PCI_DATA_PORT, value & 0xFF);
+    outb(PCI_DATA_PORT + 1, (value >> 8) & 0xFF);
+    outb(PCI_DATA_PORT + 2, (value >> 16) & 0xFF);
+    outb(PCI_DATA_PORT + 3, (value >> 24) & 0xFF);
+}

--- a/IO/pci.h
+++ b/IO/pci.h
@@ -2,3 +2,4 @@
 #include <stdint.h>
 
 uint32_t pci_config_read(uint8_t bus, uint8_t slot, uint8_t func, uint8_t offset);
+void pci_config_write(uint8_t bus, uint8_t slot, uint8_t func, uint8_t offset, uint32_t value);

--- a/Net/e1000.h
+++ b/Net/e1000.h
@@ -4,3 +4,5 @@
 // Initialize and detect Intel e1000 (or compatible) NIC on PCI bus.
 // Prints status to VGA and returns the PCI bus/slot/function or -1 on failure.
 int e1000_init(void);
+// Retrieve MAC address into the provided 6-byte buffer.
+int e1000_get_mac(uint8_t mac[6]);

--- a/Net/netstack.c
+++ b/Net/netstack.c
@@ -25,10 +25,26 @@ static size_t netbuf_avail(unsigned p) {
 void net_init(void) {
     serial_puts("[net] initializing network stack\n");
     int nic = e1000_init();
-    if (nic < 0)
+    if (nic < 0) {
         serial_puts("[net] no supported NIC found\n");
-    else
-        serial_puts("[net] NIC ready (driver stub)\n");
+    } else {
+        serial_puts("[net] NIC ready\n");
+        uint8_t mac[6];
+        if (e1000_get_mac(mac) == 0) {
+            char buf[32];
+            const char *hex = "0123456789ABCDEF";
+            int p = 0;
+            for (int i = 0; i < 6; ++i) {
+                buf[p++] = hex[(mac[i] >> 4) & 0xF];
+                buf[p++] = hex[mac[i] & 0xF];
+                if (i < 5) buf[p++] = ':';
+            }
+            buf[p] = '\0';
+            serial_puts("[net] MAC ");
+            serial_puts(buf);
+            serial_puts("\n");
+        }
+    }
     for (unsigned i = 0; i < NET_PORTS; ++i)
         head[i] = tail[i] = 0;
 }


### PR DESCRIPTION
## Summary
- add PCI config write helper
- extend e1000 driver to expose MAC address
- print detected MAC during network init

## Testing
- `make libc`
- `make kernel`
- `make bootloader`
- `make disk.img`


------
https://chatgpt.com/codex/tasks/task_b_688cb6deacb08333b8953ef16a9a956e