### PR TITLE
Increase kernel size limit to 64MB for bootloader

### DIFF
--- a/boot/src/NitrOBoot.c
+++ b/boot/src/NitrOBoot.c
@@ -7,7 +7,7 @@ static void (*g_entry)(bootinfo_t *) = NULL;
 
 
 #define KERNEL_PATH L"\\kernel.bin"
-#define KERNEL_MAX_SIZE (16 * 1024 * 1024) // allow up to 8MB
+#define KERNEL_MAX_SIZE (64 * 1024 * 1024) // allow up to 64MB
 
 // --- Minimal Hex Printer for CHAR16 (prints 0x...64bit) ---
 static void uefi_hex16(CHAR16 *buf, uint64_t val) {


### PR DESCRIPTION
## Summary
- allow bootloader to load kernels up to 64MB to avoid "Kernel too large" error

## Testing
- `make boot`
- `make kernel`
- `make disk.img`
- `make run` *(fails: XDG_RUNTIME_DIR is invalid or not set in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_6893082ec4388333b66501390eafa358