### PR TITLE
Fix timer interrupt scheduling to prevent hang

### DIFF
--- a/kernel/arch/IDT/interrupt.c
+++ b/kernel/arch/IDT/interrupt.c
@@ -19,8 +19,8 @@ void isr_timer_handler(void) {
     // Write a clock value to VGA
     volatile char* vga = (char*)0xB8000 + 160;
     vga[0] = '0' + (ticks % 10);
-    // Preempt current thread on each timer tick
-    thread_yield();
+    // actual scheduling occurs in the assembly stub after acknowledging
+    // the interrupt. This handler simply updates the timer tick display.
 }
 
 void isr_page_fault_handler(uint64_t error_code, uint64_t addr) {

--- a/kernel/arch/IDT/isr_stub.asm
+++ b/kernel/arch/IDT/isr_stub.asm
@@ -2,12 +2,16 @@ global isr_timer_stub
 isr_timer_stub:
     push rbp
     mov rbp, rsp
-    cli
     extern isr_timer_handler
     call isr_timer_handler
-    ; Send EOI to PIC
+    ; Acknowledge the PIC before switching threads
     mov al, 0x20
     out 0x20, al
+    ; Re-enable interrupts for the next thread
+    sti
+    extern thread_yield
+    call thread_yield
+    ; Execution resumes here when the preempted thread runs again
     leave
     iretq
 


### PR DESCRIPTION
## Summary
- Handle timer ticks entirely in assembly stub and remove `thread_yield` from C handler
- Acknowledge the PIC and re-enable interrupts before switching threads to avoid deadlock

## Testing
- `make libc`
- `make -C kernel/Kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_688dfe44402083339b2f8ab887433192