### PR TITLE
Fix libc build dependency for kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ CROSS_COMPILE ?= x86_64-linux-gnu-
 all: libc kernel boot disk.img
 
 libc:
-	$(CROSS_COMPILE)gcc -ffreestanding -O2 -Wall -Wextra -mno-red-zone -nostdlib -c user/libc/libc.c -o libc.o
+	$(CROSS_COMPILE)gcc -ffreestanding -O2 -Wall -Wextra -mno-red-zone -nostdlib -c user/libc/libc.c -o user/libc/libc.o
 
-kernel:
+kernel: libc
 	make -C kernel/Kernel CROSS_COMPILE=$(CROSS_COMPILE)
 	cp kernel/Kernel/kernel.bin kernel.bin
 
@@ -23,7 +23,7 @@ disk.img: boot kernel
 clean:
 	make -C kernel/Kernel clean
 	make -C boot clean
-	rm -f kernel.bin libc.o disk.img
+	rm -f kernel.bin user/libc/libc.o disk.img
 
 run: disk.img
 	qemu-system-x86_64 \

--- a/kernel/Kernel/Makefile
+++ b/kernel/Kernel/Makefile
@@ -58,7 +58,7 @@ OBJS = \
     ../arch/ACPI/acpi.o \
     ../drivers/IO/video.o \
     ../drivers/Audio/audio.o \
-    ../../libc.o
+    ../../user/libc/libc.o
 
 all: kernel.bin
 
@@ -89,4 +89,4 @@ kernel.bin: $(OBJS) kernel.ld
 clean:
 	rm -f *.o kernel.bin \
 ../arch/IDT/*.o ../drivers/IO/*.o ../drivers/Net/*.o ../VM/*.o \
-../Task/*.o ../arch/GDT/*.o ../../user/servers/*/*.o ../IPC/*.o ../arch/CPU/*.o ../../libc.o
+../Task/*.o ../arch/GDT/*.o ../../user/servers/*/*.o ../IPC/*.o ../arch/CPU/*.o ../../user/libc/libc.o


### PR DESCRIPTION
## Summary
- Build libc object in `user/libc` and make kernel depend on it
- Link kernel against the relocated libc object and clean it properly

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_b_689041c3a1048333b9a9998c40848cc4