### PR TITLE
Add login sessions, IPC capabilities, and NitrFS ACLs

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -112,15 +112,23 @@ void thread_yield(void) {
 // --- THREAD SYSTEM INIT ---
 
 void threads_init(void) {
-    uint32_t mask = (1u << 1) | (1u << 2) | (1u << 5);
-    ipc_init(&fs_queue, mask, mask);
-    thread_create(thread_fs_func);
-    thread_create(thread_init_func);
-    thread_create(thread_login_func);
-    thread_create(thread_shell_func);
-    thread_create(thread_vnc_func);
-    thread_create(thread_ssh_func);
-    thread_create(thread_ftp_func);
+    ipc_init(&fs_queue);
+    thread_t *t;
+
+    t = thread_create(thread_fs_func);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    t = thread_create(thread_init_func);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    t = thread_create(thread_login_func);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    t = thread_create(thread_shell_func);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    t = thread_create(thread_vnc_func);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    t = thread_create(thread_ssh_func);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    t = thread_create(thread_ftp_func);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
 
     // Insert kernel main thread into the run queue so the first
     // schedule() call can switch away safely.

--- a/tests/unit/test_ipc.c
+++ b/tests/unit/test_ipc.c
@@ -5,7 +5,9 @@
 
 int main(void) {
     ipc_queue_t q;
-    ipc_init(&q, (1u<<1), (1u<<2));
+    ipc_init(&q);
+    ipc_grant(&q, 1, IPC_CAP_SEND);
+    ipc_grant(&q, 2, IPC_CAP_RECV);
 
     ipc_message_t msg = { .type = 1, .len = 4 };
     memcpy(msg.data, "test", 4);

--- a/tests/unit/test_login.c
+++ b/tests/unit/test_login.c
@@ -24,5 +24,8 @@ int main(void) {
     login_done = 0;
     login_server(&q, 0);
     assert(login_done == 1);
+    assert(current_session.active);
+    assert(current_session.uid == 0);
+    assert(strcmp((const char*)current_session.username, "admin") == 0);
     return 0;
 }

--- a/tests/unit/test_nitrfs.c
+++ b/tests/unit/test_nitrfs.c
@@ -19,6 +19,11 @@ int main(void) {
     nitrfs_compute_crc(&fs, h);
     assert(nitrfs_verify(&fs, h) == 0);
 
+    /* ACL tests */
+    assert(nitrfs_acl_add(&fs, h, 1, NITRFS_PERM_READ) == 0);
+    assert(nitrfs_acl_check(&fs, h, 1, NITRFS_PERM_READ) == 1);
+    assert(nitrfs_acl_check(&fs, h, 1, NITRFS_PERM_WRITE) == 0);
+
     /* Save to mock device and reload */
     assert(nitrfs_save_device(&fs, 0) > 0);
     nitrfs_fs_t fs2;

--- a/user/servers/login/login.h
+++ b/user/servers/login/login.h
@@ -5,6 +5,15 @@
 
 extern volatile int login_done;
 
+typedef struct {
+    uint32_t uid;
+    char username[32];
+    uint32_t session_id;
+    int active;
+} login_session_t;
+
+extern volatile login_session_t current_session;
+
 void login_server(ipc_queue_t *q, uint32_t self_id);
 
 #endif // LOGIN_SERVER_H

--- a/user/servers/nitrfs/nitrfs.h
+++ b/user/servers/nitrfs/nitrfs.h
@@ -34,12 +34,22 @@
 
 /** In-memory file descriptor */
 typedef struct {
+    uint32_t uid;   /* User ID */
+    uint32_t perm;  /* Permission mask */
+} nitrfs_acl_entry_t;
+
+#define NITRFS_ACL_MAX 4
+
+typedef struct {
     char     name[NITRFS_NAME_LEN];
     uint8_t *data;         /* Allocated buffer (owned) */
     uint32_t size;         /* Bytes used */
     uint32_t capacity;     /* Bytes allocated */
-    uint32_t perm;         /* Permission flags */
+    uint32_t perm;         /* Default permission flags */
     uint32_t crc32;        /* Data CRC32 */
+    uint32_t owner;        /* Owner UID */
+    nitrfs_acl_entry_t acl[NITRFS_ACL_MAX];
+    size_t   acl_count;
 } nitrfs_file_t;
 
 /** Filesystem root struct */
@@ -137,5 +147,10 @@ int     nitrfs_load_device(nitrfs_fs_t *fs, uint32_t start_lba);
 void    nitrfs_journal_init(void);
 void    nitrfs_journal_log(nitrfs_fs_t *fs, int handle);
 void    nitrfs_journal_recover(nitrfs_fs_t *fs);
+
+/* -- ACL helpers -- */
+int     nitrfs_set_owner(nitrfs_fs_t *fs, int handle, uint32_t owner);
+int     nitrfs_acl_add(nitrfs_fs_t *fs, int handle, uint32_t uid, uint32_t perm);
+int     nitrfs_acl_check(nitrfs_fs_t *fs, int handle, uint32_t uid, uint32_t perm);
 
 #endif /* NITRFS_H */


### PR DESCRIPTION
## Summary
- enhance login server with credential checks and session tracking
- enforce capability-based access in IPC and thread setup
- store ACL metadata in NitrFS with helper APIs

## Testing
- `make -C tests clean`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_688da073602c83338d5e04f9623ca1d0