### PR TITLE
Start login, VNC, and SSH servers from init

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -1,12 +1,9 @@
 #include "thread.h"
 #include "../IPC/ipc.h"
 #include "../../user/servers/nitrfs/server.h"
-#include "../../user/servers/vnc/vnc.h"
-#include "../../user/servers/ssh/ssh.h"
 #include "../../user/servers/ftp/ftp.h"
 #include "../../user/servers/pkg/server.h"
 #include "../../user/servers/update/server.h"
-#include "../../user/servers/login/login.h"
 #include "../../user/servers/init/init.h"
 #include "../../user/libc/libc.h"
 #include "../drivers/IO/serial.h"
@@ -72,10 +69,7 @@ static void thread_fs_func(void)   { thread_t *c = current_cpu[smp_cpu_index()];
 static void thread_init_func(void) { thread_t *c = current_cpu[smp_cpu_index()]; init_main(&fs_queue, c->id); }
 static void thread_pkg_func(void)   { thread_t *c = current_cpu[smp_cpu_index()]; pkg_server(&pkg_queue, c->id); }
 static void thread_update_func(void){ thread_t *c = current_cpu[smp_cpu_index()]; update_server(&upd_queue, &pkg_queue, c->id); }
-static void thread_vnc_func(void)  { thread_t *c = current_cpu[smp_cpu_index()]; vnc_server(NULL, c->id); }
-static void thread_ssh_func(void)  { thread_t *c = current_cpu[smp_cpu_index()]; ssh_server(NULL, c->id); }
 static void thread_ftp_func(void)  { thread_t *c = current_cpu[smp_cpu_index()]; ftp_server(&fs_queue, c->id); }
-static void thread_login_func(void){ thread_t *c = current_cpu[smp_cpu_index()]; login_server(NULL, c->id); }
 
 // --- THREAD CREATION ---
 
@@ -173,23 +167,12 @@ void threads_init(void) {
     t = thread_create(thread_init_func);
     ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
 
-    t = thread_create(thread_login_func);
-    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-    ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-    ipc_grant(&upd_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-
     t = thread_create(thread_pkg_func);
     ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
 
     t = thread_create(thread_update_func);
     ipc_grant(&upd_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
     ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-
-    t = thread_create(thread_vnc_func);
-    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-
-    t = thread_create(thread_ssh_func);
-    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
 
     t = thread_create(thread_ftp_func);
     ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);

--- a/user/servers/init/init.c
+++ b/user/servers/init/init.c
@@ -1,13 +1,39 @@
 #include "init.h"
 #include "../../../kernel/drivers/IO/serial.h"
 #include "../../../kernel/Task/thread.h"
+#include "../../../kernel/IPC/ipc.h"
+#include "../../../kernel/arch/CPU/smp.h"
 #include "../../libc/libc.h"
+#include "../login/login.h"
+#include "../vnc/vnc.h"
+#include "../ssh/ssh.h"
+
+extern ipc_queue_t fs_queue;
+extern ipc_queue_t pkg_queue;
+extern ipc_queue_t upd_queue;
+
+static void login_thread(void) { thread_t *c = current_cpu[smp_cpu_index()]; login_server(NULL, c->id); }
+static void vnc_thread(void)   { thread_t *c = current_cpu[smp_cpu_index()]; vnc_server(NULL, c->id); }
+static void ssh_thread(void)   { thread_t *c = current_cpu[smp_cpu_index()]; ssh_server(NULL, c->id); }
 
 // Simple init/task spawner stub
 void init_main(ipc_queue_t *q, uint32_t self_id) {
     (void)q; (void)self_id;
     serial_puts("[init] init server started\n");
-    // In a real system this would spawn other tasks using fork/exec.
+
+    thread_t *t;
+
+    t = thread_create(login_thread);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    ipc_grant(&upd_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+
+    t = thread_create(vnc_thread);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+
+    t = thread_create(ssh_thread);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+
     for (;;) {
         thread_yield();
     }

--- a/user/servers/login/login.c
+++ b/user/servers/login/login.c
@@ -121,6 +121,7 @@ void login_server(ipc_queue_t *q, uint32_t self_id)
     puts_out("IP ");
     puts_out(ipbuf);
     puts_out(" (SSH/VNC)\n");
+    thread_yield();
 
     char user[32];
     char pass[32];
@@ -137,8 +138,8 @@ void login_server(ipc_queue_t *q, uint32_t self_id)
         if (authenticate(user, pass, &cred) == 0) {
             puts_out("Login successful\n");
             current_session.uid = cred->uid;
-            strncpy(current_session.username, cred->user, sizeof(current_session.username) - 1);
-            current_session.username[sizeof(current_session.username) - 1] = '\0';
+            strncpy((char*)current_session.username, cred->user, sizeof(current_session.username) - 1);
+            ((char*)current_session.username)[sizeof(current_session.username) - 1] = '\0';
             current_session.session_id++;
             current_session.active = 1;
             break;

--- a/user/servers/ssh/ssh.c
+++ b/user/servers/ssh/ssh.c
@@ -39,5 +39,6 @@ void ssh_server(ipc_queue_t *q, uint32_t self_id) {
         }
         thread_yield();
     }
+    net_socket_close(sock);
     serial_puts("[ssh] server exiting\n");
 }


### PR DESCRIPTION
## Summary
- Launch login, VNC, and SSH services from the init server, granting necessary IPC rights.
- Simplify kernel thread setup so only core services start directly from the kernel.
- Improve login server fairness and string handling; ensure SSH server closes its socket on exit.

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_68913bc8aac483338c69b2e28308d433