### PR TITLE
Fix current thread pointer during ISR scheduling

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -270,6 +270,10 @@ uint64_t schedule_from_isr(uint64_t *old_rsp) {
 
     thread_t *next = pick_next(cpu);
     if (!next || !next->started) {
+        // pick_next advances current_cpu even if we do not switch
+        // threads. Restore the pointer so the scheduler state remains
+        // consistent with the actually running thread.
+        current_cpu[cpu] = prev;
         prev->state = THREAD_RUNNING;
         return (uint64_t)old_rsp;
     }


### PR DESCRIPTION
## Summary
- Restore current_cpu pointer if no thread switch occurs in `schedule_from_isr`

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689059e0d98883338e0defc4950c3999