### PR TITLE
Fix ISR context handling

### DIFF
--- a/kernel/arch/IDT/isr_stub.asm
+++ b/kernel/arch/IDT/isr_stub.asm
@@ -90,14 +90,33 @@ isr_default_stub:
 
 global isr_keyboard_stub
 isr_keyboard_stub:
-    push rbp
-    mov rbp, rsp
     cli
+    push rax
+    push rbx
+    push rcx
+    push rdx
+    push rsi
+    push rdi
+    push r8
+    push r9
+    push r10
+    push r11
+    push rbp
     extern isr_keyboard_handler
     call isr_keyboard_handler
     mov al, 0x20
     out 0x20, al
-    leave
+    pop rbp
+    pop r11
+    pop r10
+    pop r9
+    pop r8
+    pop rdi
+    pop rsi
+    pop rdx
+    pop rcx
+    pop rbx
+    pop rax
     iretq
 
 global isr_mouse_stub


### PR DESCRIPTION
## Summary
- Correct ISR frame reshaping to save proper rflags and instruction pointer
- Preserve stack alignment in the init thread to avoid SSE faults
- Save and restore all registers in the keyboard ISR stub

## Testing
- `make -C tests`
- `make`
- `timeout 20 qemu-system-x86_64 -drive format=raw,file=disk.img -pflash /usr/share/OVMF/OVMF_CODE_4M.fd -pflash /usr/share/OVMF/OVMF_VARS_4M.fd -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -serial stdio -display none` *(fails: system stops after init server start)*


------
https://chatgpt.com/codex/tasks/task_b_68925b93be9c8333ad4d09826e9abdf3