### PR TITLE
Improve TTY font rendering and login prompt flow

### DIFF
--- a/kernel/drivers/IO/tty.c
+++ b/kernel/drivers/IO/tty.c
@@ -19,7 +19,10 @@ static void draw_char_fb(char c, int r, int cpos) {
         uint8_t line = glyph[y];
         for (int x = 0; x < 8; ++x) {
             uint32_t color = (line & (1u << x)) ? 0xFFFFFF : 0x000000;
-            video_draw_pixel(cpos * 8 + x, r * 8 + y, color);
+            int px = cpos * 8 + x;
+            int py = r * 16 + y * 2;
+            video_draw_pixel(px, py, color);
+            video_draw_pixel(px, py + 1, color);
         }
     }
 }
@@ -28,7 +31,7 @@ void tty_init(void) {
     fb_info = video_get_info();
     if (fb_info) {
         fb_cols = fb_info->width / 8;
-        fb_rows = fb_info->height / 8;
+        fb_rows = fb_info->height / 16;
     }
     tty_clear();
 }

--- a/user/servers/login/login.c
+++ b/user/servers/login/login.c
@@ -75,8 +75,7 @@ void login_server(ipc_queue_t *q, uint32_t self_id)
     (void)q; (void)self_id;
     tty_clear();
     puts_out("[login] login server starting\n");
-    /* Give other threads a chance to run so the start message is visible */
-    thread_yield();
+    /* Removed extra yield to avoid stalling before the prompt */
     char user[32];
     char pass[32];
     for(;;) {


### PR DESCRIPTION
## Summary
- Render framebuffer text using 8x16 glyphs for clearer TTY output
- Avoid premature scheduler yield in login server so the username prompt appears

## Testing
- `make`
- `timeout 5 qemu-system-x86_64 -drive if=pflash,format=raw,unit=0,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd -drive if=pflash,format=raw,unit=1,file=/usr/share/OVMF/OVMF_VARS_4M.fd -drive format=raw,file=disk.img -serial stdio -display none`


------
https://chatgpt.com/codex/tasks/task_b_6890a340b95483339ef4845117f92564