### PR TITLE
Trim newline handling for network servers

### DIFF
--- a/docs/NETWORK_SERVERS.md
+++ b/docs/NETWORK_SERVERS.md
@@ -5,19 +5,19 @@ This document outlines the network services for NitrOS. A very small network sta
 ## VNC Server
 
 - **Purpose**: Expose the system display over a Virtual Network Computing (VNC) protocol so that a remote client can view and control the NitrOS console.
-- **Status**: Sends a greeting on port 1 of the loopback stack.
+- **Status**: Sends a greeting on port 1 of the loopback stack and responds to `ping` with `pong`.
 - **Future work**: Requires keyboard/mouse events over the network and a frame buffer driver.
 
 ## SSH Server with SCP Support
 
 - **Purpose**: Offer a secure remote shell over the network with optional file copy using the SCP protocol.
-- **Status**: Provides an echo shell on port 2 of the loopback stack. Encryption and real networking are not yet present.
+- **Status**: Provides a line-based echo shell on port 2 of the loopback stack. Commands such as `exit` close the session. Encryption and real networking are not yet present.
 - **Future work**: Implement key exchange, authentication, encryption, and integration with the shell server.
 
 ## FTP Server
 
 - **Purpose**: Provide file transfer capabilities for legacy clients.
-- **Status**: Handles `LIST`, `RETR`, and `STOR` over port 3 of the loopback stack using NitrFS. Real file transfer and TCP/IP remain TODO.
+- **Status**: Handles `LIST`, `RETR`, `STOR`, and `QUIT` over port 3 of the loopback stack using NitrFS. Commands are terminated with CRLF and are trimmed before processing. Real file transfer and TCP/IP remain TODO.
 - **Future work**: Build on the NitrFS filesystem once a TCP/IP stack is available.
 
 Each of these services is started as a kernel thread during system initialization. They use the loopback network stack (ports 1–3) for testing but remain placeholders until true network drivers and protocols are added.

--- a/user/servers/ftp/ftp.c
+++ b/user/servers/ftp/ftp.c
@@ -9,6 +9,12 @@
 // Port used for FTP traffic on the loopback stack
 #define FTP_PORT 3
 
+static void trim_newline(char *s) {
+    char *p = s + strlen(s);
+    while (p > s && (p[-1] == '\n' || p[-1] == '\r'))
+        *--p = '\0';
+}
+
 static int find_handle(ipc_queue_t *q, uint32_t id, const char *name) {
     ipc_message_t msg = {0}, reply = {0};
     msg.type = NITRFS_MSG_LIST;
@@ -33,6 +39,7 @@ void ftp_server(ipc_queue_t *q, uint32_t self_id) {
         int n = net_socket_recv(sock, buf, sizeof(buf) - 1);
         if (n > 0) {
             buf[n] = '\0';
+            trim_newline(buf);
             if (!strncmp(buf, "QUIT", 4)) {
                 const char bye[] = "221 Bye\r\n";
                 net_socket_send(sock, bye, strlen(bye));

--- a/user/servers/ssh/ssh.c
+++ b/user/servers/ssh/ssh.c
@@ -7,6 +7,12 @@
 // Port used for SSH traffic on the loopback stack
 #define SSH_PORT 2
 
+static void trim_newline(char *s) {
+    char *p = s + strlen(s);
+    while (p > s && (p[-1] == '\n' || p[-1] == '\r'))
+        *--p = '\0';
+}
+
 void ssh_server(ipc_queue_t *q, uint32_t self_id) {
     (void)q; (void)self_id;
     serial_puts("[ssh] SSH server starting\n");
@@ -18,12 +24,13 @@ void ssh_server(ipc_queue_t *q, uint32_t self_id) {
         int n = net_socket_recv(sock, buf, sizeof(buf) - 1);
         if (n > 0) {
             buf[n] = '\0';
+            trim_newline(buf);
             if (!strncmp(buf, "exit", 4)) {
                 const char bye[] = "bye\r\n";
                 net_socket_send(sock, bye, strlen(bye));
                 break;
             }
-            net_socket_send(sock, buf, n); // echo
+            net_socket_send(sock, buf, strlen(buf));
             const char nl[] = "\r\n";
             net_socket_send(sock, nl, strlen(nl));
         }

--- a/user/servers/vnc/vnc.c
+++ b/user/servers/vnc/vnc.c
@@ -7,6 +7,12 @@
 // Port used for VNC traffic on the loopback stack
 #define VNC_PORT 1
 
+static void trim_newline(char *s) {
+    char *p = s + strlen(s);
+    while (p > s && (p[-1] == '\n' || p[-1] == '\r'))
+        *--p = '\0';
+}
+
 void vnc_server(ipc_queue_t *q, uint32_t self_id) {
     (void)q; (void)self_id;
     serial_puts("[vnc] VNC server starting\n");
@@ -18,6 +24,7 @@ void vnc_server(ipc_queue_t *q, uint32_t self_id) {
         int n = net_socket_recv(sock, buf, sizeof(buf) - 1);
         if (n > 0) {
             buf[n] = '\0';
+            trim_newline(buf);
             if (!strncmp(buf, "ping", 4)) {
                 const char pong[] = "pong\r\n";
                 net_socket_send(sock, pong, strlen(pong));


### PR DESCRIPTION
## Summary
- strip trailing CR/LF from VNC, SSH, and FTP server commands
- document network server command behavior and cleanup

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_688dbbd00f008333978749576311ea93