### PR TITLE
Implement basic USB controller scan

### DIFF
--- a/kernel/drivers/IO/serial.c
+++ b/kernel/drivers/IO/serial.c
@@ -32,3 +32,17 @@ void serial_puts(const char *s) {
         serial_write(*s++);
     }
 }
+
+void serial_puthex(uint32_t value) {
+    char buf[9];
+    for (int i = 7; i >= 0; --i) {
+        buf[i] = "0123456789ABCDEF"[value & 0xF];
+        value >>= 4;
+    }
+    buf[8] = '\0';
+
+    char *p = buf;
+    while (*p == '0' && *(p + 1))
+        p++;
+    serial_puts(p);
+}

--- a/kernel/drivers/IO/serial.h
+++ b/kernel/drivers/IO/serial.h
@@ -1,5 +1,7 @@
 #pragma once
+#include <stdint.h>
 
 void serial_init(void);
 void serial_write(char c);
 void serial_puts(const char *s);
+void serial_puthex(uint32_t value);

--- a/kernel/drivers/IO/usb.c
+++ b/kernel/drivers/IO/usb.c
@@ -1,13 +1,40 @@
+#include <stdint.h>
 #include "usb.h"
 #include "pci.h"
 #include "serial.h"
 
+/* Simple PCI scan for USB controllers. Real hardware handling
+   remains to be implemented. */
+
 void usb_init(void) {
-    /* Scan PCI bus for USB controllers and initialize them.
-       Real hardware handling to be implemented. */
-    serial_puts("USB: initialization stub\n");
+    serial_puts("USB: scanning PCI bus for controllers\n");
+
+    for (uint16_t bus = 0; bus < 256; bus++) {
+        for (uint8_t slot = 0; slot < 32; slot++) {
+            for (uint8_t func = 0; func < 8; func++) {
+                uint32_t vend_dev = pci_config_read(bus, slot, func, 0);
+                if ((vend_dev & 0xFFFF) == 0xFFFF)
+                    continue; /* Device doesn't exist */
+
+                uint32_t class_reg = pci_config_read(bus, slot, func, 0x08);
+                uint8_t class_code = (class_reg >> 24) & 0xFF;
+                uint8_t subclass   = (class_reg >> 16) & 0xFF;
+
+                if (class_code == 0x0C && subclass == 0x03) {
+                    serial_puts("USB: controller at B:");
+                    serial_puthex(bus);
+                    serial_puts(" S:");
+                    serial_puthex(slot);
+                    serial_puts(" F:");
+                    serial_puthex(func);
+                    serial_puts("\n");
+                }
+            }
+        }
+    }
 }
 
 void usb_poll(void) {
     /* Placeholder for polling USB events */
 }
+


### PR DESCRIPTION
## Summary
- add hex output helper for serial debugging
- scan PCI bus to report USB controllers during initialization

## Testing
- `make -C tests`
- `make libc`
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_688db3b0b0208333872b042ded3b7ce7