### PR TITLE
Add modular N2 kernel entry and agent infrastructure

### DIFF
--- a/boot/include/bootinfo.h
+++ b/boot/include/bootinfo.h
@@ -46,6 +46,8 @@ typedef struct {
     uint64_t size;
     char     name[64];
     uint8_t  sha256[32];
+    uint64_t manifest_addr;
+    uint64_t manifest_size;
 } bootinfo_module_t;
 
 typedef struct {

--- a/boot/src/O2.c
+++ b/boot/src/O2.c
@@ -1,5 +1,6 @@
 #include "efi.h"
 #include "bootinfo.h"
+#include "../../include/nosm.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -289,6 +290,12 @@ EFI_STATUS EFIAPI efi_main(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable
         m->size = msz;
         to_ascii(info->FileName, m->name, sizeof(m->name));
         memcpy(m->sha256, hash, 32);
+        const nosm_header_t *nh = (const nosm_header_t *)mod;
+        if (nh->magic == NOSM_MAGIC &&
+            nh->manifest_offset + nh->manifest_size <= msz) {
+            m->manifest_addr = (uint64_t)(uintptr_t)((uint8_t*)mod + nh->manifest_offset);
+            m->manifest_size = nh->manifest_size;
+        }
         bi->module_count++;
         if (bi->module_count >= BOOTINFO_MAX_MODULES) break;
     }

--- a/include/agent.h
+++ b/include/agent.h
@@ -15,5 +15,7 @@ typedef struct {
 int n2_agent_register(const n2_agent_t *agent);
 const n2_agent_t *n2_agent_get(const char *name);
 void n2_agent_registry_reset(void);
+int n2_agent_unregister(const char *name);
+size_t n2_agent_list(n2_agent_t *out, size_t max);
 
 #endif /* NOS_AGENT_H */

--- a/kernel/agent.c
+++ b/kernel/agent.c
@@ -23,3 +23,25 @@ const n2_agent_t *n2_agent_get(const char *name) {
     }
     return NULL;
 }
+
+int n2_agent_unregister(const char *name) {
+    if (!name)
+        return -1;
+    for (size_t i = 0; i < registry_count; ++i) {
+        if (strncmp(registry[i].name, name, sizeof(registry[i].name)) == 0) {
+            memmove(&registry[i], &registry[i + 1],
+                    (registry_count - i - 1) * sizeof(n2_agent_t));
+            registry_count--;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+size_t n2_agent_list(n2_agent_t *out, size_t max) {
+    if (!out || max == 0)
+        return 0;
+    size_t n = registry_count < max ? registry_count : max;
+    memcpy(out, registry, n * sizeof(n2_agent_t));
+    return n;
+}

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -1,0 +1,123 @@
+/**
+ * N2 Kernel Main
+ * ---------------
+ * Minimal demonstration of the N2 agent–based kernel.  The kernel is
+ * bootstrapped by the O2 UEFI boot agent which passes a manifest rich
+ * `bootinfo_t` structure describing the loaded kernel and NOSM modules.
+ *
+ * This file shows how the kernel:
+ *   - Initializes the runtime agent registry
+ *   - Loads and sandboxes NOSM modules declared by the bootloader
+ *   - Exposes a simple syscall table and agent discovery helpers
+ *   - Supports dynamic loading/unloading of agents and hot‑reloading of
+ *     a filesystem agent
+ *
+ * The implementation intentionally avoids any legacy monolithic design and
+ * instead treats every service – even core drivers and filesystems – as an
+ * independently versioned "agent".  Security is enforced through manifests
+ * declaring capabilities and through runtime sandbox hooks (stubbed here).
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include "../boot/include/bootinfo.h"
+#include "agent.h"
+#include "nosm.h"
+
+/* --- Syscall infrastructure -------------------------------------------- */
+typedef long (*syscall_fn_t)(long,long,long,long,long,long);
+static syscall_fn_t syscall_table[64];
+
+/* Register a syscall at runtime.  The ABI is versioned and extensible. */
+int n2_syscall_register(uint32_t num, syscall_fn_t fn) {
+    if (num >= 64) return -1;
+    syscall_table[num] = fn;
+    return 0;
+}
+
+/* --- Sandboxing -------------------------------------------------------- */
+/* In a real kernel this would configure MPU/MMU permissions, IPC handles, etc.
+ * Here it is a stub documenting intent. */
+static void sandbox_agent(const n2_agent_t *agent,
+                          const bootinfo_module_t *mod) {
+    (void)agent; (void)mod;
+    /*
+     * TODO: parse agent->manifest for capability and permission fields and
+     *       enforce least‑privilege policies here.
+     */
+}
+
+/* --- Module loading helpers ------------------------------------------- */
+static int load_module(const bootinfo_module_t *m) {
+    void *entry = nosm_load((void*)(uintptr_t)m->base, m->size);
+    if (!entry)
+        return -1;
+    const n2_agent_t *agent = n2_agent_get(m->name);
+    if (agent)
+        sandbox_agent(agent, m);
+    return 0;
+}
+
+int n2_load_agent_from_bootinfo(const bootinfo_module_t *m) {
+    return load_module(m);
+}
+
+int n2_unload_agent(const char *name) {
+    return n2_agent_unregister(name);
+}
+
+/* Hot‑reload a filesystem agent by unloading the old instance and loading
+ * the replacement provided by userland. */
+int n2_hot_reload_filesystem(const bootinfo_module_t *replacement) {
+    n2_unload_agent("NitrFS");
+    return load_module(replacement);
+}
+
+/* --- Agent discovery API ---------------------------------------------- */
+/* Copy up to `max` agents into `out` for userland discovery. */
+size_t n2_agent_enumerate(n2_agent_t *out, size_t max) {
+    return n2_agent_list(out, max);
+}
+
+/* Trivial capability query: manifests are assumed to be UTF‑8 strings listing
+ * capabilities separated by commas. */
+const n2_agent_t *n2_agent_find_capability(const char *cap) {
+    n2_agent_t tmp[N2_MAX_AGENTS];
+    size_t n = n2_agent_list(tmp, N2_MAX_AGENTS);
+    for (size_t i = 0; i < n; ++i) {
+        const char *man = (const char *)tmp[i].manifest;
+        if (man && cap && strstr(man, cap))
+            return n2_agent_get(tmp[i].name);
+    }
+    return NULL;
+}
+
+/* --- Scheduler loop --------------------------------------------------- */
+static void scheduler_loop(void) {
+    while (1) {
+        /* In a full kernel this would pick runnable agents/tasks.  We simply
+         * spin here to illustrate the hand‑off to the scheduler. */
+        __asm__("hlt");
+    }
+}
+
+/* --- Entry point ------------------------------------------------------ */
+void n2_main(bootinfo_t *bootinfo) {
+    if (!bootinfo || bootinfo->magic != BOOTINFO_MAGIC_UEFI)
+        return; /* invalid boot environment */
+
+    n2_agent_registry_reset();
+
+    for (uint32_t i = 0; i < bootinfo->module_count; ++i)
+        load_module(&bootinfo->modules[i]);
+
+    scheduler_loop();
+}
+
+/* Example static manifest for a hypothetical agent.  Real systems would use
+ * JSON or CBOR; keeping it simple ensures the sample builds on any C toolchain.
+ */
+const char nitrfs_manifest[] =
+    "name=NitrFS,version=1.2.0,capabilities=filesystem,snapshot,rollback";
+


### PR DESCRIPTION
## Summary
- Extend `bootinfo_module_t` with manifest pointers and have the O2 boot agent parse NOSM headers to populate them
- Enhance agent registry with unregister/enumerate APIs and introduce a minimal `n2_main.c` illustrating agent loading, sandboxing and hot-reload

## Testing
- `make` in `tests`


------
https://chatgpt.com/codex/tasks/task_b_68932900fadc8333a4edfb5bc034e81b