### PR TITLE
Fix thread start linkage and mark asm as non-exec

### DIFF
--- a/kernel/Kernel/kernel_entry.asm
+++ b/kernel/Kernel/kernel_entry.asm
@@ -14,3 +14,6 @@ _start:
     cli
     hlt
     jmp .hang
+
+; Indicate that this object file does not require an executable stack
+section .note.GNU-stack noalloc nobits align=1

--- a/kernel/Task/context_switch.asm
+++ b/kernel/Task/context_switch.asm
@@ -35,3 +35,6 @@ context_switch:
     popfq
 
     ret
+
+; Indicate that this object file does not require an executable stack
+section .note.GNU-stack noalloc nobits align=1

--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -51,7 +51,7 @@ static void utoa_dec(uint32_t val, char *buf) {
 // function pointer the thread should run. We pop that function pointer and
 // invoke it. When the function returns the thread marks itself as exited
 // and yields back to the scheduler.
-static void thread_start(void (*f)(void)) {
+__attribute__((used)) static void thread_start(void (*f)(void)) {
     f();
     thread_t *cur = current_cpu[smp_cpu_index()];
     cur->state = THREAD_EXITED;

--- a/kernel/Task/user_mode.asm
+++ b/kernel/Task/user_mode.asm
@@ -35,3 +35,6 @@ enter_user_mode:
     hlt
     jmp $
 
+; Indicate that this object file does not require an executable stack
+section .note.GNU-stack noalloc nobits align=1
+

--- a/kernel/arch/GDT/gdt.asm
+++ b/kernel/arch/GDT/gdt.asm
@@ -22,3 +22,6 @@ gdt_flush:
     retfq
 .flush:
     ret
+
+; Indicate that this object file does not require an executable stack
+section .note.GNU-stack noalloc nobits align=1

--- a/kernel/arch/IDT/isr_stub.asm
+++ b/kernel/arch/IDT/isr_stub.asm
@@ -135,3 +135,6 @@ isr_ipi_stub:
     call isr_ipi_handler
     leave
     iretq
+
+; Indicate that this object file does not require an executable stack
+section .note.GNU-stack noalloc nobits align=1

--- a/kernel/drivers/IO/isr_timer_stub.asm
+++ b/kernel/drivers/IO/isr_timer_stub.asm
@@ -11,3 +11,6 @@ isr_timer_stub:
     out 0x20, al
     leave
     iretq
+
+; Indicate that this object file does not require an executable stack
+section .note.GNU-stack noalloc nobits align=1


### PR DESCRIPTION
## Summary
- prevent `thread_start` from being optimized away so new threads link correctly
- declare non-executable stacks in assembly sources to silence GNU-stack linker warnings

## Testing
- `make -C kernel/Kernel`


------
https://chatgpt.com/codex/tasks/task_b_688f5caf77008333a857de9caaac8aa5