### PR TITLE
Avoid preemption to unstarted threads

### DIFF
--- a/kernel/Task/thread.h
+++ b/kernel/Task/thread.h
@@ -16,7 +16,8 @@ typedef struct thread {
     char *stack;
     int id;
     thread_state_t state;
-    struct thread *next; // run queue link
+    int started;            // has the thread begun execution
+    struct thread *next;    // run queue link
 } thread_t;
 
 extern thread_t *current_cpu[MAX_CPUS];


### PR DESCRIPTION
## Summary
- Track whether a thread has begun execution
- Skip timer preemption to threads that haven't started yet
- Mark threads as started once the scheduler switches to them

## Testing
- `make -C tests`
- `cd tests && for t in test_ipc test_pmm test_syscall test_nitrfs test_login test_ftp; do echo "running $t"; ./$t; done`


------
https://chatgpt.com/codex/tasks/task_b_6890474dfbf083339de9f86455b7b025