### PR TITLE
Fix kernel build by compiling libc with KERNEL_BUILD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CROSS_COMPILE ?= x86_64-linux-gnu-
 all: libc kernel boot disk.img
 
 libc:
-	$(CROSS_COMPILE)gcc -ffreestanding -O2 -Wall -Wextra -mno-red-zone -nostdlib -c user/libc/libc.c -o user/libc/libc.o
+	$(CROSS_COMPILE)gcc -ffreestanding -O2 -Wall -Wextra -mno-red-zone -nostdlib -DKERNEL_BUILD -c user/libc/libc.c -o user/libc/libc.o
 
 kernel: libc
 	make -C kernel/Kernel CROSS_COMPILE=$(CROSS_COMPILE)


### PR DESCRIPTION
## Summary
- Compile libc with `-DKERNEL_BUILD` so internal pthread mutex stubs are included when linking the kernel.

## Testing
- `make clean`
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_68930163750c8333b2e0a575ee80f8b9