### PR TITLE
Fix IPC thread yield to avoid scheduler hang

### DIFF
--- a/kernel/IPC/ipc.c
+++ b/kernel/IPC/ipc.c
@@ -1,7 +1,9 @@
 #include "ipc.h"
 #include "../../user/libc/libc.h"
 
-__attribute__((weak)) void thread_yield(void) {}
+// thread_yield can be provided by the threading subsystem. If not present
+// (e.g., in unit tests), it will resolve to NULL and simply not be called.
+__attribute__((weak)) void thread_yield(void);
 
 /**
  * Initialize an IPC queue for message passing.
@@ -62,7 +64,8 @@ int ipc_receive(ipc_queue_t *q, uint32_t receiver_id, ipc_message_t *msg) {
     if (receiver_id >= IPC_MAX_TASKS || !(q->caps[receiver_id] & IPC_CAP_RECV))
         return -2; // unauthorized receiver
     if (q->tail == q->head) {
-        thread_yield();
+        if (thread_yield)
+            thread_yield();
         return -1; // queue empty
     }
     *msg = q->msgs[q->tail];


### PR DESCRIPTION
## Summary
- allow external `thread_yield` implementation and call it only when present so scheduler can preempt tasks

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_688ec39e01688333b3be4fb5841fc4ba