### PR TITLE
Ensure libc builds with kernel flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 CROSS_COMPILE ?= x86_64-linux-gnu-
+CC := $(CROSS_COMPILE)gcc
+CFLAGS := -ffreestanding -O2 -Wall -Wextra -mno-red-zone -nostdlib -DKERNEL_BUILD
 
 all: libc kernel boot disk.img
 
 libc:
-	$(CROSS_COMPILE)gcc -ffreestanding -O2 -Wall -Wextra -mno-red-zone -nostdlib -DKERNEL_BUILD -c user/libc/libc.c -o user/libc/libc.o
+	$(CC) $(CFLAGS) -c user/libc/libc.c -o user/libc/libc.o
 
 kernel: libc
 	make -C kernel/Kernel CROSS_COMPILE=$(CROSS_COMPILE)


### PR DESCRIPTION
## Summary
- centralize build flags in the root Makefile so libc is built with `-DKERNEL_BUILD`

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_b_689302fb76f4833398b6ca04982fe2e0