### PR TITLE
Optimize page allocator and clarify IPC queue semantics

### DIFF
--- a/kernel/IPC/ipc.h
+++ b/kernel/IPC/ipc.h
@@ -33,8 +33,8 @@ typedef struct {
  */
 typedef struct {
     ipc_message_t msgs[IPC_QUEUE_SIZE];
-    size_t head;          // Points to oldest element
-    size_t tail;          // Points to next write slot
+    size_t head;          // Points to next write slot
+    size_t tail;          // Points to oldest element
     uint32_t caps[IPC_MAX_TASKS]; // Capability bits per task ID
 } ipc_queue_t;
 


### PR DESCRIPTION
## Summary
- track the next free physical page and bound reserved region to available frames in the physical memory manager for faster allocation and better low-memory safety
- correct `ipc_queue_t` comments so head and tail indices match the implementation

## Testing
- `make clean >/tmp/clean.log && make >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_b_689152f78da88333a79ea26ea38c5915