### PR TITLE
Fix login prompt responsiveness by yielding before input

### DIFF
--- a/tests/unit/test_login.c
+++ b/tests/unit/test_login.c
@@ -18,7 +18,8 @@ int tty_getchar(void) {
 void tty_putc(char c) { (void)c; }
 void tty_write(const char *s) { (void)s; }
 void tty_clear(void) { }
-void thread_yield(void) { }
+static int yield_count = 0;
+void thread_yield(void) { yield_count++; }
 
 static int shell_started = 0;
 void shell_main(ipc_queue_t *fs_q, ipc_queue_t *pkg_q, ipc_queue_t *upd_q, uint32_t self_id) {
@@ -33,5 +34,6 @@ int main(void) {
     assert(current_session.uid == 0);
     assert(strcmp((const char*)current_session.username, "admin") == 0);
     assert(shell_started);
+    assert(yield_count > 0);
     return 0;
 }

--- a/user/servers/login/login.c
+++ b/user/servers/login/login.c
@@ -42,8 +42,10 @@ static void puts_out(const char *s)
 static char getchar_block(void)
 {
     int ch = -1;
-    while((ch = tty_getchar()) < 0)
+    do {
         thread_yield();
+        ch = tty_getchar();
+    } while (ch < 0);
     return (char)ch;
 }
 


### PR DESCRIPTION
## Summary
- yield in login `getchar_block` before polling to let keyboard IRQs run
- add unit test to confirm login server yields CPU at least once

## Testing
- `cd tests && make`
- `for t in test_ipc test_pmm test_syscall test_nitrfs test_login test_ftp; do echo Running $t; ./$t && echo "$t OK"; done`


------
https://chatgpt.com/codex/tasks/task_b_6890b35d8a9c8333a00f7e15b1e73e6c