### PR TITLE
Initialize TTY in login server for visible prompt

### DIFF
--- a/tests/unit/test_login.c
+++ b/tests/unit/test_login.c
@@ -23,6 +23,7 @@ int tty_getchar(void) {
 
 void tty_write(const char *s) { (void)s; }
 void tty_clear(void) { }
+void tty_init(void) { }
 static int yield_count = 0;
 void thread_yield(void) { yield_count++; }
 

--- a/user/servers/login/login.c
+++ b/user/servers/login/login.c
@@ -130,6 +130,8 @@ void login_server(ipc_queue_t *q, uint32_t self_id)
 {
     health_q = q;
     login_tid = self_id;
+    /* Reinitialize the TTY to ensure output devices are ready before clearing */
+    tty_init();
     tty_clear();
     puts_out("[login] login server starting\n");
     uint32_t ip = net_get_ip();


### PR DESCRIPTION
## Summary
- Reinitialize TTY when starting the login server so the login prompt renders correctly
- Stub `tty_init` in unit test

## Testing
- `cd tests && make clean && make`

------
https://chatgpt.com/codex/tasks/task_b_6892d141a77c83339ef8babecc861a8d