### PR TITLE
Add test for keyboard-based TTY login

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,7 +4,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
     -I../user/servers/nitrfs -I../user/servers/login -I../user/servers/ftp \
     -I../user/libc -I../kernel/drivers/IO -I../kernel/drivers/Audio \
     -I../kernel/drivers/Net
-UNIT_TESTS=test_ipc test_pmm test_syscall test_nitrfs test_login test_ftp
+UNIT_TESTS=test_ipc test_pmm test_syscall test_nitrfs test_login test_ftp test_login_keyboard
 
 all: $(UNIT_TESTS)
 	for t in $(UNIT_TESTS); do ./$$t; done
@@ -24,8 +24,13 @@ test_nitrfs: unit/test_nitrfs.c ../user/servers/nitrfs/nitrfs.c ../user/libc/lib
 test_login: unit/test_login.c ../user/servers/login/login.c ../user/libc/libc.c ../kernel/IPC/ipc.c
 	$(CC) $(CFLAGS) $^ -o $@
 
+test_login_keyboard: unit/test_login_keyboard.c ../user/servers/login/login.c \
+../kernel/drivers/IO/tty.c ../user/libc/libc.c ../kernel/IPC/ipc.c
+	$(CC) $(CFLAGS) $^ -o $@
+
 test_ftp: unit/test_ftp.c ../user/servers/ftp/ftp.c ../kernel/IPC/ipc.c ../user/libc/libc.c
 	$(CC) $(CFLAGS) $^ -o $@
 
 clean:
 	rm -f $(UNIT_TESTS)
+

--- a/tests/unit/test_login_keyboard.c
+++ b/tests/unit/test_login_keyboard.c
@@ -1,0 +1,64 @@
+#include <assert.h>
+#include <string.h>
+#include "../../user/servers/login/login.h"
+#include "../../kernel/IPC/ipc.h"
+#include "../../user/libc/libc.h"
+#include "../../kernel/drivers/IO/tty.h"
+#include "bootinfo.h"
+
+static const char *input = "admin\nadmin\n";
+static size_t pos = 0;
+static int first_poll = 1;
+
+ipc_queue_t pkg_queue;
+ipc_queue_t upd_queue;
+
+/* Stubs for serial I/O */
+void serial_write(char c) { (void)c; }
+int serial_read(void) { return -1; }
+void serial_puts(const char *s) { (void)s; }
+
+/* Minimal framebuffer info so tty uses video path without touching VGA memory */
+static bootinfo_framebuffer_t fb = {
+    .address = 0,
+    .width = 640,
+    .height = 480,
+    .pitch = 640 * 4,
+    .bpp = 32,
+    .type = 0,
+    .reserved = 0
+};
+
+const bootinfo_framebuffer_t *video_get_info(void) { return &fb; }
+void video_draw_pixel(int x, int y, uint32_t color) { (void)x; (void)y; (void)color; }
+void video_clear(uint32_t color) { (void)color; }
+
+int keyboard_getchar(void) {
+    if (first_poll) {
+        first_poll = 0;
+        return -1; /* simulate initial lack of input */
+    }
+    if (pos >= strlen(input)) return -1;
+    return (unsigned char)input[pos++];
+}
+
+static int yield_count = 0;
+void thread_yield(void) { yield_count++; }
+
+static int shell_started = 0;
+void shell_main(ipc_queue_t *fs_q, ipc_queue_t *pkg_q, ipc_queue_t *upd_q, uint32_t self_id) {
+    (void)fs_q; (void)pkg_q; (void)upd_q; (void)self_id;
+    shell_started = 1;
+}
+
+int main(void) {
+    tty_init();
+    ipc_queue_t q; (void)q;
+    login_server(&q, 0);
+    assert(current_session.active);
+    assert(current_session.uid == 0);
+    assert(strcmp((const char*)current_session.username, "admin") == 0);
+    assert(shell_started);
+    assert(yield_count > 0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add unit test ensuring login server accepts keyboard input via TTY
- include new test in the suite

## Testing
- `cd tests && make`


------
https://chatgpt.com/codex/tasks/task_b_689103eceb548333912db06a6efc660d