### PR TITLE
Fix scheduler start race

### DIFF
--- a/kernel/Kernel/kernel.c
+++ b/kernel/Kernel/kernel.c
@@ -327,8 +327,11 @@ void kernel_main(bootinfo_t *bootinfo) {
     threads_init();
 
     log_line("[Stage 5] Scheduler start");
-    asm volatile("sti");      // enable interrupts before scheduling threads
-    schedule();               // start first thread now that IRQs are enabled
+    // Start the first thread with interrupts disabled to avoid a timer
+    // interrupt racing the initial call to schedule(). Each thread stack
+    // has IF set in its saved rflags, so once a thread is running timer
+    // interrupts will be enabled automatically.
+    schedule();
 
     for (;;) {
         schedule();


### PR DESCRIPTION
## Summary
- start first scheduler run with interrupts disabled to prevent PIT preemption during initial scheduling

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_68901f2f2b448333b9075650fa960701