### PR TITLE
Remove unused VGA helper and fix EFI linker flags

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -11,7 +11,6 @@ LDFLAGS=/entry:efi_main \
         /subsystem:efi_application \
         /nodefaultlib \
        /base:0 \
-        /align:32 \
         /filealign:32 \
         /out:NitrOBoot.efi
 

--- a/user/servers/shell/shell.c
+++ b/user/servers/shell/shell.c
@@ -58,7 +58,6 @@ static void putc_vga(char c) {
     }
 }
 
-static void puts_vga(const char *s) { while (*s) putc_vga(*s++); }
 
 // Write to both serial and VGA
 static void putc_out(char c) { serial_write(c); putc_vga(c); }


### PR DESCRIPTION
## Summary
- silence unused-function warning in shell server by removing `puts_vga`
- drop unsupported `/align` flag from bootloader's linker options to avoid lld warning

## Testing
- `cd boot && make clean && make`
- `cd user/servers/shell && make clean && make` *(fails: `/opt/cross/bin/x86_64-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_688df1e9094c8333b46e65d831367008