### PR TITLE
Add basic networking skeleton with socket-style API

### DIFF
--- a/kernel/drivers/Net/e1000.c
+++ b/kernel/drivers/Net/e1000.c
@@ -1,15 +1,9 @@
 #include "e1000.h"
 #include "../IO/pci.h"
 #include "../IO/mmio.h"
+#include "../IO/serial.h"
 #include "../../../user/libc/libc.h"
 
-// Simple VGA print at row 4
-static void puts_vga(const char *s) {
-    volatile uint16_t *vga = (uint16_t *)0xB8000 + 80 * 4; // row 4
-    while (*s) {
-        *vga++ = (0x0F << 8) | *s++;
-    }
-}
 
 // Intel e1000 PCI Vendor/Device ID
 #define INTEL_VENDOR_ID 0x8086
@@ -17,6 +11,76 @@ static void puts_vga(const char *s) {
 #define E1000_SUBCLASS  0x00  // Ethernet controller
 
 static volatile uint32_t *regs = NULL;
+
+// Descriptor rings and buffers for basic transmit/receive.
+#define RX_DESC_COUNT 16
+#define TX_DESC_COUNT 16
+
+struct rx_desc {
+    uint64_t addr;
+    uint16_t len;
+    uint16_t csum;
+    uint8_t status;
+    uint8_t errors;
+    uint16_t special;
+} __attribute__((packed));
+
+struct tx_desc {
+    uint64_t addr;
+    uint16_t len;
+    uint8_t cso;
+    uint8_t cmd;
+    uint8_t status;
+    uint8_t css;
+    uint16_t special;
+} __attribute__((packed));
+
+static struct rx_desc rx_ring[RX_DESC_COUNT];
+static struct tx_desc tx_ring[TX_DESC_COUNT];
+static uint8_t rx_buf[RX_DESC_COUNT][2048];
+static uint8_t tx_buf[TX_DESC_COUNT][2048];
+static uint32_t rx_cur = 0;
+static uint32_t tx_cur = 0;
+
+#define REG_RDBAL 0x2800
+#define REG_RDBAH 0x2804
+#define REG_RDLEN 0x2808
+#define REG_RDH   0x2810
+#define REG_RDT   0x2818
+#define REG_RCTRL 0x0100
+
+#define REG_TDBAL 0x3800
+#define REG_TDBAH 0x3804
+#define REG_TDLEN 0x3808
+#define REG_TDH   0x3810
+#define REG_TDT   0x3818
+#define REG_TCTRL 0x0400
+
+static void nic_setup_rx(void) {
+    for (int i = 0; i < RX_DESC_COUNT; ++i) {
+        rx_ring[i].addr = (uint64_t)(uintptr_t)rx_buf[i];
+        rx_ring[i].status = 0;
+    }
+    mmio_write32((uintptr_t)regs + REG_RDBAL, (uint32_t)(uintptr_t)rx_ring);
+    mmio_write32((uintptr_t)regs + REG_RDBAH, 0);
+    mmio_write32((uintptr_t)regs + REG_RDLEN, RX_DESC_COUNT * sizeof(struct rx_desc));
+    mmio_write32((uintptr_t)regs + REG_RDH, 0);
+    mmio_write32((uintptr_t)regs + REG_RDT, RX_DESC_COUNT - 1);
+    mmio_write32((uintptr_t)regs + REG_RCTRL, 0x00000002);
+}
+
+static void nic_setup_tx(void) {
+    for (int i = 0; i < TX_DESC_COUNT; ++i) {
+        tx_ring[i].addr = (uint64_t)(uintptr_t)tx_buf[i];
+        tx_ring[i].status = 0x01;
+    }
+    mmio_write32((uintptr_t)regs + REG_TDBAL, (uint32_t)(uintptr_t)tx_ring);
+    mmio_write32((uintptr_t)regs + REG_TDBAH, 0);
+    mmio_write32((uintptr_t)regs + REG_TDLEN, TX_DESC_COUNT * sizeof(struct tx_desc));
+    mmio_write32((uintptr_t)regs + REG_TDH, 0);
+    mmio_write32((uintptr_t)regs + REG_TDT, 0);
+    mmio_write32((uintptr_t)regs + REG_TCTRL, 0x00000002);
+}
 
 // Returns PCI bus/slot packed in int (bus<<8|slot), or -1 if not found
 int e1000_init(void) {
@@ -33,7 +97,7 @@ int e1000_init(void) {
                 uint8_t subclass = (classcode >> 16) & 0xFF;
 
                 if (class == E1000_CLASS && subclass == E1000_SUBCLASS) {
-                    puts_vga("[net] Intel e1000 NIC detected\n");
+                    serial_puts("[net] Intel e1000 NIC detected\n");
 
                     uint32_t bar0 = pci_config_read(bus, slot, 0, 0x10);
                     bar0 &= ~0xF; // mask flags
@@ -44,14 +108,18 @@ int e1000_init(void) {
                     buf[4] = ':'; buf[5] = ' '; buf[6] = '0' + bus; buf[7] = ','; buf[8] = ' ';
                     buf[9] = 's'; buf[10] = 'l'; buf[11] = 'o'; buf[12] = 't';
                     buf[13] = ':'; buf[14] = ' '; buf[15] = '0' + slot; buf[16] = ']'; buf[17] = '\0';
-                    puts_vga(buf);
+                    serial_puts(buf);
+                    serial_puts("\n");
+
+                    nic_setup_rx();
+                    nic_setup_tx();
 
                     return (bus << 8) | slot;
                 }
             }
         }
     }
-    puts_vga("[net] No Intel NIC found\n");
+    serial_puts("[net] No Intel NIC found\n");
     return -1;
 }
 
@@ -67,4 +135,32 @@ int e1000_get_mac(uint8_t mac[6]) {
     mac[4] = rah & 0xFF;
     mac[5] = (rah >> 8) & 0xFF;
     return 0;
+}
+
+int e1000_transmit(const void *data, size_t len) {
+    if (!regs) return -1;
+    if (len > sizeof(tx_buf[0])) len = sizeof(tx_buf[0]);
+    uint32_t cur = tx_cur;
+    memcpy(tx_buf[cur], data, len);
+    tx_ring[cur].len = (uint16_t)len;
+    tx_ring[cur].cmd = (1 << 0) | (1 << 3); // EOP + RS
+    tx_ring[cur].status = 0;
+    tx_cur = (tx_cur + 1) % TX_DESC_COUNT;
+    mmio_write32((uintptr_t)regs + REG_TDT, tx_cur);
+    while (!(tx_ring[cur].status & 0xFF)) { }
+    return 0;
+}
+
+int e1000_poll(uint8_t *buf, size_t buflen) {
+    if (!regs) return -1;
+    uint32_t cur = rx_cur;
+    if (!(rx_ring[cur].status & 0x01))
+        return 0;
+    size_t len = rx_ring[cur].len;
+    if (len > buflen) len = buflen;
+    memcpy(buf, (void *)(uintptr_t)rx_ring[cur].addr, len);
+    rx_ring[cur].status = 0;
+    rx_cur = (rx_cur + 1) % RX_DESC_COUNT;
+    mmio_write32((uintptr_t)regs + REG_RDT, rx_cur);
+    return (int)len;
 }

--- a/kernel/drivers/Net/e1000.h
+++ b/kernel/drivers/Net/e1000.h
@@ -1,8 +1,14 @@
 #pragma once
 #include <stdint.h>
+#include <stddef.h>
 
 // Initialize and detect Intel e1000 (or compatible) NIC on PCI bus.
 // Prints status to VGA and returns the PCI bus/slot/function or -1 on failure.
 int e1000_init(void);
 // Retrieve MAC address into the provided 6-byte buffer.
 int e1000_get_mac(uint8_t mac[6]);
+
+// Transmit a raw Ethernet frame.
+int e1000_transmit(const void *data, size_t len);
+// Poll for a received frame.  Returns length of frame or 0 if none available.
+int e1000_poll(uint8_t *buf, size_t buflen);

--- a/kernel/drivers/Net/netstack.c
+++ b/kernel/drivers/Net/netstack.c
@@ -4,15 +4,85 @@
 #include <stdint.h>
 #include <string.h>
 
-// Simple loopback ring buffers indexed by port.  This allows the demo
-// network servers (VNC, SSH, FTP) to operate independently while still
-// using the very small in-memory transport.
+// Basic network stack with optional hardware backing.  Frames received from
+// the NIC are decoded and queued into small per-port buffers so that user
+// servers can continue to interact through a simple IPC style API.
+
 #define NET_PORTS   8
 #define NETBUF_SIZE 512
+
+// Socket bookkeeping.  Each port can be bound by one socket at a time.
+static uint8_t socket_type[NET_PORTS];
 
 static uint8_t netbuf[NET_PORTS][NETBUF_SIZE];
 static size_t head[NET_PORTS];
 static size_t tail[NET_PORTS];
+static uint8_t our_mac[6];
+
+static uint16_t swap16(uint16_t x) { return (x >> 8) | (x << 8); }
+static uint32_t swap32(uint32_t x) { return ((uint32_t)swap16(x & 0xFFFF) << 16) | swap16(x >> 16); }
+#define htons(x) swap16(x)
+#define ntohs(x) swap16(x)
+#define htonl(x) swap32(x)
+#define ntohl(x) swap32(x)
+
+struct eth_hdr {
+    uint8_t dst[6];
+    uint8_t src[6];
+    uint16_t type;
+} __attribute__((packed));
+
+struct arp_hdr {
+    uint16_t htype;
+    uint16_t ptype;
+    uint8_t hlen;
+    uint8_t plen;
+    uint16_t oper;
+    uint8_t sha[6];
+    uint32_t spa;
+    uint8_t tha[6];
+    uint32_t tpa;
+} __attribute__((packed));
+
+struct ipv4_hdr {
+    uint8_t ver_ihl;
+    uint8_t tos;
+    uint16_t len;
+    uint16_t id;
+    uint16_t frag_off;
+    uint8_t ttl;
+    uint8_t proto;
+    uint16_t checksum;
+    uint32_t src;
+    uint32_t dst;
+} __attribute__((packed));
+
+struct ipv6_hdr {
+    uint32_t ver_tc_flow;
+    uint16_t payload_len;
+    uint8_t next_hdr;
+    uint8_t hop_limit;
+    uint8_t src[16];
+    uint8_t dst[16];
+} __attribute__((packed));
+
+struct udp_hdr {
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint16_t len;
+    uint16_t checksum;
+} __attribute__((packed));
+
+struct tcp_hdr {
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint32_t seq;
+    uint32_t ack;
+    uint16_t offset_flags;
+    uint16_t window;
+    uint16_t checksum;
+    uint16_t urgent;
+} __attribute__((packed));
 
 static size_t netbuf_avail(unsigned p) {
     size_t h = head[p];
@@ -29,14 +99,13 @@ void net_init(void) {
         serial_puts("[net] no supported NIC found\n");
     } else {
         serial_puts("[net] NIC ready\n");
-        uint8_t mac[6];
-        if (e1000_get_mac(mac) == 0) {
+        if (e1000_get_mac(our_mac) == 0) {
             char buf[32];
             const char *hex = "0123456789ABCDEF";
             int p = 0;
             for (int i = 0; i < 6; ++i) {
-                buf[p++] = hex[(mac[i] >> 4) & 0xF];
-                buf[p++] = hex[mac[i] & 0xF];
+                buf[p++] = hex[(our_mac[i] >> 4) & 0xF];
+                buf[p++] = hex[our_mac[i] & 0xF];
                 if (i < 5) buf[p++] = ':';
             }
             buf[p] = '\0';
@@ -46,7 +115,7 @@ void net_init(void) {
         }
     }
     for (unsigned i = 0; i < NET_PORTS; ++i)
-        head[i] = tail[i] = 0;
+        head[i] = tail[i] = socket_type[i] = 0;
 }
 
 int net_send(unsigned port, const void *data, size_t len) {
@@ -79,4 +148,190 @@ int net_receive(unsigned port, void *buf, size_t buflen) {
             tail[port] = 0;
     }
     return (int)avail;
+}
+
+// ---- Socket style API ---------------------------------------------------
+
+int net_socket_open(uint16_t port, net_socket_type_t type) {
+    if (port >= NET_PORTS) return -1;
+    socket_type[port] = (uint8_t)type;
+    head[port] = tail[port] = 0;
+    return (int)port;
+}
+
+int net_socket_close(int sock) {
+    if (sock < 0 || sock >= (int)NET_PORTS) return -1;
+    socket_type[sock] = 0;
+    head[sock] = tail[sock] = 0;
+    return 0;
+}
+
+int net_socket_send(int sock, const void *data, size_t len) {
+    if (sock < 0) return -1;
+    return net_send((unsigned)sock, data, len);
+}
+
+int net_socket_recv(int sock, void *buf, size_t len) {
+    if (sock < 0) return -1;
+    return net_receive((unsigned)sock, buf, len);
+}
+
+// ---- Protocol handlers --------------------------------------------------
+
+static void enqueue_port(uint16_t port, const uint8_t *data, size_t len) {
+    if (port >= NET_PORTS) return;
+    net_send(port, data, len);
+}
+
+static void handle_udp(const uint8_t *pkt, size_t len) {
+    if (len < sizeof(struct udp_hdr)) return;
+    const struct udp_hdr *u = (const struct udp_hdr *)pkt;
+    uint16_t dst = ntohs(u->dst_port);
+    size_t payload_len = ntohs(u->len);
+    if (payload_len < sizeof(struct udp_hdr)) return;
+    payload_len -= sizeof(struct udp_hdr);
+    if (payload_len > len - sizeof(struct udp_hdr))
+        payload_len = len - sizeof(struct udp_hdr);
+    enqueue_port(dst % NET_PORTS, pkt + sizeof(struct udp_hdr), payload_len);
+}
+
+static void handle_tcp(const uint8_t *pkt, size_t len) {
+    if (len < sizeof(struct tcp_hdr)) return;
+    const struct tcp_hdr *t = (const struct tcp_hdr *)pkt;
+    uint16_t dst = ntohs(t->dst_port);
+    uint16_t offset = ((ntohs(t->offset_flags) >> 12) & 0xF) * 4;
+    if (offset > len) return;
+    size_t payload_len = len - offset;
+    enqueue_port(dst % NET_PORTS, pkt + offset, payload_len);
+}
+
+static void handle_ipv4(const uint8_t *pkt, size_t len) {
+    if (len < sizeof(struct ipv4_hdr)) return;
+    const struct ipv4_hdr *ip = (const struct ipv4_hdr *)pkt;
+    size_t ihl = (ip->ver_ihl & 0x0F) * 4;
+    if (ihl > len) return;
+    size_t total = ntohs(ip->len);
+    if (total > len) total = len;
+    const uint8_t *payload = pkt + ihl;
+    size_t paylen = total - ihl;
+    if (ip->proto == 17) {
+        handle_udp(payload, paylen);
+    } else if (ip->proto == 6) {
+        handle_tcp(payload, paylen);
+    }
+}
+
+static void handle_ipv6(const uint8_t *pkt, size_t len) {
+    if (len < sizeof(struct ipv6_hdr)) return;
+    const struct ipv6_hdr *ip6 = (const struct ipv6_hdr *)pkt;
+    uint8_t next = ip6->next_hdr;
+    const uint8_t *payload = pkt + sizeof(struct ipv6_hdr);
+    size_t paylen = ntohs(ip6->payload_len);
+    if (paylen > len - sizeof(struct ipv6_hdr))
+        paylen = len - sizeof(struct ipv6_hdr);
+    if (next == 17) {
+        handle_udp(payload, paylen);
+    } else if (next == 6) {
+        handle_tcp(payload, paylen);
+    }
+}
+
+static void handle_arp(const uint8_t *pkt, size_t len) {
+    (void)pkt; (void)len;
+    // ARP parsing hook; currently no operational logic.
+}
+
+static void handle_frame(const uint8_t *frame, size_t len) {
+    if (len < sizeof(struct eth_hdr)) return;
+    const struct eth_hdr *eth = (const struct eth_hdr *)frame;
+    uint16_t type = ntohs(eth->type);
+    const uint8_t *payload = frame + sizeof(struct eth_hdr);
+    size_t paylen = len - sizeof(struct eth_hdr);
+    if (type == 0x0800) {
+        handle_ipv4(payload, paylen);
+    } else if (type == 0x86DD) {
+        handle_ipv6(payload, paylen);
+    } else if (type == 0x0806) {
+        handle_arp(payload, paylen);
+    }
+}
+
+void net_poll(void) {
+    uint8_t buf[1600];
+    int n;
+    while ((n = e1000_poll(buf, sizeof(buf))) > 0) {
+        handle_frame(buf, (size_t)n);
+    }
+}
+
+int net_send_ipv4_udp(uint32_t dst_ip, uint16_t src_port, uint16_t dst_port,
+                      const void *data, size_t len) {
+    uint8_t frame[1600];
+    struct eth_hdr *eth = (struct eth_hdr *)frame;
+    for (int i = 0; i < 6; ++i) {
+        eth->dst[i] = 0xFF;
+        eth->src[i] = our_mac[i];
+    }
+    eth->type = htons(0x0800);
+
+    struct ipv4_hdr *ip = (struct ipv4_hdr *)(frame + sizeof(struct eth_hdr));
+    ip->ver_ihl = 0x45;
+    ip->tos = 0;
+    ip->len = htons(sizeof(struct ipv4_hdr) + sizeof(struct udp_hdr) + len);
+    ip->id = 0;
+    ip->frag_off = 0;
+    ip->ttl = 64;
+    ip->proto = 17;
+    ip->checksum = 0;
+    ip->src = 0;
+    ip->dst = htonl(dst_ip);
+
+    struct udp_hdr *udp = (struct udp_hdr *)((uint8_t *)ip + sizeof(struct ipv4_hdr));
+    udp->src_port = htons(src_port);
+    udp->dst_port = htons(dst_port);
+    udp->len = htons(sizeof(struct udp_hdr) + len);
+    udp->checksum = 0;
+
+    memcpy((uint8_t *)udp + sizeof(struct udp_hdr), data, len);
+    size_t total = sizeof(struct eth_hdr) + sizeof(struct ipv4_hdr) +
+                   sizeof(struct udp_hdr) + len;
+    return e1000_transmit(frame, total);
+}
+
+int net_send_ipv4_tcp(uint32_t dst_ip, uint16_t src_port, uint16_t dst_port,
+                      const void *data, size_t len) {
+    uint8_t frame[1600];
+    struct eth_hdr *eth = (struct eth_hdr *)frame;
+    for (int i = 0; i < 6; ++i) {
+        eth->dst[i] = 0xFF;
+        eth->src[i] = our_mac[i];
+    }
+    eth->type = htons(0x0800);
+
+    struct ipv4_hdr *ip = (struct ipv4_hdr *)(frame + sizeof(struct eth_hdr));
+    ip->ver_ihl = 0x45;
+    ip->tos = 0;
+    ip->len = htons(sizeof(struct ipv4_hdr) + sizeof(struct tcp_hdr) + len);
+    ip->id = 0;
+    ip->frag_off = 0;
+    ip->ttl = 64;
+    ip->proto = 6;
+    ip->checksum = 0;
+    ip->src = 0;
+    ip->dst = htonl(dst_ip);
+
+    struct tcp_hdr *tcp = (struct tcp_hdr *)((uint8_t *)ip + sizeof(struct ipv4_hdr));
+    tcp->src_port = htons(src_port);
+    tcp->dst_port = htons(dst_port);
+    tcp->seq = 0;
+    tcp->ack = 0;
+    tcp->offset_flags = htons((5 << 12) | 0x18); // PSH+ACK
+    tcp->window = htons(512);
+    tcp->checksum = 0;
+    tcp->urgent = 0;
+
+    memcpy((uint8_t *)tcp + sizeof(struct tcp_hdr), data, len);
+    size_t total = sizeof(struct eth_hdr) + sizeof(struct ipv4_hdr) +
+                   sizeof(struct tcp_hdr) + len;
+    return e1000_transmit(frame, total);
 }

--- a/kernel/drivers/Net/netstack.h
+++ b/kernel/drivers/Net/netstack.h
@@ -1,9 +1,11 @@
 #ifndef NET_STACK_H
 #define NET_STACK_H
 #include <stddef.h>
+#include <stdint.h>
 // Simple loopback network stack used by the user space servers.  It now
 // supports a small number of logical "ports" so that multiple servers can
-// exchange data without clobbering each other.
+// exchange data without clobbering each other.  When hardware is present the
+// same interfaces are used to send and receive real Ethernet frames.
 
 void net_init(void);
 
@@ -12,4 +14,26 @@ int net_send(unsigned port, const void *data, size_t len);
 
 // Receive data from a given port.  Returns the number of bytes read.
 int net_receive(unsigned port, void *buf, size_t buflen);
+
+// ---- Socket style API ---------------------------------------------------
+
+typedef enum {
+    NET_SOCK_DGRAM = 1,
+    NET_SOCK_STREAM = 2
+} net_socket_type_t;
+
+int net_socket_open(uint16_t port, net_socket_type_t type);
+int net_socket_close(int sock);
+int net_socket_send(int sock, const void *data, size_t len);
+int net_socket_recv(int sock, void *buf, size_t len);
+
+// Poll hardware NIC and dispatch incoming frames.
+void net_poll(void);
+
+// Convenience helpers for transmitting IPv4 packets.
+int net_send_ipv4_udp(uint32_t dst_ip, uint16_t src_port, uint16_t dst_port,
+                      const void *data, size_t len);
+int net_send_ipv4_tcp(uint32_t dst_ip, uint16_t src_port, uint16_t dst_port,
+                      const void *data, size_t len);
+
 #endif // NET_STACK_H

--- a/user/servers/ssh/ssh.c
+++ b/user/servers/ssh/ssh.c
@@ -10,21 +10,22 @@
 void ssh_server(ipc_queue_t *q, uint32_t self_id) {
     (void)q; (void)self_id;
     serial_puts("[ssh] SSH server starting\n");
+    int sock = net_socket_open(SSH_PORT, NET_SOCK_STREAM);
     const char banner[] = "NOS SSH\r\n";
-    net_send(SSH_PORT, banner, strlen(banner));
+    net_socket_send(sock, banner, strlen(banner));
     char buf[128];
     for (;;) {
-        int n = net_receive(SSH_PORT, buf, sizeof(buf) - 1);
+        int n = net_socket_recv(sock, buf, sizeof(buf) - 1);
         if (n > 0) {
             buf[n] = '\0';
             if (!strncmp(buf, "exit", 4)) {
                 const char bye[] = "bye\r\n";
-                net_send(SSH_PORT, bye, strlen(bye));
+                net_socket_send(sock, bye, strlen(bye));
                 break;
             }
-            net_send(SSH_PORT, buf, n); // echo
+            net_socket_send(sock, buf, n); // echo
             const char nl[] = "\r\n";
-            net_send(SSH_PORT, nl, strlen(nl));
+            net_socket_send(sock, nl, strlen(nl));
         }
         thread_yield();
     }

--- a/user/servers/vnc/vnc.c
+++ b/user/servers/vnc/vnc.c
@@ -10,19 +10,20 @@
 void vnc_server(ipc_queue_t *q, uint32_t self_id) {
     (void)q; (void)self_id;
     serial_puts("[vnc] VNC server starting\n");
+    int sock = net_socket_open(VNC_PORT, NET_SOCK_STREAM);
     const char hello[] = "NOS VNC ready\r\n";
-    net_send(VNC_PORT, hello, strlen(hello));
+    net_socket_send(sock, hello, strlen(hello));
     char buf[64];
     for (;;) {
-        int n = net_receive(VNC_PORT, buf, sizeof(buf) - 1);
+        int n = net_socket_recv(sock, buf, sizeof(buf) - 1);
         if (n > 0) {
             buf[n] = '\0';
             if (!strncmp(buf, "ping", 4)) {
                 const char pong[] = "pong\r\n";
-                net_send(VNC_PORT, pong, strlen(pong));
+                net_socket_send(sock, pong, strlen(pong));
             } else {
                 const char unk[] = "unknown\r\n";
-                net_send(VNC_PORT, unk, strlen(unk));
+                net_socket_send(sock, unk, strlen(unk));
             }
         }
         thread_yield();


### PR DESCRIPTION
## Summary
- expand netstack with IPv4/IPv6 parsing, ARP hooks, and UDP/TCP helpers alongside a socket API for user-space servers
- add preliminary e1000 NIC driver with rx/tx rings and serial-based logging
- update demo FTP/SSH/VNC servers to communicate over the socket interface

## Testing
- `sudo apt-get install -y clang lld dosfstools mtools`
- `make`


------
https://chatgpt.com/codex/tasks/task_b_688d94ce7e04833384ce19ecd04e43cd