### PR TITLE
Enable scheduler on timer interrupt

### DIFF
--- a/kernel/arch/IDT/isr_stub.asm
+++ b/kernel/arch/IDT/isr_stub.asm
@@ -1,13 +1,45 @@
 global isr_timer_stub
 isr_timer_stub:
+    cli
+    ; Save general purpose registers
+    push rax
+    push rbx
+    push rcx
+    push rdx
+    push rsi
+    push rdi
+    push r8
+    push r9
+    push r10
+    push r11
     push rbp
-    mov rbp, rsp
+    push r12
+    push r13
+    push r14
+    push r15
     extern isr_timer_handler
     call isr_timer_handler
-    ; Acknowledge the PIC and return
+    ; Send End of Interrupt to PIC
     mov al, 0x20
     out 0x20, al
-    leave
+    extern schedule
+    call schedule
+    ; Restore registers and return to scheduled thread
+    pop r15
+    pop r14
+    pop r13
+    pop r12
+    pop rbp
+    pop r11
+    pop r10
+    pop r9
+    pop r8
+    pop rdi
+    pop rsi
+    pop rdx
+    pop rcx
+    pop rbx
+    pop rax
     iretq
 
 


### PR DESCRIPTION
## Summary
- invoke scheduler from timer interrupt stub so threads preempt

## Testing
- `cd tests && make clean && make`
- `make libc && make kernel`


------
https://chatgpt.com/codex/tasks/task_b_688edd9718cc833396097c5d83dc60eb