### PR TITLE
Fix COW module compilation and add page helpers

### DIFF
--- a/kernel/VM/cow.h
+++ b/kernel/VM/cow.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <stdint.h>
 
+#ifndef PAGE_SIZE
 #define PAGE_SIZE 4096
+#endif
 
 /**
  * Initialize the COW system with the total number of page frames.
@@ -38,6 +40,10 @@ void cow_unmark(uint64_t virt);
  * Return 1 if the virtual address is marked COW, 0 otherwise.
  */
 int cow_is_marked(uint64_t virt);
+
+// Allocate and free multiple contiguous pages
+void *alloc_pages(uint32_t pages);
+void free_pages(void *addr, uint32_t pages);
 
 /**
  * (Optional) Called by frame allocator to free a page only if fully unreferenced.


### PR DESCRIPTION
## Summary
- include paging, pmm, serial headers in COW module
- add alloc_pages/free_pages helpers and guard PAGE_SIZE macro

## Testing
- `make kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_6892c692e3308333aa9bc093d4441592