### PR TITLE
Ensure login server announces start

### DIFF
--- a/user/servers/login/login.c
+++ b/user/servers/login/login.c
@@ -88,7 +88,9 @@ static void read_line(char *buf, size_t len, int hide)
 void login_server(ipc_queue_t *q, uint32_t self_id)
 {
     (void)q; (void)self_id;
-    serial_puts("[login] login server starting\n");
+    puts_out("[login] login server starting\n");
+    /* Give other threads a chance to run so the start message is visible */
+    thread_yield();
     char user[32];
     char pass[32];
     for(;;) {


### PR DESCRIPTION
## Summary
- Ensure login server prints a startup message to both serial and VGA output
- Yield once at startup so other tasks can run and the message appears

## Testing
- `cd tests && make clean && make`


------
https://chatgpt.com/codex/tasks/task_b_68904d2cd9488333bcc7cadbbb9e5efe