### PR TITLE
Add window server with basic IPC and demos

### DIFF
--- a/user/servers/window/Makefile
+++ b/user/servers/window/Makefile
@@ -1,0 +1,34 @@
+CROSS_COMPILE ?= x86_64-elf-
+CC      = $(CROSS_COMPILE)gcc
+CFLAGS  = -ffreestanding -O2 -Wall -Wextra -nostdlib -mno-red-zone
+OBJS    = window.o server.o ../../libc/libc.o ../../../kernel/IPC/ipc.o \
+          ../../../kernel/drivers/IO/video.o ../../../kernel/drivers/IO/keyboard.o \
+          ../../../kernel/drivers/IO/pic.o
+
+all: window_server.bin demo1.bin demo2.bin
+
+window.o: window.c window.h ; $(CC) $(CFLAGS) -I../../../kernel/IPC -I../../libc -I../../../kernel/Task -c window.c -o window.o
+
+server.o: server.c server.h window.h ; $(CC) $(CFLAGS) -I../../../kernel/IPC -I../../libc -I../../../kernel/drivers/IO -c server.c -o server.o
+
+../../../kernel/drivers/IO/video.o: ; $(CC) $(CFLAGS) -I../../../boot/include -c ../../../kernel/drivers/IO/video.c -o ../../../kernel/drivers/IO/video.o
+
+../../../kernel/drivers/IO/keyboard.o: ; $(CC) $(CFLAGS) -c ../../../kernel/drivers/IO/keyboard.c -o ../../../kernel/drivers/IO/keyboard.o
+
+../../../kernel/drivers/IO/pic.o: ; $(CC) $(CFLAGS) -c ../../../kernel/drivers/IO/pic.c -o ../../../kernel/drivers/IO/pic.o
+
+../../../kernel/drivers/IO/serial.o: ; $(CC) $(CFLAGS) -c ../../../kernel/drivers/IO/serial.c -o ../../../kernel/drivers/IO/serial.o
+
+window_server.bin: $(OBJS) ; $(CC) $(CFLAGS) $(OBJS) -o window_server.bin
+
+# Demo clients
+
+demo1.o: demo1.c demo1.h window.h ; $(CC) $(CFLAGS) -I../../../kernel/IPC -I../../libc -c demo1.c -o demo1.o
+
+demo2.o: demo2.c demo2.h window.h ; $(CC) $(CFLAGS) -I../../../kernel/IPC -I../../libc -c demo2.c -o demo2.o
+
+demo1.bin: demo1.o window.o ../../libc/libc.o ../../../kernel/IPC/ipc.o ../../../kernel/drivers/IO/serial.o ; $(CC) $(CFLAGS) demo1.o window.o ../../libc/libc.o ../../../kernel/IPC/ipc.o ../../../kernel/drivers/IO/serial.o -o demo1.bin
+
+demo2.bin: demo2.o window.o ../../libc/libc.o ../../../kernel/IPC/ipc.o ../../../kernel/drivers/IO/serial.o ; $(CC) $(CFLAGS) demo2.o window.o ../../libc/libc.o ../../../kernel/IPC/ipc.o ../../../kernel/drivers/IO/serial.o -o demo2.bin
+
+clean: ; rm -f *.o *.bin ../../../kernel/drivers/IO/video.o ../../../kernel/drivers/IO/keyboard.o ../../../kernel/drivers/IO/pic.o ../../../kernel/drivers/IO/serial.o

--- a/user/servers/window/demo1.c
+++ b/user/servers/window/demo1.c
@@ -1,0 +1,18 @@
+#include "demo1.h"
+#include "window.h"
+#include "../../libc/libc.h"
+#include "../../../kernel/drivers/IO/serial.h"
+
+void window_demo1(ipc_queue_t *q, uint32_t self_id, uint32_t server) {
+    int win = window_create(q, server, 20, 20, 120, 80);
+    if (win < 0)
+        return;
+    window_draw_rect(q, server, (uint32_t)win, 0, 0, 120, 80, 0xFFFF0000);
+    ipc_message_t ev;
+    while (window_get_event(q, &ev) == 0) {
+        if (ev.type == WINDOW_MSG_KEY && ev.arg1 == (uint32_t)win) {
+            char buf[2] = {(char)ev.arg2, '\0'};
+            serial_puts(buf);
+        }
+    }
+}

--- a/user/servers/window/demo1.h
+++ b/user/servers/window/demo1.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <stdint.h>
+#include "../../../kernel/IPC/ipc.h"
+
+void window_demo1(ipc_queue_t *q, uint32_t self_id, uint32_t server);

--- a/user/servers/window/demo2.c
+++ b/user/servers/window/demo2.c
@@ -1,0 +1,18 @@
+#include "demo2.h"
+#include "window.h"
+#include "../../libc/libc.h"
+#include "../../../kernel/drivers/IO/serial.h"
+
+void window_demo2(ipc_queue_t *q, uint32_t self_id, uint32_t server) {
+    int win = window_create(q, server, 160, 20, 120, 80);
+    if (win < 0)
+        return;
+    window_draw_rect(q, server, (uint32_t)win, 0, 0, 120, 80, 0xFF0000FF);
+    ipc_message_t ev;
+    while (window_get_event(q, &ev) == 0) {
+        if (ev.type == WINDOW_MSG_KEY && ev.arg1 == (uint32_t)win) {
+            char buf[2] = {(char)ev.arg2, '\0'};
+            serial_puts(buf);
+        }
+    }
+}

--- a/user/servers/window/demo2.h
+++ b/user/servers/window/demo2.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <stdint.h>
+#include "../../../kernel/IPC/ipc.h"
+
+void window_demo2(ipc_queue_t *q, uint32_t self_id, uint32_t server);

--- a/user/servers/window/server.c
+++ b/user/servers/window/server.c
@@ -1,0 +1,75 @@
+#include "server.h"
+#include "window.h"
+#include "../../libc/libc.h"
+#include "../../../kernel/drivers/IO/video.h"
+#include "../../../kernel/drivers/IO/keyboard.h"
+
+#define MAX_WINDOWS 8
+
+typedef struct {
+    uint32_t id;
+    uint32_t owner;
+    uint32_t x, y, w, h;
+} win_t;
+
+void window_server(ipc_queue_t *q, uint32_t self_id) {
+    win_t wins[MAX_WINDOWS];
+    memset(wins, 0, sizeof(wins));
+    uint32_t next_id = 1;
+    int focused = -1;
+    ipc_message_t msg;
+
+    while (1) {
+        if (ipc_receive(q, self_id, &msg) == 0) {
+            switch (msg.type) {
+            case WINDOW_MSG_CREATE: {
+                int slot = -1;
+                for (int i = 0; i < MAX_WINDOWS; ++i) {
+                    if (wins[i].id == 0) { slot = i; break; }
+                }
+                if (slot >= 0) {
+                    uint32_t w = 0, h = 0;
+                    if (msg.len >= 8) {
+                        uint32_t *p = (uint32_t*)msg.data;
+                        w = p[0]; h = p[1];
+                    }
+                    wins[slot].id = next_id++;
+                    wins[slot].owner = msg.sender;
+                    wins[slot].x = msg.arg1;
+                    wins[slot].y = msg.arg2;
+                    wins[slot].w = w;
+                    wins[slot].h = h;
+                    focused = slot;
+                    video_fill_rect(wins[slot].x, wins[slot].y, w, h, 0xFFCCCCCC);
+                    ipc_message_t reply = {0};
+                    reply.type = WINDOW_MSG_CREATE;
+                    reply.arg1 = wins[slot].id;
+                    ipc_send(q, msg.sender, &reply);
+                }
+                break; }
+            case WINDOW_MSG_DRAW_RECT: {
+                uint32_t id = msg.arg1;
+                win_t *win = NULL;
+                for (int i = 0; i < MAX_WINDOWS; ++i)
+                    if (wins[i].id == id) { win = &wins[i]; break; }
+                if (win && msg.len >= 20) {
+                    uint32_t *p = (uint32_t*)msg.data;
+                    uint32_t x = p[0], y = p[1], w = p[2], h = p[3], color = p[4];
+                    video_fill_rect(win->x + x, win->y + y, w, h, color);
+                }
+                break; }
+            default:
+                break;
+            }
+        }
+
+        int ch = keyboard_getchar();
+        if (ch >= 0 && focused >= 0) {
+            ipc_message_t ev = {0};
+            ev.type = WINDOW_MSG_KEY;
+            ev.arg1 = wins[focused].id;
+            ev.arg2 = (uint32_t)ch;
+            ipc_send(q, wins[focused].owner, &ev);
+        }
+    }
+}

--- a/user/servers/window/server.h
+++ b/user/servers/window/server.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <stdint.h>
+#include "../../../kernel/IPC/ipc.h"
+
+void window_server(ipc_queue_t *q, uint32_t self_id);

--- a/user/servers/window/window.c
+++ b/user/servers/window/window.c
@@ -1,0 +1,41 @@
+#include "window.h"
+#include "../../libc/libc.h"
+#include "../../../kernel/Task/thread.h"
+
+extern thread_t *current_cpu[MAX_CPUS];
+extern uint32_t smp_cpu_index(void);
+
+static inline uint32_t self_id(void) {
+    thread_t *t = current_cpu[smp_cpu_index()];
+    return t ? (uint32_t)t->id : 0;
+}
+
+int window_create(ipc_queue_t *q, uint32_t server,
+                  uint32_t x, uint32_t y, uint32_t w, uint32_t h) {
+    ipc_message_t msg = {0}, reply = {0};
+    uint32_t dims[2] = {w, h};
+    msg.type = WINDOW_MSG_CREATE;
+    msg.arg1 = x;
+    msg.arg2 = y;
+    msg.len  = sizeof(dims);
+    memcpy(msg.data, dims, sizeof(dims));
+    ipc_send(q, server, &msg);
+    if (ipc_receive(q, self_id(), &reply) != 0)
+        return -1;
+    return (int)reply.arg1;
+}
+
+int window_draw_rect(ipc_queue_t *q, uint32_t server, uint32_t window,
+                     uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color) {
+    ipc_message_t msg = {0};
+    uint32_t data[5] = {x, y, w, h, color};
+    msg.type = WINDOW_MSG_DRAW_RECT;
+    msg.arg1 = window;
+    msg.len  = sizeof(data);
+    memcpy(msg.data, data, sizeof(data));
+    return ipc_send(q, server, &msg);
+}
+
+int window_get_event(ipc_queue_t *q, ipc_message_t *ev) {
+    return ipc_receive(q, self_id(), ev);
+}

--- a/user/servers/window/window.h
+++ b/user/servers/window/window.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <stdint.h>
+#include "../../../kernel/IPC/ipc.h"
+
+enum {
+    WINDOW_MSG_CREATE = 1,
+    WINDOW_MSG_DRAW_RECT,
+    WINDOW_MSG_KEY,
+};
+
+int window_create(ipc_queue_t *q, uint32_t server,
+                  uint32_t x, uint32_t y, uint32_t w, uint32_t h);
+int window_draw_rect(ipc_queue_t *q, uint32_t server, uint32_t window,
+                     uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color);
+int window_get_event(ipc_queue_t *q, ipc_message_t *ev);


### PR DESCRIPTION
## Summary
- implement simple window server with framebuffer compositor and keyboard event loop
- define IPC protocols and client library for window creation, drawing, and input messages
- add sample GUI clients showing how to open a window, draw, and handle key events

## Testing
- `make -C user/servers/window CROSS_COMPILE=`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_688dac496a1c8333a072d59865c6596f