### PR TITLE
Add compatibility Makefile for legacy kernel builds

### DIFF
--- a/kernel/Kernel/Makefile
+++ b/kernel/Kernel/Makefile
@@ -1,0 +1,11 @@
+# Compatibility Makefile for legacy build scripts
+# Redirects builds to the top-level kernel target
+
+.PHONY: all clean
+
+all:
+	$(MAKE) -C ../.. kernel CROSS_COMPILE=$(CROSS_COMPILE)
+
+clean:
+	$(MAKE) -C ../.. clean
+


### PR DESCRIPTION
## Summary
- Add `kernel/Kernel/Makefile` that proxies to the top-level kernel build to satisfy legacy scripts

## Testing
- `make -C kernel/Kernel`

------
https://chatgpt.com/codex/tasks/task_b_6893595f75408333b6e2a9af9fe7b7c1