### PR TITLE
Use PS/2 keyboard in QEMU run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ run: disk.img
 		-m 512M \
 		-netdev user,id=n0 \
 		-device e1000,netdev=n0 \
-			-device qemu-xhci,id=xhci \
-		-device usb-kbd,bus=xhci.0 \
+		-device isa-keyboard \
 		-serial stdio -display sdl
 
 .PHONY: all libc kernel boot clean run

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ run: disk.img
 		-drive file=disk.img,format=raw \
 		-m 512M \
 		-netdev user,id=n0 \
-		-device e1000,netdev=n0 \
-		-device isa-keyboard \
-		-serial stdio -display sdl
+                -device e1000,netdev=n0 \
+                -device i8042 \
+                -serial stdio -display sdl
 
 .PHONY: all libc kernel boot clean run

--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@
    qemu-system-x86_64 -drive format=raw,file=disk.img \
      -bios /usr/share/OVMF/OVMF_CODE.fd \
      -netdev user,id=n0 -device e1000,netdev=n0 \
-     -device isa-keyboard \
+    -device i8042 \
      -serial stdio -display sdl
    ```
 
    The `-serial stdio` option attaches COM1 to your terminal so early boot
    logs appear even before the framebuffer is initialized. The
-   `-device isa-keyboard` flag explicitly adds a PS/2 keyboard device, which
-   QEMU may omit if no graphical display is present. Keep a graphical window
-   such as `-display sdl` so the login prompt can receive keyboard input;
+   `-device i8042` flag explicitly adds the legacy PS/2 controller so the login
+   server can receive keyboard scancodes. Keep a graphical window such as
+   `-display sdl` so the login prompt can receive keyboard input;
    running with `-display none` will leave the prompt unresponsive. See
    [docs/SERIAL_CONSOLE.md](docs/SERIAL_CONSOLE.md) for more details.
   Networking support is under active development. See

--- a/tests/integration/test_qemu.py
+++ b/tests/integration/test_qemu.py
@@ -11,7 +11,7 @@ def run_qemu():
             "-m", "512M",
             "-netdev", "user,id=n0",
             "-device", "e1000,netdev=n0",
-            "-device", "isa-keyboard",
+            "-device", "i8042",
             "-serial", "stdio",
             "-display", "none",
             "-no-reboot",


### PR DESCRIPTION
## Summary
- ensure QEMU run configuration provides a PS/2 keyboard instead of a USB keyboard so the login server can receive input

## Testing
- `cd tests && make clean && make all`
- `for t in test_ipc test_pmm test_syscall test_nitrfs test_login test_ftp test_login_keyboard; do echo Running $t; ./$t; echo Exit:$?; done`


------
https://chatgpt.com/codex/tasks/task_b_6891266495a883338446ed490c9e0e12