### PR TITLE
Add startup yield to FTP server

### DIFF
--- a/user/servers/ftp/ftp.c
+++ b/user/servers/ftp/ftp.c
@@ -34,6 +34,9 @@ void ftp_server(ipc_queue_t *q, uint32_t self_id) {
     int sock = net_socket_open(FTP_PORT, NET_SOCK_STREAM);
     const char hello[] = "220 NOS FTP\r\n";
     net_socket_send(sock, hello, strlen(hello));
+    /* Yield once after initialisation so other threads can run even if
+     * the networking calls above block or take time to complete. */
+    thread_yield();
     char buf[128];
     for (;;) {
         int n = net_socket_recv(sock, buf, sizeof(buf) - 1);


### PR DESCRIPTION
## Summary
- let the FTP server yield after sending its initial banner so other services (like login/ssh) can run even if network calls stall

## Testing
- `cd tests && make clean && make`

------
https://chatgpt.com/codex/tasks/task_b_689056fef5f48333afc5f6bec9c961cf