### PR TITLE
Implement full init task spawner

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -1,9 +1,5 @@
 #include "thread.h"
 #include "../IPC/ipc.h"
-#include "../../user/servers/nitrfs/server.h"
-#include "../../user/servers/ftp/ftp.h"
-#include "../../user/servers/pkg/server.h"
-#include "../../user/servers/update/server.h"
 #include "../../user/servers/init/init.h"
 #include "../../user/libc/libc.h"
 #include "../drivers/IO/serial.h"
@@ -65,11 +61,10 @@ static void __attribute__((naked)) thread_entry(void) {
 
 // --- THREAD FUNCTIONS ---
 
-static void thread_fs_func(void)   { thread_t *c = current_cpu[smp_cpu_index()]; nitrfs_server(&fs_queue, c->id); }
-static void thread_init_func(void) { thread_t *c = current_cpu[smp_cpu_index()]; init_main(&fs_queue, c->id); }
-static void thread_pkg_func(void)   { thread_t *c = current_cpu[smp_cpu_index()]; pkg_server(&pkg_queue, c->id); }
-static void thread_update_func(void){ thread_t *c = current_cpu[smp_cpu_index()]; update_server(&upd_queue, &pkg_queue, c->id); }
-static void thread_ftp_func(void)  { thread_t *c = current_cpu[smp_cpu_index()]; ftp_server(&fs_queue, c->id); }
+// Return the currently running thread
+thread_t *thread_current(void) { return current_cpu[smp_cpu_index()]; }
+
+static void thread_init_func(void) { init_main(&fs_queue, thread_current()->id); }
 
 // --- THREAD CREATION ---
 
@@ -110,18 +105,9 @@ thread_t *thread_create(void (*func)(void)) {
         tail_cpu[cpu]->next = t;
         tail_cpu[cpu] = t;
     }
-    char buf[32];
+    char buf[16];
     serial_puts("[thread] created id=");
-    buf[0] = '\0';
-    {
-        int id = t->id;
-        int pos = 0;
-        char tmp[16];
-        if (id == 0) { tmp[pos++] = '0'; }
-        while (id > 0 && pos < 15) { tmp[pos++] = '0' + (id % 10); id /= 10; }
-        for (int i = pos-1, j=0; i>=0; --i,++j) buf[j]=tmp[i];
-        buf[pos] = 0;
-    }
+    utoa_dec(t->id, buf);
     serial_puts(buf);
     serial_puts("\n");
     return t;
@@ -161,21 +147,10 @@ void threads_init(void) {
     ipc_init(&upd_queue);
     thread_t *t;
 
-    t = thread_create(thread_fs_func);
-    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-
     t = thread_create(thread_init_func);
     ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-
-    t = thread_create(thread_pkg_func);
     ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-
-    t = thread_create(thread_update_func);
     ipc_grant(&upd_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-    ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
-
-    t = thread_create(thread_ftp_func);
-    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
 
     // Insert kernel main thread into the run queue so the first
     // schedule() call can switch away safely.

--- a/kernel/Task/thread.h
+++ b/kernel/Task/thread.h
@@ -22,6 +22,9 @@ typedef struct thread {
 
 extern thread_t *current_cpu[MAX_CPUS];
 
+// Retrieve pointer to currently running thread on this CPU
+thread_t *thread_current(void);
+
 // Initialize threading system and create initial threads
 void threads_init(void);
 

--- a/user/servers/init/init.c
+++ b/user/servers/init/init.c
@@ -2,27 +2,51 @@
 #include "../../../kernel/drivers/IO/serial.h"
 #include "../../../kernel/Task/thread.h"
 #include "../../../kernel/IPC/ipc.h"
-#include "../../../kernel/arch/CPU/smp.h"
 #include "../../libc/libc.h"
 #include "../login/login.h"
 #include "../vnc/vnc.h"
 #include "../ssh/ssh.h"
+#include "../nitrfs/server.h"
+#include "../ftp/ftp.h"
+#include "../pkg/server.h"
+#include "../update/server.h"
 
 extern ipc_queue_t fs_queue;
 extern ipc_queue_t pkg_queue;
 extern ipc_queue_t upd_queue;
 
-static void login_thread(void) { thread_t *c = current_cpu[smp_cpu_index()]; login_server(NULL, c->id); }
-static void vnc_thread(void)   { thread_t *c = current_cpu[smp_cpu_index()]; vnc_server(NULL, c->id); }
-static void ssh_thread(void)   { thread_t *c = current_cpu[smp_cpu_index()]; ssh_server(NULL, c->id); }
+static uint32_t self_id(void) { return thread_current()->id; }
 
-// Simple init/task spawner stub
+static void login_thread(void)  { login_server(NULL, self_id()); }
+static void vnc_thread(void)    { vnc_server(NULL, self_id()); }
+static void ssh_thread(void)    { ssh_server(NULL, self_id()); }
+static void nitrfs_thread(void) { nitrfs_server(&fs_queue, self_id()); }
+static void ftp_thread(void)    { ftp_server(&fs_queue, self_id()); }
+static void pkg_thread(void)    { pkg_server(&pkg_queue, self_id()); }
+static void update_thread(void) { update_server(&upd_queue, &pkg_queue, self_id()); }
+
+// Initial userspace task spawner. Creates core servers and remote access tasks.
 void init_main(ipc_queue_t *q, uint32_t self_id) {
     (void)q; (void)self_id;
     serial_puts("[init] init server started\n");
 
     thread_t *t;
 
+    // Core system servers
+    t = thread_create(nitrfs_thread);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+
+    t = thread_create(pkg_thread);
+    ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+
+    t = thread_create(update_thread);
+    ipc_grant(&upd_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+    ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+
+    t = thread_create(ftp_thread);
+    ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
+
+    // Login and remote access servers
     t = thread_create(login_thread);
     ipc_grant(&fs_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);
     ipc_grant(&pkg_queue, t->id, IPC_CAP_SEND | IPC_CAP_RECV);


### PR DESCRIPTION
## Summary
- Replace init stub with full task spawner that launches NitrFS, package, update, FTP, login, VNC, and SSH servers
- Simplify thread initialization to start only init thread and grant queue access
- Centralize thread lookup and streamline init server wrappers

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_68913d5dd408833391e7223594d70b9c