### PR TITLE
Expose IP via net stack and reply to ARP

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,19 @@
    qemu-system-x86_64 -drive format=raw,file=disk.img \
      -bios /usr/share/OVMF/OVMF_CODE.fd \
      -netdev user,id=n0 -device e1000,netdev=n0 \
-    -device i8042 \
-     -serial stdio -display sdl
+     -device i8042 \
+     -serial stdio -display none -vnc :0
    ```
 
    The `-serial stdio` option attaches COM1 to your terminal so early boot
    logs appear even before the framebuffer is initialized. The
    `-device i8042` flag explicitly adds the legacy PS/2 controller so the login
-   server can receive keyboard scancodes. Keep a graphical window such as
-   `-display sdl` so the login prompt can receive keyboard input;
-   running with `-display none` will leave the prompt unresponsive. See
-   [docs/SERIAL_CONSOLE.md](docs/SERIAL_CONSOLE.md) for more details.
-  Networking support is under active development. See
+   server can receive keyboard scancodes. `-vnc :0` exposes the display over
+  VNC (port 5900) when local keyboard input is unavailable. The login prompt
+  prints the guest IP (default `10.0.2.15` with user networking) so experimental
+  SSH or VNC servers can be reached over QEMU's user networking. See
+  [docs/SERIAL_CONSOLE.md](docs/SERIAL_CONSOLE.md) for more details. Networking
+  support is under active development. See
   [docs/NETWORK_SERVERS.md](docs/NETWORK_SERVERS.md) for current status.
 
 ---

--- a/docs/NETWORK_SERVERS.md
+++ b/docs/NETWORK_SERVERS.md
@@ -1,11 +1,12 @@
 # Planned Network Servers
 
-This document outlines the network services for NitrOS.  A small loopback
-network stack lives in `Net/` and allows local user-mode servers to exchange
-packets without real hardware.  Each service communicates over a dedicated
-logical port so they no longer interfere with one another.  The VNC, SSH, and
-FTP servers remain simple demonstrations until higher level protocols are
-implemented.
+This document outlines the network services for NitrOS.  A small network stack
+in `Net/` allows user-mode servers to exchange packets even without real
+hardware.  Each service communicates over a dedicated logical port so they no
+longer interfere with one another.  The stack tracks a basic IPv4 address and
+can now answer ARP requests, paving the way for real hardware networking. The
+VNC, SSH, and FTP servers remain simple demonstrations until higher level
+protocols are implemented.
 
 ## VNC Server
 

--- a/kernel/drivers/Net/netstack.h
+++ b/kernel/drivers/Net/netstack.h
@@ -30,6 +30,10 @@ int net_socket_recv(int sock, void *buf, size_t len);
 // Poll hardware NIC and dispatch incoming frames.
 void net_poll(void);
 
+// Configure or query the IPv4 address used by the stack.
+uint32_t net_get_ip(void);
+void net_set_ip(uint32_t ip);
+
 // Convenience helpers for transmitting IPv4 packets.
 int net_send_ipv4_udp(uint32_t dst_ip, uint16_t src_port, uint16_t dst_port,
                       const void *data, size_t len);


### PR DESCRIPTION
## Summary
- show guest IP at login by querying the net stack
- track a configurable IPv4 address and answer ARP requests
- document basic IP support and ARP handling

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_6891311c681c8333a38248d68ff2cb61