### PR TITLE
Enforce port binding in network stack

### DIFF
--- a/kernel/drivers/Net/netstack.c
+++ b/kernel/drivers/Net/netstack.c
@@ -151,7 +151,7 @@ void net_init(void) {
 }
 
 int net_send(unsigned port, const void *data, size_t len) {
-    if (port >= NET_PORTS)
+    if (port >= NET_PORTS || socket_type[port] == 0)
         return 0;
     const uint8_t *d = (const uint8_t *)data;
     size_t space = NETBUF_SIZE - netbuf_avail(port);
@@ -166,7 +166,7 @@ int net_send(unsigned port, const void *data, size_t len) {
 }
 
 int net_receive(unsigned port, void *buf, size_t buflen) {
-    if (port >= NET_PORTS)
+    if (port >= NET_PORTS || socket_type[port] == 0)
         return 0;
     uint8_t *b = (uint8_t *)buf;
     size_t avail = netbuf_avail(port);
@@ -194,6 +194,7 @@ void net_set_ip(uint32_t ip) {
 
 int net_socket_open(uint16_t port, net_socket_type_t type) {
     if (port >= NET_PORTS) return -1;
+    if (socket_type[port] != 0) return -1; // already bound
     socket_type[port] = (uint8_t)type;
     head[port] = tail[port] = 0;
     return (int)port;

--- a/tests/unit/test_net.c
+++ b/tests/unit/test_net.c
@@ -91,6 +91,24 @@ int main(void) {
     net_set_ip(0x0A00020F);
     uint8_t payload[3] = {1,2,3};
 
+    /* Basic socket open/close and loopback send/recv */
+    int s = net_socket_open(1, NET_SOCK_DGRAM);
+    assert(s == 1);
+    const char msg[] = "hello";
+    net_socket_send(s, msg, sizeof(msg));
+    char rbuf[16];
+    int rn = net_socket_recv(s, rbuf, sizeof(rbuf));
+    assert(rn == (int)sizeof(msg));
+    assert(memcmp(rbuf, msg, sizeof(msg)) == 0);
+    /* cannot bind same port twice */
+    assert(net_socket_open(1, NET_SOCK_STREAM) == -1);
+    net_socket_close(s);
+    rn = net_socket_recv(s, rbuf, sizeof(rbuf));
+    assert(rn == 0);
+    s = net_socket_open(1, NET_SOCK_STREAM);
+    assert(s == 1);
+    net_socket_close(s);
+
     net_send_ipv4_udp(0x0A000201, 1111, 2222, payload, sizeof(payload));
     assert(frame_len == sizeof(struct eth_hdr) + sizeof(struct ipv4_hdr) +
                           sizeof(struct udp_hdr) + sizeof(payload));


### PR DESCRIPTION
## Summary
- require sockets to be opened before sending or receiving data
- prevent double-binding ports in `net_socket_open`
- add unit test covering socket open/close and loopback behaviour

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_6891372438a483338a807218135ca272