### PR TITLE
Fix network ring buffer tracking and add test

### DIFF
--- a/tests/unit/test_net.c
+++ b/tests/unit/test_net.c
@@ -109,6 +109,19 @@ int main(void) {
     assert(s == 1);
     net_socket_close(s);
 
+    /* Ring buffer should handle full capacity without appearing empty */
+    s = net_socket_open(2, NET_SOCK_DGRAM);
+    assert(s == 2);
+    char big[512];
+    memset(big, 'A', sizeof(big));
+    int sn = net_socket_send(s, big, sizeof(big));
+    assert(sn == (int)sizeof(big));
+    char bigrecv[512];
+    int rn2 = net_socket_recv(s, bigrecv, sizeof(bigrecv));
+    assert(rn2 == (int)sizeof(big));
+    assert(memcmp(big, bigrecv, sizeof(big)) == 0);
+    net_socket_close(s);
+
     net_send_ipv4_udp(0x0A000201, 1111, 2222, payload, sizeof(payload));
     assert(frame_len == sizeof(struct eth_hdr) + sizeof(struct ipv4_hdr) +
                           sizeof(struct udp_hdr) + sizeof(payload));


### PR DESCRIPTION
## Summary
- prevent network socket buffers from misinterpreting full buffers as empty by tracking counts
- add unit test covering full-capacity send/receive handling

## Testing
- `make -C tests clean all`


------
https://chatgpt.com/codex/tasks/task_b_6891418e3aa08333ad5b3c6e74986ce4