### PR TITLE
Fix network init hang with proper PCI config I/O

### DIFF
--- a/kernel/drivers/IO/io.h
+++ b/kernel/drivers/IO/io.h
@@ -11,6 +11,16 @@ static inline uint8_t inb(uint16_t port) {
     return ret;
 }
 
+static inline void outl(uint16_t port, uint32_t val) {
+    asm volatile ( "outl %0, %1" : : "a"(val), "Nd"(port) );
+}
+
+static inline uint32_t inl(uint16_t port) {
+    uint32_t ret;
+    asm volatile ( "inl %1, %0" : "=a"(ret) : "Nd"(port) );
+    return ret;
+}
+
 static inline void io_wait(void) {
     asm volatile ( "outb %%al, $0x80" : : "a"(0) );
 }

--- a/kernel/drivers/IO/pci.c
+++ b/kernel/drivers/IO/pci.c
@@ -7,27 +7,13 @@
 uint32_t pci_config_read(uint8_t bus, uint8_t slot, uint8_t func, uint8_t offset) {
     uint32_t address = (uint32_t)((bus << 16) | (slot << 11) |
                            (func << 8) | (offset & 0xfc) | ((uint32_t)0x80000000));
-    outb(PCI_ADDRESS_PORT, address & 0xFF);
-    outb(PCI_ADDRESS_PORT + 1, (address >> 8) & 0xFF);
-    outb(PCI_ADDRESS_PORT + 2, (address >> 16) & 0xFF);
-    outb(PCI_ADDRESS_PORT + 3, (address >> 24) & 0xFF);
-    uint32_t value = 0;
-    value |= inb(PCI_DATA_PORT);
-    value |= inb(PCI_DATA_PORT + 1) << 8;
-    value |= inb(PCI_DATA_PORT + 2) << 16;
-    value |= inb(PCI_DATA_PORT + 3) << 24;
-    return value;
+    outl(PCI_ADDRESS_PORT, address);
+    return inl(PCI_DATA_PORT);
 }
 
 void pci_config_write(uint8_t bus, uint8_t slot, uint8_t func, uint8_t offset, uint32_t value) {
     uint32_t address = (uint32_t)((bus << 16) | (slot << 11) |
                            (func << 8) | (offset & 0xfc) | ((uint32_t)0x80000000));
-    outb(PCI_ADDRESS_PORT, address & 0xFF);
-    outb(PCI_ADDRESS_PORT + 1, (address >> 8) & 0xFF);
-    outb(PCI_ADDRESS_PORT + 2, (address >> 16) & 0xFF);
-    outb(PCI_ADDRESS_PORT + 3, (address >> 24) & 0xFF);
-    outb(PCI_DATA_PORT, value & 0xFF);
-    outb(PCI_DATA_PORT + 1, (value >> 8) & 0xFF);
-    outb(PCI_DATA_PORT + 2, (value >> 16) & 0xFF);
-    outb(PCI_DATA_PORT + 3, (value >> 24) & 0xFF);
+    outl(PCI_ADDRESS_PORT, address);
+    outl(PCI_DATA_PORT, value);
 }


### PR DESCRIPTION
## Summary
- Add 32-bit `outl`/`inl` helpers for port I/O
- Use atomic 32-bit PCI config accesses to avoid long bus scans during network init

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_6890438dd2008333b6f4717576c7ef8b