### PR TITLE
Integrate NSH shell into login path

### DIFF
--- a/tests/unit/test_login.c
+++ b/tests/unit/test_login.c
@@ -28,10 +28,10 @@ void tty_init(void) { }
 static int yield_count = 0;
 void thread_yield(void) { yield_count++; }
 
-static int shell_started = 0;
-void shell_main(ipc_queue_t *fs_q, ipc_queue_t *pkg_q, ipc_queue_t *upd_q, uint32_t self_id) {
-    (void)fs_q; (void)pkg_q; (void)upd_q; (void)self_id;
-    shell_started = 1;
+static int nsh_started = 0;
+void nsh_main(ipc_queue_t *registry_q, uint32_t self_id) {
+    (void)registry_q; (void)self_id;
+    nsh_started = 1;
 }
 
 int main(void) {
@@ -40,7 +40,7 @@ int main(void) {
     assert(current_session.active);
     assert(current_session.uid == 0);
     assert(strcmp((const char*)current_session.username, "admin") == 0);
-    assert(shell_started);
+    assert(nsh_started);
     assert(yield_count > 0);
     return 0;
 }

--- a/tests/unit/test_login_keyboard.c
+++ b/tests/unit/test_login_keyboard.c
@@ -47,10 +47,10 @@ void video_clear(uint32_t color) { (void)color; }
 static int yield_count = 0;
 void thread_yield(void) { yield_count++; }
 
-static int shell_started = 0;
-void shell_main(ipc_queue_t *fs_q, ipc_queue_t *pkg_q, ipc_queue_t *upd_q, uint32_t self_id) {
-    (void)fs_q; (void)pkg_q; (void)upd_q; (void)self_id;
-    shell_started = 1;
+static int nsh_started = 0;
+void nsh_main(ipc_queue_t *registry_q, uint32_t self_id) {
+    (void)registry_q; (void)self_id;
+    nsh_started = 1;
 }
 
 int main(void) {
@@ -60,7 +60,7 @@ int main(void) {
     assert(current_session.active);
     assert(current_session.uid == 0);
     assert(strcmp((const char*)current_session.username, "admin") == 0);
-    assert(shell_started);
+    assert(nsh_started);
     assert(yield_count > 0);
     return 0;
 }

--- a/user/servers/login/login.c
+++ b/user/servers/login/login.c
@@ -2,7 +2,7 @@
 #include "../../../kernel/drivers/IO/tty.h"
 #include "../../../kernel/Task/thread.h"
 #include "../../libc/libc.h"
-#include "../shell/shell.h"
+#include "../nsh/nsh.h"
 #include "../../../kernel/drivers/Net/netstack.h"
 #include "../../../kernel/IPC/ipc.h"
 #include <stddef.h>
@@ -16,9 +16,6 @@ static uint32_t login_tid = 0;
 // Weak fallback so unit tests can link without the full netstack.
 __attribute__((weak)) uint32_t net_get_ip(void) { return 0x0A00020F; }
 
-extern ipc_queue_t fs_queue;
-extern ipc_queue_t pkg_queue;
-extern ipc_queue_t upd_queue;
 
 typedef struct {
     const char *user;
@@ -168,5 +165,5 @@ void login_server(ipc_queue_t *q, uint32_t self_id)
     }
 
     puts_out("[login] starting shell\n");
-    shell_main(&fs_queue, &pkg_queue, &upd_queue, self_id);
+    nsh_main(NULL, self_id);
 }

--- a/user/servers/nsh/Makefile
+++ b/user/servers/nsh/Makefile
@@ -1,7 +1,12 @@
-CROSS_COMPILE ?= /opt/cross/bin/x86_64-elf-
+CROSS_COMPILE ?= x86_64-linux-gnu-
 CC      = $(CROSS_COMPILE)gcc
 CFLAGS  = -ffreestanding -O2 -Wall -Wextra -nostdlib -mno-red-zone
-OBJS    = nsh.o ../../../kernel/IPC/ipc.o ../../libc/libc.o
+OBJS    = nsh.o ../../../kernel/IPC/ipc.o ../../libc/libc.o \
+          ../../../kernel/drivers/IO/tty.o \
+          ../../../kernel/drivers/IO/video.o \
+          ../../../kernel/drivers/IO/serial.o \
+          ../../../kernel/drivers/IO/keyboard.o \
+          ../../../kernel/drivers/IO/pic.o
 
 all: nsh.bin
 

--- a/user/servers/nsh/nsh.c
+++ b/user/servers/nsh/nsh.c
@@ -1,6 +1,6 @@
 #include "../../../kernel/IPC/ipc.h"
 #include "../../libc/libc.h"
-#include "../../include/nosfs.h"
+#define NOSFS_NAME_LEN 32
 #include "../../../kernel/drivers/IO/tty.h"
 #include <stdint.h>
 #include <stddef.h>

--- a/user/servers/nsh/nsh.h
+++ b/user/servers/nsh/nsh.h
@@ -1,0 +1,11 @@
+#ifndef NSH_H
+#define NSH_H
+
+#include <stdint.h>
+#include "../../../kernel/IPC/ipc.h"
+
+/* Entry point for the NitroShell user interface. */
+void nsh_main(ipc_queue_t *registry_q, uint32_t self_id);
+
+#endif /* NSH_H */
+


### PR DESCRIPTION
## Summary
- Switch login server to launch the new NSH shell and expose a header for it
- Define NOSFS constants directly in NSH and add a Makefile for building the shell with required drivers
- Update login unit tests for NSH integration

## Testing
- `make -C user/servers/nsh nsh.o`
- `make -C user/servers/nsh`
- `make -C tests test_login test_login_keyboard`
- `./tests/test_login`
- `./tests/test_login_keyboard`


------
https://chatgpt.com/codex/tasks/task_b_6893397c6d288333a9fc83c0051afb5f