### PR TITLE
Optimize memmove and fix init header

### DIFF
--- a/user/libc/libc.c
+++ b/user/libc/libc.c
@@ -65,6 +65,12 @@ void *memmove(void *dest, const void *src, size_t n) {
             s += sizeof(uint64_t);
             n -= sizeof(uint64_t);
         }
+        while (n >= sizeof(uint32_t)) {
+            *(uint32_t *)d = *(const uint32_t *)s;
+            d += sizeof(uint32_t);
+            s += sizeof(uint32_t);
+            n -= sizeof(uint32_t);
+        }
         while (n--)
             *d++ = *s++;
     } else if (d > s) {
@@ -75,6 +81,12 @@ void *memmove(void *dest, const void *src, size_t n) {
             s -= sizeof(uint64_t);
             *(uint64_t *)d = *(const uint64_t *)s;
             n -= sizeof(uint64_t);
+        }
+        while (n >= sizeof(uint32_t)) {
+            d -= sizeof(uint32_t);
+            s -= sizeof(uint32_t);
+            *(uint32_t *)d = *(const uint32_t *)s;
+            n -= sizeof(uint32_t);
         }
         while (n--) {
             d--;

--- a/user/servers/init/init.h
+++ b/user/servers/init/init.h
@@ -1,6 +1,12 @@
 #ifndef INIT_H
 #define INIT_H
 
-void init_main(void);
+#include <stdint.h>
+#include "../../../kernel/IPC/ipc.h"
+
+// Entry point for the user-space init server.  Accepts the filesystem IPC
+// queue and the caller's task identifier so the server can communicate and
+// identify itself to other components.
+void init_main(ipc_queue_t *q, uint32_t self_id);
 
 #endif // INIT_H


### PR DESCRIPTION
## Summary
- optimize `memmove` to copy 32-bit chunks for better performance
- correct `init_main` header prototype and include dependencies for clean builds

## Testing
- `make -C tests clean && make -C tests`
- `make`

------
https://chatgpt.com/codex/tasks/task_b_6891a77b24108333a00c6c33e22b0a3d