### PR TITLE
Fix timer ISR scheduling

### DIFF
--- a/kernel/arch/IDT/isr_stub.asm
+++ b/kernel/arch/IDT/isr_stub.asm
@@ -4,13 +4,9 @@ isr_timer_stub:
     mov rbp, rsp
     extern isr_timer_handler
     call isr_timer_handler
-    ; Acknowledge the PIC before switching threads
+    ; Acknowledge the PIC and return
     mov al, 0x20
     out 0x20, al
-    ; Yield to the scheduler to pick the next thread
-    extern thread_yield
-    call thread_yield
-    ; Execution resumes here when the preempted thread runs again
     leave
     iretq
 


### PR DESCRIPTION
## Summary
- Avoid context switching directly from the PIT interrupt handler

## Testing
- `make -C tests`
- `make libc kernel`


------
https://chatgpt.com/codex/tasks/task_b_688ec57ff0388333849dd9a7d32090be