### PR TITLE
Fix COW page mapping after unmark

### DIFF
--- a/kernel/VM/cow.c
+++ b/kernel/VM/cow.c
@@ -42,17 +42,25 @@ static int flag_index(uint64_t virt) {
 void cow_mark(uint64_t virt) {
     int idx = flag_index(virt);
     if (idx < 0) return;
+
+    uint64_t phys = paging_virt_to_phys(virt);
+    if (!phys) return;
+
     cow_flags[idx] = 1;
     paging_unmap(virt);
-    paging_map(virt, paging_virt_to_phys(virt), PAGE_PRESENT | PAGE_USER);
+    paging_map(virt, phys, PAGE_PRESENT | PAGE_USER);
 }
 
 void cow_unmark(uint64_t virt) {
     int idx = flag_index(virt);
     if (idx < 0) return;
+
+    uint64_t phys = paging_virt_to_phys(virt);
+    if (!phys) return;
+
     cow_flags[idx] = 0;
     paging_unmap(virt);
-    paging_map(virt, paging_virt_to_phys(virt), PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER);
+    paging_map(virt, phys, PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER);
 }
 
 int cow_is_marked(uint64_t virt) {


### PR DESCRIPTION
## Summary
- preserve original physical address when marking/unmarking copy-on-write pages
- avoid remapping to null pages during COW operations

## Testing
- `make -C tests clean && make -C tests`
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_6892b884a9cc83339183b01bc7f847a0