### PR TITLE
Use TTY for login server I/O

### DIFF
--- a/tests/unit/test_login.c
+++ b/tests/unit/test_login.c
@@ -11,8 +11,8 @@ static int first_poll = 1;
 ipc_queue_t pkg_queue;
 ipc_queue_t upd_queue;
 
-/* Minimal stubs for the serial driver used by the login server */
-int serial_read(void) {
+/* Stubs for the TTY driver used by the login server */
+int tty_getchar(void) {
     if (first_poll) {
         first_poll = 0;
         return -1; /* simulate initial lack of input */
@@ -21,9 +21,7 @@ int serial_read(void) {
     return (unsigned char)input[pos++];
 }
 
-void serial_puts(const char *s) { (void)s; }
-
-/* login_server clears the TTY even when using serial for I/O */
+void tty_write(const char *s) { (void)s; }
 void tty_clear(void) { }
 static int yield_count = 0;
 void thread_yield(void) { yield_count++; }

--- a/user/servers/login/login.c
+++ b/user/servers/login/login.c
@@ -1,6 +1,5 @@
 #include "login.h"
 #include "../../../kernel/drivers/IO/tty.h"
-#include "../../../kernel/drivers/IO/serial.h"
 #include "../../../kernel/Task/thread.h"
 #include "../../libc/libc.h"
 #include "../shell/shell.h"
@@ -43,18 +42,17 @@ static int authenticate(const char *user, const char *pass, const credential_t *
 static void puts_out(const char *s)
 {
     /*
-     * Use the serial port directly so the login server can run in
-     * environments without a graphical console. tty_write() also emits to
-     * the framebuffer which is unnecessary when running headless.
+     * Use the TTY driver so output reaches both the serial console and the
+     * framebuffer, making the login prompt visible on local displays.
      */
-    serial_puts(s);
+    tty_write(s);
 }
 
 static char getchar_block(void)
 {
     int ch;
-    /* Poll the serial port until input is available. */
-    while ((ch = serial_read()) < 0) {
+    /* Poll the TTY until input is available from keyboard or serial. */
+    while ((ch = tty_getchar()) < 0) {
         thread_yield();
     }
     return (char)ch;


### PR DESCRIPTION
## Summary
- route login server output through TTY so messages appear on screen
- poll TTY for input to support keyboard or serial consoles
- adapt unit test stubs to new TTY-based login server

## Testing
- `make -C tests test_login test_login_keyboard`
- `tests/test_login && echo test_login_ok`
- `tests/test_login_keyboard && echo test_login_keyboard_ok`


------
https://chatgpt.com/codex/tasks/task_b_6892667a60c48333bc80fc0a4a488ff3