### PR TITLE
Fix NitrFS server busy wait

### DIFF
--- a/user/servers/nitrfs/server.c
+++ b/user/servers/nitrfs/server.c
@@ -16,8 +16,8 @@ void nitrfs_server(ipc_queue_t *q, uint32_t self_id) {
     int handle, ret;
 
     while (1) {
-        // Block for a message
-        if (ipc_receive(q, self_id, &msg) != 0)
+        // Block for a message and yield if none pending
+        if (ipc_receive_blocking(q, self_id, &msg) != 0)
             continue;
         if (msg.len > IPC_MSG_DATA_MAX)
             continue; // Ignore bogus message


### PR DESCRIPTION
## Summary
- ensure NitrFS server blocks and yields when no messages are present so other services like login can start

## Testing
- `cd tests && make clean && make`
- `./test_ipc`
- `./test_pmm`
- `./test_syscall`
- `./test_nitrfs`
- `./test_login`
- `./test_ftp`
- `./test_login_keyboard`
- `./test_net`
- `./test_gdt`


------
https://chatgpt.com/codex/tasks/task_b_6892cbe58344833390517dfcbc2f5033