### PR TITLE
Use PS/2 keyboard in QEMU run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ run: disk.img
 		-m 512M \
 		-netdev user,id=n0 \
 		-device e1000,netdev=n0 \
-			-device qemu-xhci,id=xhci \
-		-device usb-kbd,bus=xhci.0 \
+		-device isa-keyboard \
 		-serial stdio -display sdl
 
 .PHONY: all libc kernel boot clean run


### PR DESCRIPTION
## Summary
- ensure QEMU run configuration provides a PS/2 keyboard instead of a USB keyboard so the login server can receive input

## Testing
- `cd tests && make clean && make all`
- `for t in test_ipc test_pmm test_syscall test_nitrfs test_login test_ftp test_login_keyboard; do echo Running $t; ./$t; echo Exit:$?; done`


------
https://chatgpt.com/codex/tasks/task_b_6891266495a883338446ed490c9e0e12