### PR TITLE
Fix bitwise OR precedence warning in ISR

### DIFF
--- a/kernel/arch/IDT/isr.c
+++ b/kernel/arch/IDT/isr.c
@@ -27,7 +27,7 @@ void isr_default_handler(struct isr_context *ctx) {
     const char *msg = "FAULT! IRQ: ";
     for (int i = 0; msg[i]; ++i)
         vga[i] = msg[i] | (0x47 << 8);
-    vga[12] = '0' + (ctx->int_no % 10) | (0x47 << 8);
+    vga[12] = ('0' + (ctx->int_no % 10)) | (0x47 << 8);
 
     while (1) __asm__ volatile ("hlt");
 }


### PR DESCRIPTION
## Summary
- Parenthesize addition before bitwise OR when writing interrupt number to VGA memory to avoid precedence warning.

## Testing
- `make kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_6892cd7ba60883338aff38a1c2f7c6e5