### PR TITLE
Fix login server startup logging

### DIFF
--- a/user/servers/login/login.c
+++ b/user/servers/login/login.c
@@ -51,7 +51,8 @@ static void putc_vga(char c)
 
 static void puts_out(const char *s)
 {
-    while(*s) { serial_write(*s); putc_vga(*s++); }
+    serial_puts(s);
+    while(*s) { putc_vga(*s++); }
 }
 
 static char getchar_block(void)


### PR DESCRIPTION
## Summary
- use `serial_puts` in login server helper so startup message appears on serial console

## Testing
- `make clean && make test_login`
- `./test_login`

------
https://chatgpt.com/codex/tasks/task_b_68904f08a91083339288bec835edd808