### PR TITLE
Prevent VNC server startup from monopolizing scheduler

### DIFF
--- a/user/servers/vnc/vnc.c
+++ b/user/servers/vnc/vnc.c
@@ -19,6 +19,9 @@ void vnc_server(ipc_queue_t *q, uint32_t self_id) {
     int sock = net_socket_open(VNC_PORT, NET_SOCK_STREAM);
     const char hello[] = "NOS VNC ready\r\n";
     net_socket_send(sock, hello, strlen(hello));
+    // Yield once after initialisation so other threads can run even if
+    // the networking calls above block or take time to complete.
+    thread_yield();
     char buf[64];
     for (;;) {
         int n = net_socket_recv(sock, buf, sizeof(buf) - 1);


### PR DESCRIPTION
## Summary
- Yield once after the VNC server starts to allow other threads to run even if networking calls block

## Testing
- `make kernel`

------
https://chatgpt.com/codex/tasks/task_b_68904a1a58948333b316b617019a2697