### PR TITLE
Support serial TTY input for login

### DIFF
--- a/kernel/drivers/IO/keyboard.c
+++ b/kernel/drivers/IO/keyboard.c
@@ -1,7 +1,6 @@
 #include "io.h"
 #include "keyboard.h"
 #include "pic.h"
-#include "serial.h"
 #include <stddef.h>
 
 #define KEYBUF_SIZE 32
@@ -52,7 +51,7 @@ static char scancode_ascii(uint8_t sc) {
 int keyboard_getchar(void) {
     int sc = keyboard_read_scancode();
     if (sc < 0)
-        return serial_read();
+        return -1;
     if (sc == 0x2A || sc == 0x36) {
         shift_state = 1;
         return -1;

--- a/kernel/drivers/IO/tty.c
+++ b/kernel/drivers/IO/tty.c
@@ -97,6 +97,9 @@ void tty_write(const char *s) {
 }
 
 int tty_getchar(void) {
-    return keyboard_getchar();
+    int ch = keyboard_getchar();
+    if (ch >= 0)
+        return ch;
+    return serial_read();
 }
 


### PR DESCRIPTION
## Summary
- Allow tty_getchar to fall back to serial input
- Keep keyboard driver focused on keyboard scancodes only

## Testing
- `make all`
- `for t in test_ipc test_pmm test_syscall test_nitrfs test_login test_ftp; do ./$t && echo "$t ok"; done`


------
https://chatgpt.com/codex/tasks/task_b_68908e0cc8b48333933b27f9a4fdde1e