### PR TITLE
Add PS/2 and USB input support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ run: disk.img
 		-m 512M \
 		-netdev user,id=n0 \
 		-device e1000,netdev=n0 \
-		-device isa-keyboard \
+			-device qemu-xhci,id=xhci \
+		-device usb-kbd,bus=xhci.0 \
 		-serial stdio -display sdl
 
 .PHONY: all libc kernel boot clean run

--- a/kernel/Kernel/Makefile
+++ b/kernel/Kernel/Makefile
@@ -16,6 +16,7 @@ OBJS = \
     ../drivers/IO/pit.o \
     ../drivers/IO/keyboard.o \
     ../drivers/IO/mouse.o \
+    ../drivers/IO/ps2.o \
     ../drivers/IO/pci.o \
     ../drivers/IO/usb.o \
     ../drivers/IO/serial.o \

--- a/kernel/Kernel/kernel.c
+++ b/kernel/Kernel/kernel.c
@@ -5,8 +5,8 @@
 #include "../arch/IDT/idt.h"
 #include "../drivers/IO/pic.h"
 #include "../drivers/IO/pit.h"
-#include "../drivers/IO/keyboard.h"
-#include "../drivers/IO/mouse.h"
+#include "../drivers/IO/ps2.h"
+#include "../drivers/IO/usb.h"
 #include "../drivers/IO/serial.h"
 #include "../drivers/IO/tty.h"
 #include "../drivers/Net/netstack.h"
@@ -312,12 +312,12 @@ void kernel_main(bootinfo_t *bootinfo) {
     log_line("  pit_init start");
     pit_init(100);
     log_line("  pit_init done");
-    log_line("  keyboard_init start");
-    keyboard_init();
-    log_good("[kbd] Keyboard initialized");
-    log_line("  mouse_init start");
-    mouse_init();
-    log_good("[mou] Mouse initialized");
+    log_line("  ps2_init start");
+    ps2_init();
+    log_good("[ps2] Keyboard and mouse initialized");
+    log_line("  usb_init start");
+    usb_init();
+    log_good("[usb] Controllers initialized");
 
     log_line("  tty_init start");
     tty_init();
@@ -339,6 +339,7 @@ void kernel_main(bootinfo_t *bootinfo) {
     schedule();
 
     for (;;) {
+        usb_poll();
         schedule();
     }
 }

--- a/kernel/drivers/IO/ps2.c
+++ b/kernel/drivers/IO/ps2.c
@@ -1,0 +1,11 @@
+#include "ps2.h"
+#include "keyboard.h"
+#include "mouse.h"
+#include "serial.h"
+
+void ps2_init(void) {
+    serial_puts("PS/2: initializing keyboard and mouse\n");
+    keyboard_init();
+    mouse_init();
+}
+

--- a/kernel/drivers/IO/ps2.h
+++ b/kernel/drivers/IO/ps2.h
@@ -1,0 +1,5 @@
+#pragma once
+
+/* Initialize PS/2 controller along with keyboard and mouse devices. */
+void ps2_init(void);
+


### PR DESCRIPTION
## Summary
- add ps2 wrapper driver initializing keyboard and mouse
- initialize ps2 and usb subsystems in kernel and poll usb events
- update run target to expose USB keyboard via QEMU

## Testing
- `make kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_6890aae9bb808333a1db8a8120246b06