### PR TITLE
Fix timer interrupt reentrancy causing scheduler hang

### DIFF
--- a/kernel/arch/IDT/isr_stub.asm
+++ b/kernel/arch/IDT/isr_stub.asm
@@ -7,8 +7,7 @@ isr_timer_stub:
     ; Acknowledge the PIC before switching threads
     mov al, 0x20
     out 0x20, al
-    ; Re-enable interrupts for the next thread
-    sti
+    ; Yield to the scheduler to pick the next thread
     extern thread_yield
     call thread_yield
     ; Execution resumes here when the preempted thread runs again


### PR DESCRIPTION
## Summary
- Prevent nested timer interrupts by removing premature STI in the timer ISR and yielding directly to the scheduler

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_688e0b26216083339be4d6c9aabaf4aa