### PR TITLE
Increase heap and add verbose Stage 2 logging

### DIFF
--- a/kernel/Kernel/kernel.c
+++ b/kernel/Kernel/kernel.c
@@ -282,21 +282,40 @@ void kernel_main(bootinfo_t *bootinfo) {
     }
     print_bootinfo(bootinfo);
     log_line("[Stage 2] Init memory management");
+    log_line("  pmm_init start");
     pmm_init(bootinfo);
+    log_line("  pmm_init done");
+    log_line("  cow_init start");
     cow_init(pmm_total_frames());
+    log_line("  cow_init done");
+    log_line("  numa_init start");
     numa_init(bootinfo);
+    log_line("  numa_init done");
+    log_line("  paging_init start");
     paging_init();
+    log_line("  paging_init done");
 
     log_line("[Stage 3] Set up interrupts");
+    log_line("  gdt_install start");
     gdt_install();
+    log_line("  gdt_install done");
+    log_line("  idt_install start");
     idt_install();
+    log_line("  idt_install done");
+    log_line("  pic_remap start");
     pic_remap();
+    log_line("  pic_remap done");
+    log_line("  pit_init start");
     pit_init(100);
+    log_line("  pit_init done");
+    log_line("  keyboard_init start");
     keyboard_init();
     log_good("[kbd] Keyboard initialized");
+    log_line("  mouse_init start");
     mouse_init();
     log_good("[mou] Mouse initialized");
 
+    log_line("  net_init start");
     net_init();
     log_good("[net] Network stack ready");
 

--- a/user/libc/libc.c
+++ b/user/libc/libc.c
@@ -127,7 +127,7 @@ char *strstr(const char *haystack, const char *needle) {
     return NULL;
 }
 
-#define HEAP_SIZE (64 * 1024)
+#define HEAP_SIZE (1024 * 1024)  // 1 MiB bootstrap heap for early allocations
 #define HEAP_MAGIC 0xC0DECAFE
 
 typedef struct block_header {


### PR DESCRIPTION
## Summary
- enlarge bootstrap heap to 1 MiB so early memory management has room for COW metadata
- add detailed logging around memory management and interrupt setup steps

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_688df7ced58083339081696526412cf6