### PR TITLE
Avoid scheduling from timer interrupt

### DIFF
--- a/kernel/arch/IDT/isr_stub.asm
+++ b/kernel/arch/IDT/isr_stub.asm
@@ -22,9 +22,12 @@ isr_timer_stub:
     ; Send End of Interrupt to PIC
     mov al, 0x20
     out 0x20, al
-    extern schedule
-    call schedule
-    ; Restore registers and return to scheduled thread
+    ; Preemptive scheduling is not yet supported here. Calling the
+    ; scheduler from interrupt context corrupts the stack because the
+    ; context switch routine expects a normal function call frame.  For
+    ; now simply return to the interrupted thread after updating the
+    ; timer tick.
+    ; Restore registers and return to the interrupted thread
     pop r15
     pop r14
     pop r13


### PR DESCRIPTION
## Summary
- Remove scheduler call from timer interrupt stub to avoid stack corruption
- Document why preemptive scheduling from interrupt context is disabled

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_688ee51e85d4833389bcf1d39976e4b1