### PR TITLE
Optimize low-level memory and I/O helpers

### DIFF
--- a/kernel/drivers/IO/io.h
+++ b/kernel/drivers/IO/io.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#include <stddef.h>
 
 static inline void outb(uint16_t port, uint8_t val) {
     asm volatile ( "outb %0, %1" : : "a"(val), "Nd"(port) );
@@ -11,6 +12,16 @@ static inline uint8_t inb(uint16_t port) {
     return ret;
 }
 
+static inline void outw(uint16_t port, uint16_t val) {
+    asm volatile ( "outw %0, %1" : : "a"(val), "Nd"(port) );
+}
+
+static inline uint16_t inw(uint16_t port) {
+    uint16_t ret;
+    asm volatile ( "inw %1, %0" : "=a"(ret) : "Nd"(port) );
+    return ret;
+}
+
 static inline void outl(uint16_t port, uint32_t val) {
     asm volatile ( "outl %0, %1" : : "a"(val), "Nd"(port) );
 }
@@ -19,6 +30,22 @@ static inline uint32_t inl(uint16_t port) {
     uint32_t ret;
     asm volatile ( "inl %1, %0" : "=a"(ret) : "Nd"(port) );
     return ret;
+}
+
+static inline void outsw(uint16_t port, const void *addr, size_t count) {
+    asm volatile ("rep outsw" : "+S"(addr), "+c"(count) : "d"(port) : "memory");
+}
+
+static inline void insw(uint16_t port, void *addr, size_t count) {
+    asm volatile ("rep insw" : "+D"(addr), "+c"(count) : "d"(port) : "memory");
+}
+
+static inline void outsl(uint16_t port, const void *addr, size_t count) {
+    asm volatile ("rep outsl" : "+S"(addr), "+c"(count) : "d"(port) : "memory");
+}
+
+static inline void insl(uint16_t port, void *addr, size_t count) {
+    asm volatile ("rep insl" : "+D"(addr), "+c"(count) : "d"(port) : "memory");
 }
 
 static inline void io_wait(void) {


### PR DESCRIPTION
## Summary
- speed up `memset`, `memcpy`, and `memmove` with word-sized operations
- add 16/32-bit and block port I/O helpers for efficient peripheral access

## Testing
- `make` (in `tests`)


------
https://chatgpt.com/codex/tasks/task_b_6890fddebba8833382a62e9fc5738a34