### PR TITLE
Improve kernel startup stack and RAM reporting

### DIFF
--- a/kernel/Kernel/kernel_entry.asm
+++ b/kernel/Kernel/kernel_entry.asm
@@ -1,9 +1,3 @@
-section .bss
-align 16
-kernel_stack:
-    resb 16384            ; 16 KiB kernel stack
-kernel_stack_top:
-
 section .text
 global _start
 
@@ -12,16 +6,8 @@ extern kernel_main
 
 _start:
     cld
-
-    ; rdi contains the bootinfo pointer from the bootloader
-    mov rax, rdi          ; preserve bootinfo pointer
-
-    ; Set up a small kernel stack
-    lea rsp, [kernel_stack_top]
+    ; Bootloader already set up stack and passed bootinfo in rdi
     xor rbp, rbp
-
-    ; Pass bootinfo pointer to kernel_main in rdi
-    mov rdi, rax
     call kernel_main
 
 .hang:


### PR DESCRIPTION
## Summary
- Drop redundant kernel stack; use bootloader-provided stack during startup
- Report total usable RAM from UEFI memory map during boot info printout

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_688dd094c6bc83338595e073133757c5