### PR TITLE
Track free physical frames in PMM

### DIFF
--- a/kernel/VM/pmm.h
+++ b/kernel/VM/pmm.h
@@ -10,6 +10,7 @@ void pmm_init(const bootinfo_t *bootinfo);
 void *alloc_page(void);
 void free_page(void *page);
 uint64_t pmm_total_frames(void);
+uint64_t pmm_free_frames(void);
 
 #ifdef __cplusplus
 }

--- a/tests/unit/test_pmm.c
+++ b/tests/unit/test_pmm.c
@@ -13,11 +13,16 @@ int main(void) {
     bi.mmap_entries = 1;
     pmm_init(&bi);
     assert(pmm_total_frames() >= 516);
+    assert(pmm_free_frames() == 4);
     void *p1 = alloc_page();
+    assert(pmm_free_frames() == 3);
     void *p2 = alloc_page();
+    assert(pmm_free_frames() == 2);
     assert(p1 && p2 && p1 != p2);
     free_page(p1);
+    assert(pmm_free_frames() == 3);
     void *p3 = alloc_page();
+    assert(pmm_free_frames() == 2);
     assert(p3 == p1);
     return 0;
 }


### PR DESCRIPTION
## Summary
- Track available physical frames in the memory manager and expose `pmm_free_frames`
- Update allocator routines to maintain free-frame count
- Expand PMM unit test to validate free-frame accounting

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_68917a0083008333a3c58cf1012b74df