### PR TITLE
Fix ISR context layout

### DIFF
--- a/kernel/arch/IDT/context.h
+++ b/kernel/arch/IDT/context.h
@@ -1,16 +1,23 @@
 #pragma once
 #include <stdint.h>
 
-// This struct must match your register push order in assembly!
+// This struct must match the register push order in isr_stub.asm.
+// The assembly stubs push values in the following sequence (from first to
+// last): general-purpose registers, the interrupt metadata, and finally the
+// CPU-pushed state (RIP, CS, RFLAGS, etc).  To obtain a pointer to this
+// structure, the stub simply passes the current RSP after pushing the CR2
+// value.  Consequently, the first fields here correspond to the last values
+// pushed.
 struct isr_context {
-    // General-purpose registers (saved by the stub)
-    uint64_t r15, r14, r13, r12, r11, r10, r9, r8;
-    uint64_t rdi, rsi, rbp, rbx, rdx, rcx, rax;
-    // Interrupt number and error code (always present for uniformity)
-    uint64_t int_no;
-    uint64_t error_code;
-    // CR2: present for page faults (pushed by stub before CPU state)
+    // CR2 (for page faults), error code and vector number
     uint64_t cr2;
-    // Automatically-pushed by CPU on interrupt/exception
+    uint64_t error_code;
+    uint64_t int_no;
+
+    // General-purpose registers saved by the stub
+    uint64_t rax, rcx, rdx, rbx, rbp, rsi, rdi;
+    uint64_t r8, r9, r10, r11, r12, r13, r14, r15;
+
+    // Automatically pushed by the CPU on interrupt/exception entry
     uint64_t rip, cs, rflags, rsp, ss;
 };

--- a/kernel/arch/IDT/handler.c
+++ b/kernel/arch/IDT/handler.c
@@ -14,7 +14,7 @@ void isr_default_handler(struct isr_context *ctx) {
 
     // Print all general purpose registers
     serial_printf("RAX=%016lx RBX=%016lx RCX=%016lx RDX=%016lx\n", ctx->rax, ctx->rbx, ctx->rcx, ctx->rdx);
-    serial_printf("RSI=%016lx RDI=%016lx RBP=%016lx RSP=%016lx\n", ctx->rsi, ctx->rdi, ctx->rbp, (uint64_t)ctx);
+    serial_printf("RSI=%016lx RDI=%016lx RBP=%016lx RSP=%016lx\n", ctx->rsi, ctx->rdi, ctx->rbp, ctx->rsp);
     serial_printf("R8 =%016lx R9 =%016lx R10=%016lx R11=%016lx\n", ctx->r8, ctx->r9, ctx->r10, ctx->r11);
     serial_printf("R12=%016lx R13=%016lx R14=%016lx R15=%016lx\n", ctx->r12, ctx->r13, ctx->r14, ctx->r15);
 
@@ -25,7 +25,7 @@ void isr_default_handler(struct isr_context *ctx) {
     serial_printf("Error Code: 0x%016lx\n", ctx->error_code);
 
     // Optionally: Print a mini stack trace (just show top 4 qwords of stack)
-    uint64_t *sp = (uint64_t *)(ctx->user_rsp ? ctx->user_rsp : (uint64_t)ctx + sizeof(*ctx));
+    uint64_t *sp = (uint64_t *)(ctx->rsp);
     serial_printf("Stack (top 4): ");
     for (int i = 0; i < 4; ++i) {
         serial_printf("%016lx ", sp[i]);

--- a/kernel/interrupt/context.h
+++ b/kernel/interrupt/context.h
@@ -1,12 +1,15 @@
 #pragma once
 #include <stdint.h>
 
-// This struct must match your assembly push order!
+// This struct mirrors the stack layout produced by the ISR stubs in
+// arch/IDT/isr_stub.asm.  See that file for the exact push order.
 struct isr_context {
-    uint64_t r15, r14, r13, r12, r11, r10, r9, r8;
-    uint64_t rdi, rsi, rbp, rbx, rdx, rcx, rax;
-    uint64_t int_no;
-    uint64_t error_code;
-    uint64_t rip, cs, rflags, rsp, ss;
     uint64_t cr2;
+    uint64_t error_code;
+    uint64_t int_no;
+
+    uint64_t rax, rcx, rdx, rbx, rbp, rsi, rdi;
+    uint64_t r8, r9, r10, r11, r12, r13, r14, r15;
+
+    uint64_t rip, cs, rflags, rsp, ss;
 };


### PR DESCRIPTION
## Summary
- Align `isr_context` structure with actual register push order
- Simplify ISR handler to use correct stack pointer

## Testing
- `make kernel`

------
https://chatgpt.com/codex/tasks/task_b_6892ab44f9c483338f2acdb5ff24c371