### PR TITLE
Fix kernel linking by including missing servers

### DIFF
--- a/kernel/Kernel/Makefile
+++ b/kernel/Kernel/Makefile
@@ -42,8 +42,11 @@ OBJS = \
     ../../user/servers/ssh/ssh.o \
     ../../user/servers/ftp/ftp.o \
     ../../user/servers/login/login.o \
+    ../../user/servers/pkg/pkg.o \
+    ../../user/servers/pkg/server.o \
     ../../user/servers/audio/audio.o \
     ../../user/servers/audio/server.o \
+    ../../user/servers/update/server.o \
     ../../user/servers/cp/cp.o \
     ../../user/servers/mv/mv.o \
     ../../user/servers/grep/grep.o \

--- a/kernel/Kernel/kernel.ld
+++ b/kernel/Kernel/kernel.ld
@@ -25,4 +25,5 @@ SECTIONS
         *(.bss*)
         *(COMMON)
     }
+    _end = .;
 }


### PR DESCRIPTION
## Summary
- link package and update servers into the kernel build
- define `_end` symbol in the linker script for `sbrk`

## Testing
- `make`
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_688db02c3f08833393e62f1468505181