### PR TITLE
bootloader: provide CPU info to kernel

### DIFF
--- a/boot/src/NitrOBoot.c
+++ b/boot/src/NitrOBoot.c
@@ -71,6 +71,42 @@ static VOID *find_acpi_rsdp(struct EFI_SYSTEM_TABLE *SystemTable) {
     return NULL;
 }
 
+// --- Minimal CPUID helpers for basic CPU info ---
+static inline void cpuid(UINT32 eax_in, UINT32 ecx_in,
+                         UINT32 *eax, UINT32 *ebx,
+                         UINT32 *ecx_out, UINT32 *edx)
+{
+    __asm__ __volatile__("cpuid"
+                         : "=a"(*eax), "=b"(*ebx), "=c"(*ecx_out), "=d"(*edx)
+                         : "a"(eax_in), "c"(ecx_in));
+}
+
+static UINT32 detect_logical_cpus(void)
+{
+    UINT32 max_leaf, eax, ebx, ecx, edx;
+    cpuid(0, 0, &max_leaf, &ebx, &ecx, &edx);
+    if (max_leaf >= 0x0B) {
+        cpuid(0x0B, 0, &eax, &ebx, &ecx, &edx);
+        UINT32 count = ebx & 0xFFFF;
+        if (count == 0) count = 1;
+        return count;
+    }
+    if (max_leaf >= 1) {
+        cpuid(1, 0, &eax, &ebx, &ecx, &edx);
+        UINT32 count = (ebx >> 16) & 0xFF;
+        if (count == 0) count = 1;
+        return count;
+    }
+    return 1;
+}
+
+static UINT32 detect_bsp_apic_id(void)
+{
+    UINT32 eax, ebx, ecx, edx;
+    cpuid(1, 0, &eax, &ebx, &ecx, &edx);
+    return (ebx >> 24) & 0xFF;
+}
+
 // --- ELF structs ---
 typedef struct {
     unsigned char e_ident[16];
@@ -168,6 +204,16 @@ EFI_STATUS efi_main(EFI_HANDLE ImageHandle, struct EFI_SYSTEM_TABLE *SystemTable
     info->magic = BOOTINFO_MAGIC_UEFI;
     info->size = sizeof(bootinfo_t);
     info->bootloader_name = "NitrOBoot UEFI";
+
+    // Detect basic CPU information for the kernel
+    info->cpu_count = detect_logical_cpus();
+    if (info->cpu_count > 0) {
+        info->cpus[0].processor_id = 0;
+        info->cpus[0].apic_id = detect_bsp_apic_id();
+        info->cpus[0].flags = 1;
+    }
+    print_hex(ConOut, L"cpu count: ", info->cpu_count);
+    print_hex(ConOut, L"BSP APIC ID: ", info->cpus[0].apic_id);
 
     // Retrieve optional command line from UEFI load options
     EFI_LOADED_IMAGE_PROTOCOL *LoadedImage = NULL;

--- a/kernel/Kernel/kernel.c
+++ b/kernel/Kernel/kernel.c
@@ -275,10 +275,13 @@ void kernel_main(bootinfo_t *bootinfo) {
         parse_cmdline(bootinfo->cmdline);
     acpi_init(bootinfo);
     if (bootinfo && bootinfo->cpu_count == 0) {
+        log_warn("[boot] CPU count missing; using CPUID");
         bootinfo->cpu_count = cpu_detect_logical_count();
         bootinfo->cpus[0].processor_id = 0;
         bootinfo->cpus[0].apic_id = 0;
         bootinfo->cpus[0].flags = 1;
+    } else if (bootinfo) {
+        log_info("[boot] CPU info provided by bootloader");
     }
     print_bootinfo(bootinfo);
     log_line("[Stage 2] Init memory management");


### PR DESCRIPTION
## Summary
- populate bootinfo with CPU count and BSP APIC ID using CPUID
- log whether CPU info came from bootloader or kernel detection

## Testing
- `make -C boot`
- `make -C kernel/Kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_688e020d0b5c8333833369aac4299434