### PR TITLE
Fix ISR context layout mismatch

### DIFF
--- a/kernel/arch/IDT/context.h
+++ b/kernel/arch/IDT/context.h
@@ -9,8 +9,8 @@ struct isr_context {
     // Interrupt number and error code (always present for uniformity)
     uint64_t int_no;
     uint64_t error_code;
+    // CR2: present for page faults (pushed by stub before CPU state)
+    uint64_t cr2;
     // Automatically-pushed by CPU on interrupt/exception
     uint64_t rip, cs, rflags, rsp, ss;
-    // CR2: present for page faults (must be set in stub)
-    uint64_t cr2;
 };


### PR DESCRIPTION
## Summary
- align `isr_context` structure with assembly stub's push order

## Testing
- `cd tests && make`
- `for t in test_ipc test_pmm test_syscall test_nitrfs test_login test_ftp test_login_keyboard test_net test_gdt; do echo Running $t; ./$t; done`

------
https://chatgpt.com/codex/tasks/task_b_689297ea55e88333be2747e9320d9098