### PR TITLE
Implement TTY-based login and shell

### DIFF
--- a/kernel/Kernel/Makefile
+++ b/kernel/Kernel/Makefile
@@ -19,6 +19,7 @@ OBJS = \
     ../drivers/IO/pci.o \
     ../drivers/IO/usb.o \
     ../drivers/IO/serial.o \
+    ../drivers/IO/tty.o \
     ../drivers/IO/block.o \
     ../drivers/Net/e1000.o \
     ../drivers/Net/netstack.o \

--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -1,7 +1,6 @@
 #include "thread.h"
 #include "../IPC/ipc.h"
 #include "../../user/servers/nitrfs/server.h"
-#include "../../user/servers/shell/shell.h"
 #include "../../user/servers/vnc/vnc.h"
 #include "../../user/servers/ssh/ssh.h"
 #include "../../user/servers/ftp/ftp.h"
@@ -71,7 +70,6 @@ static void __attribute__((naked)) thread_entry(void) {
 
 static void thread_fs_func(void)   { thread_t *c = current_cpu[smp_cpu_index()]; nitrfs_server(&fs_queue, c->id); }
 static void thread_init_func(void) { thread_t *c = current_cpu[smp_cpu_index()]; init_main(&fs_queue, c->id); }
-static void thread_shell_func(void){ thread_t *c = current_cpu[smp_cpu_index()]; shell_main(&fs_queue, &pkg_queue, &upd_queue, c->id); }
 static void thread_pkg_func(void)   { thread_t *c = current_cpu[smp_cpu_index()]; pkg_server(&pkg_queue, c->id); }
 static void thread_update_func(void){ thread_t *c = current_cpu[smp_cpu_index()]; update_server(&upd_queue, &pkg_queue, c->id); }
 static void thread_vnc_func(void)  { thread_t *c = current_cpu[smp_cpu_index()]; vnc_server(NULL, c->id); }
@@ -177,6 +175,8 @@ void threads_init(void) {
 
     t = thread_create(thread_login_func);
     ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    ipc_grant(&upd_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
 
     t = thread_create(thread_pkg_func);
     ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
@@ -184,11 +184,6 @@ void threads_init(void) {
     t = thread_create(thread_update_func);
     ipc_grant(&upd_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
     ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-
-    t = thread_create(thread_shell_func);
-    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-    ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-    ipc_grant(&upd_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
 
     t = thread_create(thread_vnc_func);
     ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);

--- a/kernel/drivers/IO/tty.c
+++ b/kernel/drivers/IO/tty.c
@@ -1,0 +1,50 @@
+#include "tty.h"
+#include "keyboard.h"
+#include "serial.h"
+#include "video.h"
+
+#define VGA_TEXT_BUF 0xB8000
+#define VGA_COLS 80
+#define VGA_ROWS 25
+
+static int row = 0, col = 0;
+
+void tty_init(void) {
+    tty_clear();
+}
+
+void tty_clear(void) {
+    video_clear(0);
+    volatile uint16_t *vga = (uint16_t *)VGA_TEXT_BUF;
+    for (int i = 0; i < VGA_COLS * VGA_ROWS; ++i)
+        vga[i] = (0x0F << 8) | ' ';
+    row = 0;
+    col = 0;
+}
+
+void tty_putc(char c) {
+    serial_write(c);
+    volatile uint16_t *vga = (uint16_t *)VGA_TEXT_BUF;
+    if (c == '\n') {
+        col = 0;
+        if (++row >= VGA_ROWS - 1)
+            row = VGA_ROWS - 2;
+        return;
+    }
+    vga[row * VGA_COLS + col] = (0x0F << 8) | c;
+    if (++col >= VGA_COLS) {
+        col = 0;
+        if (++row >= VGA_ROWS - 1)
+            row = VGA_ROWS - 2;
+    }
+}
+
+void tty_write(const char *s) {
+    while (*s)
+        tty_putc(*s++);
+}
+
+int tty_getchar(void) {
+    return keyboard_getchar();
+}
+

--- a/kernel/drivers/IO/tty.h
+++ b/kernel/drivers/IO/tty.h
@@ -1,0 +1,12 @@
+#ifndef TTY_H
+#define TTY_H
+
+#include <stdint.h>
+
+void tty_init(void);
+void tty_clear(void);
+void tty_putc(char c);
+void tty_write(const char *s);
+int tty_getchar(void);
+
+#endif // TTY_H

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,7 +21,7 @@ test_syscall: unit/test_syscall.c ../kernel/Kernel/syscall.c ../kernel/Kernel/el
 test_nitrfs: unit/test_nitrfs.c ../user/servers/nitrfs/nitrfs.c ../user/libc/libc.c ../kernel/drivers/IO/block.c
 	$(CC) $(CFLAGS) $^ -o $@
 
-test_login: unit/test_login.c ../user/servers/login/login.c ../user/libc/libc.c ../kernel/IPC/ipc.c ../kernel/drivers/IO/video.c
+test_login: unit/test_login.c ../user/servers/login/login.c ../user/libc/libc.c ../kernel/IPC/ipc.c
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_ftp: unit/test_ftp.c ../user/servers/ftp/ftp.c ../kernel/IPC/ipc.c ../user/libc/libc.c

--- a/tests/unit/test_login.c
+++ b/tests/unit/test_login.c
@@ -3,29 +3,35 @@
 #include "../../user/servers/login/login.h"
 #include "../../kernel/IPC/ipc.h"
 #include "../../user/libc/libc.h"
-#include <sys/mman.h>
 
 static const char *input = "admin\nadmin\n";
 static size_t pos = 0;
 
-int keyboard_getchar(void) {
+ipc_queue_t pkg_queue;
+ipc_queue_t upd_queue;
+
+int tty_getchar(void) {
     if (pos >= strlen(input)) return -1;
     return (unsigned char)input[pos++];
 }
 
-void serial_write(char c) { (void)c; }
-void serial_puts(const char *s) { (void)s; }
+void tty_putc(char c) { (void)c; }
+void tty_write(const char *s) { (void)s; }
+void tty_clear(void) { }
 void thread_yield(void) { }
+
+static int shell_started = 0;
+void shell_main(ipc_queue_t *fs_q, ipc_queue_t *pkg_q, ipc_queue_t *upd_q, uint32_t self_id) {
+    (void)fs_q; (void)pkg_q; (void)upd_q; (void)self_id;
+    shell_started = 1;
+}
 
 int main(void) {
     ipc_queue_t q; (void)q;
-    mmap((void*)0xB8000, 0x1000, PROT_READ|PROT_WRITE,
-         MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED, -1, 0);
-    login_done = 0;
     login_server(&q, 0);
-    assert(login_done == 1);
     assert(current_session.active);
     assert(current_session.uid == 0);
     assert(strcmp((const char*)current_session.username, "admin") == 0);
+    assert(shell_started);
     return 0;
 }

--- a/user/servers/login/login.h
+++ b/user/servers/login/login.h
@@ -3,8 +3,6 @@
 #include "../../../kernel/IPC/ipc.h"
 #include <stdint.h>
 
-extern volatile int login_done;
-
 typedef struct {
     uint32_t uid;
     char username[32];


### PR DESCRIPTION
## Summary
- add a simple kernel TTY driver for character I/O
- switch login server to use the TTY and launch the shell after authentication
- update shell to run on the TTY and initialize only after login

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_68907f07355083338350533b725b643f