### PR TITLE
Add kernel loglevel boot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 * Experimental copy-on-write paging and basic demand paging
 * Early NUMA node enumeration from bootloader memory map
 * IPC shared memory channels with rights masks
+* Adjustable kernel log verbosity via `loglevel=` and `quiet` boot options
 
 ---
 


### PR DESCRIPTION
## Summary
- add configurable log levels and logging macros
- parse `loglevel=` and `quiet` kernel command line options to control boot verbosity
- document `loglevel` and `quiet` boot options in README

## Testing
- `make -C tests`
- `make libc`
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_688dd7395e708333ac5f7432357a0278