### PR TITLE
Clamp UEFI memory map and surface kernel entry

### DIFF
--- a/kernel/Kernel/kernel.c
+++ b/kernel/Kernel/kernel.c
@@ -122,6 +122,7 @@ static void print_bootinfo(const bootinfo_t *bi) {
     utoa(bi->mmap_entries, buf, 10); log_line("[boot] mmap entries:"); log_line(buf);
     ptoa((uint64_t)bi->framebuffer, buf); log_line("[boot] framebuffer ptr:"); log_line(buf);
     utoa(sizeof(bootinfo_memory_t), buf, 10); log_line("[boot] bootinfo_memory_t size:"); log_line(buf);
+    ptoa((uint64_t)bi->kernel_entry, buf); log_line("[boot] kernel entry:"); log_line(buf);
     if (bi->magic == BOOTINFO_MAGIC_UEFI) log_good("[boot] UEFI detected.");
     else if (bi->magic == BOOTINFO_MAGIC_MB2) log_good("[boot] Multiboot2 detected.");
     else log_warn("[boot] Unknown boot magic!");


### PR DESCRIPTION
## Summary
- cap UEFI memory map to `BOOTINFO_MAX_MMAP` and bound copy loops
- record and log the kernel entry address in `bootinfo`

## Testing
- `make -C boot`
- `gcc -ffreestanding ... user/libc/libc.c -o libc.o`
- `make -C kernel/Kernel CROSS_COMPILE=`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_688dcd23d038833385def9e86c42c91e