### PR TITLE
Add ELF loader, new syscalls, and init server

### DIFF
--- a/kernel/Kernel/Makefile
+++ b/kernel/Kernel/Makefile
@@ -31,9 +31,11 @@ OBJS = \
     ../arch/GDT/gdt.o \
     ../arch/GDT/gdt_flush.o \
     ../arch/GDT/user.o \
+    elf.o \
     syscall.o \
     ../../user/servers/nitrfs/nitrfs.o \
     ../../user/servers/nitrfs/server.o \
+    ../../user/servers/init/init.o \
     ../../user/servers/shell/shell.o \
     ../../user/servers/vnc/vnc.o \
     ../../user/servers/ssh/ssh.o \

--- a/kernel/Kernel/elf.c
+++ b/kernel/Kernel/elf.c
@@ -1,0 +1,38 @@
+#include "elf.h"
+#include <stdint.h>
+#include <stddef.h>
+#include "../../user/libc/libc.h" // for memcpy/memset
+
+// Basic validation of ELF64 image
+int elf_validate(const void *image) {
+    const Elf64_Ehdr *eh = (const Elf64_Ehdr *)image;
+    if (eh->e_ident[0] != 0x7F || eh->e_ident[1] != 'E' ||
+        eh->e_ident[2] != 'L' || eh->e_ident[3] != 'F')
+        return -1;
+    if (eh->e_ident[4] != 2) // 64-bit
+        return -1;
+    if (eh->e_machine != 0x3E) // x86_64
+        return -1;
+    return 0;
+}
+
+// Load PT_LOAD segments into memory. Assumes identity mapping.
+void *elf_load(const void *image) {
+    if (elf_validate(image) != 0)
+        return NULL;
+    const uint8_t *base = (const uint8_t *)image;
+    const Elf64_Ehdr *eh = (const Elf64_Ehdr *)base;
+    const Elf64_Phdr *ph = (const Elf64_Phdr *)(base + eh->e_phoff);
+    for (uint16_t i = 0; i < eh->e_phnum; ++i) {
+        if (ph[i].p_type != 1) // PT_LOAD
+            continue;
+        uint8_t *dest = (uint8_t *)ph[i].p_vaddr;
+        const uint8_t *src = base + ph[i].p_offset;
+        memcpy(dest, src, (size_t)ph[i].p_filesz);
+        if (ph[i].p_memsz > ph[i].p_filesz) {
+            memset(dest + ph[i].p_filesz, 0,
+                   (size_t)(ph[i].p_memsz - ph[i].p_filesz));
+        }
+    }
+    return (void *)eh->e_entry;
+}

--- a/kernel/Kernel/elf.h
+++ b/kernel/Kernel/elf.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+
+// Minimal ELF64 structures for loader
+
+typedef struct {
+    unsigned char e_ident[16];
+    uint16_t e_type;
+    uint16_t e_machine;
+    uint32_t e_version;
+    uint64_t e_entry;
+    uint64_t e_phoff;
+    uint64_t e_shoff;
+    uint32_t e_flags;
+    uint16_t e_ehsize;
+    uint16_t e_phentsize;
+    uint16_t e_phnum;
+    uint16_t e_shentsize;
+    uint16_t e_shnum;
+    uint16_t e_shstrndx;
+} Elf64_Ehdr;
+
+typedef struct {
+    uint32_t p_type;
+    uint32_t p_flags;
+    uint64_t p_offset;
+    uint64_t p_vaddr;
+    uint64_t p_paddr;
+    uint64_t p_filesz;
+    uint64_t p_memsz;
+    uint64_t p_align;
+} Elf64_Phdr;
+
+// Validate ELF image. Returns 0 on success.
+int elf_validate(const void *image);
+// Load ELF image into memory and return entry point, or NULL on failure.
+void *elf_load(const void *image);

--- a/kernel/Kernel/syscall.h
+++ b/kernel/Kernel/syscall.h
@@ -4,6 +4,9 @@
 enum syscall_num {
     SYS_YIELD = 0,
     SYS_WRITE_VGA = 1,
+    SYS_FORK = 2,
+    SYS_EXEC = 3,
+    SYS_SBRK = 4,
 };
 
 uint64_t syscall_handle(uint64_t num, uint64_t arg1, uint64_t arg2, uint64_t arg3);

--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -6,6 +6,7 @@
 #include "../../user/servers/ssh/ssh.h"
 #include "../../user/servers/ftp/ftp.h"
 #include "../../user/servers/login/login.h"
+#include "../../user/servers/init/init.h"
 #include "../../user/libc/libc.h"
 #include "../drivers/IO/serial.h"
 #include <stdint.h>
@@ -33,6 +34,7 @@ static void thread_entry(void (*f)(void)) {
 // --- THREAD FUNCTIONS ---
 
 static void thread_fs_func(void)   { thread_t *c = current_cpu[smp_cpu_index()]; nitrfs_server(&fs_queue, c->id); }
+static void thread_init_func(void) { thread_t *c = current_cpu[smp_cpu_index()]; init_main(&fs_queue, c->id); }
 static void thread_shell_func(void){ thread_t *c = current_cpu[smp_cpu_index()]; shell_main(&fs_queue, c->id); }
 static void thread_vnc_func(void)  { thread_t *c = current_cpu[smp_cpu_index()]; vnc_server(NULL, c->id); }
 static void thread_ssh_func(void)  { thread_t *c = current_cpu[smp_cpu_index()]; ssh_server(NULL, c->id); }
@@ -113,6 +115,7 @@ void threads_init(void) {
     uint32_t mask = (1u << 1) | (1u << 2) | (1u << 5);
     ipc_init(&fs_queue, mask, mask);
     thread_create(thread_fs_func);
+    thread_create(thread_init_func);
     thread_create(thread_login_func);
     thread_create(thread_shell_func);
     thread_create(thread_vnc_func);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ test_ipc: unit/test_ipc.c ../kernel/IPC/ipc.c ../user/libc/libc.c
 test_pmm: unit/test_pmm.c ../kernel/VM/pmm.c ../user/libc/libc.c
 	$(CC) $(CFLAGS) $^ -o $@
 
-test_syscall: unit/test_syscall.c ../kernel/Kernel/syscall.c ../user/libc/libc.c
+test_syscall: unit/test_syscall.c ../kernel/Kernel/syscall.c ../kernel/Kernel/elf.c ../user/libc/libc.c
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_nitrfs: unit/test_nitrfs.c ../user/servers/nitrfs/nitrfs.c ../user/libc/libc.c ../kernel/drivers/IO/block.c

--- a/tests/unit/test_syscall.c
+++ b/tests/unit/test_syscall.c
@@ -1,8 +1,13 @@
 #include <assert.h>
 #include <stdint.h>
 #include "../../kernel/Kernel/syscall.h"
+#include "../../kernel/Task/thread.h"
 
 void thread_yield(void) { }
+uint32_t smp_cpu_index(void) { return 0; }
+thread_t dummy_thread = {0};
+thread_t *current_cpu[MAX_CPUS] = { &dummy_thread };
+thread_t *thread_create(void (*func)(void)) { (void)func; return &dummy_thread; }
 
 int main(void) {
     assert(syscall_handle(SYS_YIELD, 0, 0, 0) == 0);

--- a/user/libc/libc.h
+++ b/user/libc/libc.h
@@ -18,3 +18,7 @@ void free(void *ptr);
 void *__memcpy_chk(void *dest, const void *src, size_t n, size_t destlen);
 char *__strncpy_chk(char *dest, const char *src, size_t n, size_t destlen);
 
+int fork(void);
+int exec(const char *path);
+void *sbrk(long inc);
+

--- a/user/servers/init/init.c
+++ b/user/servers/init/init.c
@@ -1,0 +1,14 @@
+#include "init.h"
+#include "../../../kernel/drivers/IO/serial.h"
+#include "../../../kernel/Task/thread.h"
+#include "../../libc/libc.h"
+
+// Simple init/task spawner stub
+void init_main(ipc_queue_t *q, uint32_t self_id) {
+    (void)q; (void)self_id;
+    serial_puts("[init] init server started\n");
+    // In a real system this would spawn other tasks using fork/exec.
+    for (;;) {
+        thread_yield();
+    }
+}

--- a/user/servers/init/init.h
+++ b/user/servers/init/init.h
@@ -1,0 +1,9 @@
+#ifndef INIT_H
+#define INIT_H
+
+#include <stdint.h>
+#include "../../../kernel/IPC/ipc.h"
+
+void init_main(ipc_queue_t *q, uint32_t self_id);
+
+#endif // INIT_H


### PR DESCRIPTION
## Summary
- implement minimal ELF64 loading routines and expose entry point
- expand syscall dispatcher with fork, exec, and sbrk
- add libc wrappers and simple init task-spawner server

## Testing
- `make clean && make`
- `./test_ipc && ./test_pmm && ./test_syscall && ./test_nitrfs && ./test_login`


------
https://chatgpt.com/codex/tasks/task_b_688d9edcd98c83338119ab36b327fba1