### PR TITLE
Improve boot memory map handling

### DIFF
--- a/boot/include/bootinfo.h
+++ b/boot/include/bootinfo.h
@@ -36,7 +36,7 @@ typedef struct bootinfo {
     bootinfo_cpu_t cpus[BOOTINFO_MAX_CPUS];
     uint32_t cpu_count;
     void *mb2_tags;
-    uint64_t reserved[8];
+    uint64_t reserved[8]; // reserved[0] stores total mmap entries before clamping
     void *kernel_entry;
 } bootinfo_t;
 

--- a/kernel/Kernel/kernel.c
+++ b/kernel/Kernel/kernel.c
@@ -166,6 +166,11 @@ static void print_bootinfo(const bootinfo_t *bi) {
     ptoa((uint64_t)bi, buf); log_line("[boot] bootinfo ptr:"); log_line(buf);
     ptoa((uint64_t)bi->mmap, buf); log_line("[boot] mmap ptr:"); log_line(buf);
     utoa(bi->mmap_entries, buf, 10); log_line("[boot] mmap entries:"); log_line(buf);
+    if (bi->reserved[0] > bi->mmap_entries) {
+        utoa(bi->reserved[0], buf, 10);
+        log_warn("[boot] mmap truncated; total descriptors:");
+        log_line(buf);
+    }
     ptoa((uint64_t)bi->framebuffer, buf); log_line("[boot] framebuffer ptr:"); log_line(buf);
     utoa(sizeof(bootinfo_memory_t), buf, 10); log_line("[boot] bootinfo_memory_t size:"); log_line(buf);
     ptoa((uint64_t)bi->kernel_entry, buf); log_line("[boot] kernel entry:"); log_line(buf);


### PR DESCRIPTION
## Summary
- ensure UEFI memory descriptor size is valid before parsing
- track total memory map descriptors and warn in kernel when truncated

## Testing
- `make -C tests`
- `./tests/test_ipc`
- `./tests/test_pmm`
- `./tests/test_syscall`
- `./tests/test_nitrfs`
- `./tests/test_login`
- `./tests/test_ftp`


------
https://chatgpt.com/codex/tasks/task_b_688de4e98a888333867d13333b363f3e