### PR TITLE
Add FTP server unit test and expand network docs

### DIFF
--- a/docs/NETWORK_SERVERS.md
+++ b/docs/NETWORK_SERVERS.md
@@ -1,6 +1,11 @@
 # Planned Network Servers
 
-This document outlines the network services for NitrOS. A very small network stack with a loopback device is now present in `Net/`. It can send and receive data within the system but does not talk to real hardware yet.  Each service communicates over a dedicated logical port on the loopback stack so they no longer interfere with one another.  The VNC, SSH, and FTP servers remain simple demonstrations until higher level protocols are implemented.
+This document outlines the network services for NitrOS.  A small loopback
+network stack lives in `Net/` and allows local user-mode servers to exchange
+packets without real hardware.  Each service communicates over a dedicated
+logical port so they no longer interfere with one another.  The VNC, SSH, and
+FTP servers remain simple demonstrations until higher level protocols are
+implemented.
 
 ## VNC Server
 
@@ -17,7 +22,16 @@ This document outlines the network services for NitrOS. A very small network sta
 ## FTP Server
 
 - **Purpose**: Provide file transfer capabilities for legacy clients.
-- **Status**: Handles `LIST`, `RETR`, `STOR`, and `QUIT` over port 3 of the loopback stack using NitrFS. Commands are terminated with CRLF and are trimmed before processing. Real file transfer and TCP/IP remain TODO.
-- **Future work**: Build on the NitrFS filesystem once a TCP/IP stack is available.
+- **Status**: Responds on port 3 of the loopback stack. After a greeting, it processes `LIST`, `RETR`, `STOR`, and `QUIT` commands using the NitrFS server for storage. Commands are terminated with CRLF and trimmed before processing.
+- **Example**:
+  ```text
+  LIST
+      (files listed)
+  STOR demo.txt hello world
+  RETR demo.txt
+  QUIT
+  ```
+- **Limitations**: Only the loopback device is supported and transfers are in-memory; there is no authentication or real TCP/IP stack yet.
+- **Future work**: Build on the NitrFS filesystem once a TCP/IP stack is available and hardware drivers are implemented.
 
 Each of these services is started as a kernel thread during system initialization. They use the loopback network stack (ports 1–3) for testing but remain placeholders until true network drivers and protocols are added.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,10 @@
 CC=gcc
 CFLAGS=-Wall -Wextra -std=gnu11 \
     -I../kernel/IPC -I../kernel/Kernel -I../kernel/VM -I../boot/include \
-    -I../user/servers/nitrfs -I../user/servers/login -I../user/libc \
-    -I../kernel/drivers/IO -I../kernel/drivers/Audio
-UNIT_TESTS=test_ipc test_pmm test_syscall test_nitrfs test_login
+    -I../user/servers/nitrfs -I../user/servers/login -I../user/servers/ftp \
+    -I../user/libc -I../kernel/drivers/IO -I../kernel/drivers/Audio \
+    -I../kernel/drivers/Net
+UNIT_TESTS=test_ipc test_pmm test_syscall test_nitrfs test_login test_ftp
 
 all: $(UNIT_TESTS)
 	for t in $(UNIT_TESTS); do ./$$t; done
@@ -21,6 +22,9 @@ test_nitrfs: unit/test_nitrfs.c ../user/servers/nitrfs/nitrfs.c ../user/libc/lib
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_login: unit/test_login.c ../user/servers/login/login.c ../user/libc/libc.c ../kernel/IPC/ipc.c
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_ftp: unit/test_ftp.c ../user/servers/ftp/ftp.c ../kernel/IPC/ipc.c ../user/libc/libc.c
 	$(CC) $(CFLAGS) $^ -o $@
 
 clean:

--- a/tests/unit/test_ftp.c
+++ b/tests/unit/test_ftp.c
@@ -1,0 +1,46 @@
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+#include "../../user/servers/ftp/ftp.h"
+#include "../../kernel/IPC/ipc.h"
+#include "../../user/libc/libc.h"
+#include "../../kernel/drivers/Net/netstack.h"
+
+static const char *input = "QUIT\r\n";
+static size_t in_pos;
+static char output[256];
+static size_t out_pos;
+
+int net_socket_open(uint16_t port, net_socket_type_t type) {
+    (void)port; (void)type;
+    return 1;
+}
+int net_socket_close(int sock) { (void)sock; return 0; }
+int net_socket_send(int sock, const void *data, size_t len) {
+    (void)sock;
+    if (out_pos + len > sizeof(output)) len = sizeof(output) - out_pos;
+    memcpy(output + out_pos, data, len);
+    out_pos += len;
+    return (int)len;
+}
+int net_socket_recv(int sock, void *buf, size_t len) {
+    (void)sock;
+    if (in_pos >= strlen(input))
+        return 0;
+    size_t n = strlen(input) - in_pos;
+    if (n > len) n = len;
+    memcpy(buf, input + in_pos, n);
+    in_pos += n;
+    return (int)n;
+}
+void thread_yield(void) {}
+void serial_puts(const char *s) { (void)s; }
+void serial_write(char c) { (void)c; }
+
+int main(void) {
+    ftp_server(NULL, 0);
+    const char expect[] = "220 NOS FTP\r\n221 Bye\r\n";
+    assert(out_pos == strlen(expect));
+    assert(memcmp(output, expect, out_pos) == 0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add unit test validating FTP server greeting and QUIT handling
- document network servers with loopback stack overview and FTP usage examples

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_688ddc71cf948333b4dfa8c1f732a654