### PR TITLE
Add test suite and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y make gcc nasm qemu-system-x86 mtools dosfstools ovmf
+    - name: Run unit tests
+      run: make -C tests
+    - name: Run integration tests
+      run: python3 tests/integration/test_qemu.py

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ qemu.log
 qemu_output.txt
 *.img
 
+tests/test_*

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,26 @@
+CC=gcc
+CFLAGS=-Wall -Wextra -std=gnu11 \
+    -I../kernel/IPC -I../kernel/Kernel -I../kernel/VM -I../boot/include \
+    -I../user/servers/nitrfs -I../user/servers/login -I../user/libc
+UNIT_TESTS=test_ipc test_pmm test_syscall test_nitrfs test_login
+
+all: $(UNIT_TESTS)
+	for t in $(UNIT_TESTS); do ./$$t; done
+
+test_ipc: unit/test_ipc.c ../kernel/IPC/ipc.c ../user/libc/libc.c
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_pmm: unit/test_pmm.c ../kernel/VM/pmm.c ../user/libc/libc.c
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_syscall: unit/test_syscall.c ../kernel/Kernel/syscall.c ../user/libc/libc.c
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_nitrfs: unit/test_nitrfs.c ../user/servers/nitrfs/nitrfs.c ../user/libc/libc.c
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_login: unit/test_login.c ../user/servers/login/login.c ../user/libc/libc.c ../kernel/IPC/ipc.c
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f $(UNIT_TESTS)

--- a/tests/integration/test_qemu.py
+++ b/tests/integration/test_qemu.py
@@ -1,0 +1,24 @@
+import subprocess
+import pathlib
+
+def run_qemu():
+    subprocess.run(["make"], check=True)
+    try:
+        result = subprocess.run([
+            "qemu-system-x86_64",
+            "-bios", "/usr/share/ovmf/OVMF.fd",
+            "-drive", "file=disk.img,format=raw",
+            "-m", "512M",
+            "-serial", "stdio",
+            "-display", "none",
+            "-no-reboot",
+            "-no-shutdown"
+        ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=10, text=True)
+        out = result.stdout
+    except subprocess.TimeoutExpired as e:
+        out = (e.stdout or b"").decode()
+    assert "Mach Microkernel: Boot OK" in out
+    return out
+
+if __name__ == "__main__":
+    run_qemu()

--- a/tests/unit/test_ipc.c
+++ b/tests/unit/test_ipc.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <string.h>
+#include "../../kernel/IPC/ipc.h"
+#include "../../user/libc/libc.h"
+
+int main(void) {
+    ipc_queue_t q;
+    ipc_init(&q, (1u<<1), (1u<<2));
+
+    ipc_message_t msg = { .type = 1, .len = 4 };
+    memcpy(msg.data, "test", 4);
+    int ret = ipc_send(&q, 1, &msg);
+    assert(ret == 0);
+    ipc_message_t out;
+    ret = ipc_receive(&q, 2, &out);
+    assert(ret == 0);
+    assert(out.type == 1);
+    assert(out.len == 4);
+    assert(memcmp(out.data, "test", 4) == 0);
+
+    ret = ipc_send(&q, 2, &msg);
+    assert(ret == -2);
+
+    ret = ipc_receive(&q, 2, &out);
+    assert(ret == -1);
+
+    return 0;
+}

--- a/tests/unit/test_login.c
+++ b/tests/unit/test_login.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <string.h>
+#include "../../user/servers/login/login.h"
+#include "../../kernel/IPC/ipc.h"
+#include "../../user/libc/libc.h"
+#include <sys/mman.h>
+
+static const char *input = "admin\nadmin\n";
+static size_t pos = 0;
+
+int keyboard_getchar(void) {
+    if (pos >= strlen(input)) return -1;
+    return (unsigned char)input[pos++];
+}
+
+void serial_write(char c) { (void)c; }
+void serial_puts(const char *s) { (void)s; }
+void thread_yield(void) { }
+
+int main(void) {
+    ipc_queue_t q; (void)q;
+    mmap((void*)0xB8000, 0x1000, PROT_READ|PROT_WRITE,
+         MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED, -1, 0);
+    login_done = 0;
+    login_server(&q, 0);
+    assert(login_done == 1);
+    return 0;
+}

--- a/tests/unit/test_nitrfs.c
+++ b/tests/unit/test_nitrfs.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <string.h>
+#include "../../user/servers/nitrfs/nitrfs.h"
+#include "../../user/libc/libc.h"
+
+int main(void) {
+    nitrfs_fs_t fs;
+    nitrfs_init(&fs);
+    int h = nitrfs_create(&fs, "file.txt", 16, NITRFS_PERM_READ | NITRFS_PERM_WRITE);
+    assert(h >= 0);
+    const char *data = "hi";
+    assert(nitrfs_write(&fs, h, 0, data, 2) == 0);
+    char buf[4];
+    assert(nitrfs_read(&fs, h, 0, buf, 2) == 0);
+    buf[2] = '\0';
+    assert(strcmp(buf, "hi") == 0);
+    nitrfs_compute_crc(&fs, h);
+    assert(nitrfs_verify(&fs, h) == 0);
+    assert(nitrfs_rename(&fs, h, "new.txt") == 0);
+    assert(nitrfs_delete(&fs, h) == 0);
+    return 0;
+}

--- a/tests/unit/test_pmm.c
+++ b/tests/unit/test_pmm.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include "../../kernel/VM/pmm.h"
+#include "../../kernel/VM/paging.h"
+#include "../../boot/include/bootinfo.h"
+#include "../../user/libc/libc.h"
+
+int main(void) {
+    bootinfo_memory_t mmap[1] = {
+        { .addr = 512*PAGE_SIZE, .len = 4*PAGE_SIZE, .type = 7, .reserved = 0 }
+    };
+    bootinfo_t bi = {0};
+    bi.mmap = mmap;
+    bi.mmap_entries = 1;
+    pmm_init(&bi);
+    assert(pmm_total_frames() >= 516);
+    void *p1 = alloc_page();
+    void *p2 = alloc_page();
+    assert(p1 && p2 && p1 != p2);
+    free_page(p1);
+    void *p3 = alloc_page();
+    assert(p3 == p1);
+    return 0;
+}

--- a/tests/unit/test_syscall.c
+++ b/tests/unit/test_syscall.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+#include <stdint.h>
+#include "../../kernel/Kernel/syscall.h"
+
+void thread_yield(void) { }
+
+int main(void) {
+    assert(syscall_handle(SYS_YIELD, 0, 0, 0) == 0);
+    assert(syscall_handle(999, 0, 0, 0) == (uint64_t)-1);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add unit tests covering kernel IPC, physical memory manager, syscalls and key user-space servers
- provide a QEMU-based boot smoke test
- wire up GitHub Actions to build and run tests

## Testing
- `make -C tests`
- `python3 tests/integration/test_qemu.py`


------
https://chatgpt.com/codex/tasks/task_b_688d94bbab30833394f26ccda0e174c6