### PR TITLE
Fix thread stack alignment to avoid GPF

### DIFF
--- a/kernel/Task/context_switch.asm
+++ b/kernel/Task/context_switch.asm
@@ -5,6 +5,7 @@ global context_switch
 
 section .text
 context_switch:
+    push rax        ; Maintain 16-byte stack alignment
     pushfq          ; Save flags
     cli             ; Disable interrupts (if kernel context switch)
     push rbp
@@ -25,6 +26,7 @@ context_switch:
     pop rbx
     pop rbp
     popfq           ; Restore flags (including IF)
+    pop rax         ; Discard alignment placeholder
 
     ret
 

--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -95,16 +95,14 @@ thread_t *thread_create_with_priority(void (*func)(void), int priority) {
 
     uint64_t *sp = (uint64_t *)(t->stack + STACK_SIZE);
 
-    // Ensure 16‑byte alignment: after pushing 9 values (arg, RIP, RFLAGS, rbp, rbx, r12, r13, r14, r15)
+    // Ensure 16‑byte alignment: after pushing 10 values (arg, RIP, RAX, RFLAGS, rbp, rbx, r12, r13, r14, r15)
     if (((uintptr_t)sp & 0xF) != 0)
         --sp;
 
-    // Optional dummy push for alignment clarity
-    *--sp = 0;
-
-    // Layout: [arg][RIP][RFLAGS][rbp][rbx][r12][r13][r14][r15]
+    // Layout: [arg][RIP][RAX][RFLAGS][rbp][rbx][r12][r13][r14][r15]
     *--sp = (uint64_t)func;         // argument for thread_entry (popped into rdi)
     *--sp = (uint64_t)thread_entry; // RIP
+    *--sp = 0;                      // RAX placeholder (alignment)
     *--sp = 0x202;                  // RFLAGS (IF=1)
     *--sp = 0; // rbp
     *--sp = 0; // rbx


### PR DESCRIPTION
## Summary
- ensure context switch preserves 16-byte stack alignment
- initialize thread stacks with rax slot for alignment

## Testing
- `make -C tests`
- `python - <<'PY'
from tests.integration.test_qemu import run_qemu
print(run_qemu())
PY`

------
https://chatgpt.com/codex/tasks/task_b_6892bf9d11208333b2ad8476d31d1adc