### PR TITLE
Add file seek support to NitrFS

### DIFF
--- a/tests/unit/test_nitrfs.c
+++ b/tests/unit/test_nitrfs.c
@@ -21,6 +21,14 @@ int main(void) {
     nitrfs_compute_crc(&fs, h);
     assert(nitrfs_verify(&fs, h) == 0);
 
+    /* Offset write/read */
+    assert(nitrfs_write(&fs, h, 2, "xy", 2) == 0);
+    assert(nitrfs_read(&fs, h, 1, buf, 3) == 0);
+    buf[3] = '\0';
+    assert(strcmp(buf, "ixy") == 0);
+    nitrfs_compute_crc(&fs, h);
+    assert(nitrfs_verify(&fs, h) == 0);
+
     /* ACL tests */
     assert(nitrfs_acl_add(&fs, h, 1, NITRFS_PERM_READ) == 0);
     assert(nitrfs_acl_check(&fs, h, 1, NITRFS_PERM_READ) == 1);

--- a/user/libc/libc.h
+++ b/user/libc/libc.h
@@ -20,11 +20,17 @@ typedef struct {
     unsigned int pos;
 } FILE;
 
+#define SEEK_SET 0
+#define SEEK_CUR 1
+#define SEEK_END 2
+
 FILE *fopen(const char *path, const char *mode);
 size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
 size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 int fclose(FILE *stream);
 int rename(const char *old, const char *new);
+long ftell(FILE *stream);
+int fseek(FILE *stream, long offset, int whence);
 
 int abs(int x);
 long labs(long x);

--- a/user/servers/ftp/ftp.c
+++ b/user/servers/ftp/ftp.c
@@ -66,8 +66,8 @@ void ftp_server(ipc_queue_t *q, uint32_t self_id) {
                 ipc_message_t msg = {0}, reply = {0};
                 msg.type = NITRFS_MSG_READ;
                 msg.arg1 = h;
-                msg.arg2 = IPC_MSG_DATA_MAX;
-                msg.len = 0;
+                msg.arg2 = 0;
+                msg.len = IPC_MSG_DATA_MAX;
                 ipc_send(q, self_id, &msg);
                 if (ipc_receive(q, self_id, &reply) == 0 && reply.arg1 == 0) {
                     net_socket_send(sock, reply.data, reply.len);
@@ -112,7 +112,7 @@ void ftp_server(ipc_queue_t *q, uint32_t self_id) {
                 msg.arg1 = h;
                 size_t len = strlen(data);
                 if (len > IPC_MSG_DATA_MAX) len = IPC_MSG_DATA_MAX;
-                msg.arg2 = len;
+                msg.arg2 = 0;
                 memcpy(msg.data, data, len);
                 msg.len = len;
                 ipc_send(q, self_id, &msg);

--- a/user/servers/nitrfs/README.md
+++ b/user/servers/nitrfs/README.md
@@ -33,8 +33,8 @@ The filesystem server understands the following request types:
 | Type              | Description                          |
 | ----------------- | ------------------------------------ |
 | `NITRFS_MSG_CREATE` | Create a new file with a given size and permissions |
-| `NITRFS_MSG_WRITE`  | Write data to an open file           |
-| `NITRFS_MSG_READ`   | Read data from an open file          |
+| `NITRFS_MSG_WRITE`  | Write data to an open file (arg1=handle, arg2=offset, msg.len=bytes, msg.data=payload) |
+| `NITRFS_MSG_READ`   | Read data from an open file  (arg1=handle, arg2=offset, msg.len=bytes) |
 | `NITRFS_MSG_DELETE` | Delete a file by handle              |
 | `NITRFS_MSG_RENAME` | Rename an existing file              |
 | `NITRFS_MSG_LIST`   | List all file names                  |

--- a/user/servers/nitrfs/server.c
+++ b/user/servers/nitrfs/server.c
@@ -33,15 +33,14 @@ void nitrfs_server(ipc_queue_t *q, uint32_t self_id) {
             break;
         case NITRFS_MSG_WRITE:
             handle = msg.arg1;
-            ret = nitrfs_write(&fs, handle, 0, msg.data, msg.arg2);
+            ret = nitrfs_write(&fs, handle, msg.arg2, msg.data, msg.len);
             reply.arg1 = ret; // 0 = ok
             break;
         case NITRFS_MSG_READ:
             handle = msg.arg1;
-            ret = nitrfs_read(&fs, handle, 0, reply.data, msg.arg2);
+            ret = nitrfs_read(&fs, handle, msg.arg2, reply.data, msg.len);
             reply.arg1 = ret; // 0 = ok
-            reply.arg2 = msg.arg2;
-            reply.len  = (ret == 0) ? msg.arg2 : 0;
+            reply.len  = (ret == 0) ? msg.len : 0;
             break;
         case NITRFS_MSG_DELETE:
             handle = msg.arg1;

--- a/user/servers/nitrfs/server.h
+++ b/user/servers/nitrfs/server.h
@@ -6,8 +6,8 @@
 // NITRFS IPC message types (match these in your shell/server code)
 enum {
     NITRFS_MSG_CREATE = 1,   // Create file (msg.data=name, arg1=capacity, arg2=perm)
-    NITRFS_MSG_WRITE,        // Write file  (arg1=handle, arg2=len, msg.data=buffer)
-    NITRFS_MSG_READ,         // Read file   (arg1=handle, arg2=len)
+    NITRFS_MSG_WRITE,        // Write file  (arg1=handle, arg2=offset, msg.len=len, msg.data=buffer)
+    NITRFS_MSG_READ,         // Read file   (arg1=handle, arg2=offset, msg.len=len)
     NITRFS_MSG_DELETE,       // Delete file (arg1=handle)
     NITRFS_MSG_RENAME,       // Rename file (arg1=handle, msg.data=new name)
     NITRFS_MSG_LIST,         // List files  (no args)

--- a/user/servers/shell/shell.c
+++ b/user/servers/shell/shell.c
@@ -179,8 +179,8 @@ static void cmd_cat(ipc_queue_t *q, uint32_t self_id, const char *name) {
     int h = find_handle(q, self_id, name);
     if (h < 0) { puts_out("not found\n"); return; }
     ipc_message_t msg = {0}, reply = {0};
-    msg.type = NITRFS_MSG_READ; msg.arg1 = h; msg.arg2 = IPC_MSG_DATA_MAX;
-    msg.len = 0;
+    msg.type = NITRFS_MSG_READ; msg.arg1 = h; msg.arg2 = 0;
+    msg.len = IPC_MSG_DATA_MAX;
     ipc_send(q, self_id, &msg);
     ipc_receive(q, self_id, &reply);
     if (reply.arg1 != 0) { puts_out("read error\n"); return; }
@@ -210,7 +210,7 @@ static void cmd_write(ipc_queue_t *q, uint32_t self_id, const char *name, const 
     ipc_message_t msg = {0}, reply = {0};
     size_t len = strlen(data);
     if (len > IPC_MSG_DATA_MAX) len = IPC_MSG_DATA_MAX;
-    msg.type = NITRFS_MSG_WRITE; msg.arg1 = h; msg.arg2 = len;
+    msg.type = NITRFS_MSG_WRITE; msg.arg1 = h; msg.arg2 = 0;
     memcpy(msg.data, data, len); msg.len = len;
     ipc_send(q, self_id, &msg); ipc_receive(q, self_id, &reply);
     puts_out(reply.arg1 == 0 ? "ok\n" : "error\n");


### PR DESCRIPTION
## Summary
- allow NitrFS read/write messages to carry a file offset
- add `fseek`/`ftell` and offset-aware `fread`/`fwrite` to the C library
- update shell, FTP server, docs and tests for the new protocol

## Testing
- `make -C tests all`

------
https://chatgpt.com/codex/tasks/task_b_688db74bf3848333bc4f79f60e269fc6