### PR TITLE
Prevent duplicate filenames in NitrFS

### DIFF
--- a/tests/unit/test_nitrfs.c
+++ b/tests/unit/test_nitrfs.c
@@ -10,6 +10,8 @@ int main(void) {
     nitrfs_init(&fs);
     int h = nitrfs_create(&fs, "file.txt", 16, NITRFS_PERM_READ | NITRFS_PERM_WRITE);
     assert(h >= 0);
+    /* duplicate name should fail */
+    assert(nitrfs_create(&fs, "file.txt", 16, NITRFS_PERM_READ) == -1);
     const char *data = "hi";
     assert(nitrfs_write(&fs, h, 0, data, 2) == 0);
     char buf[4];

--- a/user/servers/nitrfs/nitrfs.c
+++ b/user/servers/nitrfs/nitrfs.c
@@ -69,8 +69,14 @@ void nitrfs_init(nitrfs_fs_t *fs) {
 }
 
 int nitrfs_create(nitrfs_fs_t *fs, const char *name, uint32_t capacity, uint32_t perm) {
+    if (!fs || !name || capacity == 0)
+        return -1;
     if (fs->file_count >= NITRFS_MAX_FILES)
         return -1;
+    for (size_t i = 0; i < fs->file_count; ++i) {
+        if (strncmp(fs->files[i].name, name, NITRFS_NAME_LEN) == 0)
+            return -1; // duplicate name
+    }
     nitrfs_file_t *f = &fs->files[fs->file_count];
     strncpy(f->name, name, NITRFS_NAME_LEN-1);
     f->name[NITRFS_NAME_LEN-1] = '\0';


### PR DESCRIPTION
## Summary
- disallow creating files with existing names in NitrFS
- test that duplicate file creation fails

## Testing
- `cd tests && make clean && make`
- `./test_nitrfs`


------
https://chatgpt.com/codex/tasks/task_b_688db2336cb4833386b03a55e6c49aea