### PR TITLE
Add Mach-O2 manifest format and tooling

### DIFF
--- a/boot/macho2_loader_example.c
+++ b/boot/macho2_loader_example.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdint.h>
+#include "../include/macho2.h"
+
+/* Example loader that locates the manifest and entry point */
+int load_and_run(const char *path)
+{
+    struct macho2_manifest m;
+    if (macho2_load_manifest(path, &m)) {
+        fprintf(stderr, "manifest not found\n");
+        return -1;
+    }
+    printf("agent %s (%s) entry %s\n", m.name, m.version, m.entry);
+    /* In a real kernel this would map segments and jump to entry */
+    /* Here we simply report the entry point symbol */
+    return 0;
+}
+
+#ifdef TEST_MACHO2_LOADER
+int main(int argc, char **argv)
+{
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <macho2>\n", argv[0]);
+        return 1;
+    }
+    return load_and_run(argv[1]);
+}
+#endif

--- a/docs/macho2.md
+++ b/docs/macho2.md
@@ -1,0 +1,82 @@
+# Mach-O2 Specification
+
+Mach-O2 extends the 64-bit Mach-O format with a manifest-driven agent
+model used by NitrOS.  Each Mach-O2 binary embeds a self-describing
+manifest and optional resources so that the kernel can verify and launch
+agents without external metadata.
+
+## New Load Command
+
+```
+#define LC_MACHO2INFO 0x80000035
+
+struct macho2_info_command {
+    uint32_t cmd;        /* LC_MACHO2INFO */
+    uint32_t cmdsize;    /* sizeof(struct macho2_info_command) */
+    uint64_t manifest_offset; /* file offset of manifest bytes */
+    uint64_t manifest_size;   /* size of manifest */
+    uint64_t reserved;        /* future expansion */
+};
+```
+
+`LC_MACHO2INFO` records the location of the agent manifest.  The command
+is placed in the normal load-command table and the `mach_header_64`
+fields `ncmds` and `sizeofcmds` are updated accordingly.
+
+## Sections
+
+The manifest is stored in segment `__O2INFO` section `__manifest`.
+Additional resources may be embedded using other sections within the
+same segment (`__O2INFO,__<name>`).  Tools should mark these sections as
+`S_REGULAR` and read-only.
+
+## Manifest Format
+
+The manifest is UTF‑8 JSON with the following fields:
+
+```json
+{
+  "name": "echo",
+  "type": "user-agent",
+  "version": "1.0",
+  "entry": "_start",
+  "required_privileges": ["filesystem", "network"],
+  "resources": [
+    {"name": "logo", "offset": 0x2000, "size": 512}
+  ]
+}
+```
+
+* **name** – human readable identifier
+* **type** – `kernel`, `module`, or `user-agent`
+* **version** – semantic version string
+* **entry** – symbol or address of entry point
+* **required_privileges** – array of capabilities requested
+* **resources** – optional table of named data blobs stored in other
+  sections; offsets are raw file offsets
+
+## Embedding Convention
+
+Single-file agents embed the JSON directly in section
+`__O2INFO,__manifest`.  Container agents distribute a directory with the
+binary and a separate `manifest.json` file:
+
+```
+agent.mo2/
+  binary            # Mach-O2 image without embedded manifest
+  manifest.json     # standalone manifest
+```
+
+## Reserved Identifiers
+
+* Load command value `0x80000035` is reserved for `LC_MACHO2INFO`.
+* Segment name `__O2INFO` and section `__manifest` are reserved.
+* Future revisions may define additional sections within `__O2INFO` or
+additional fields inside `macho2_info_command`.
+
+## Example Loader
+
+See `boot/macho2_loader_example.c` for a minimal loader that locates the
+manifest, extracts the entry symbol, and would transfer control to the
+agent.
+

--- a/include/macho2.h
+++ b/include/macho2.h
@@ -1,0 +1,63 @@
+#ifndef NOS_MACHO2_H
+#define NOS_MACHO2_H
+
+#include <stdint.h>
+
+/* Mach-O2 custom load command for manifest information */
+#define LC_MACHO2INFO 0x80000035
+
+/* Magic for 64-bit little endian Mach-O */
+#ifndef MH_MAGIC_64
+#define MH_MAGIC_64 0xfeedfacf
+#endif
+
+struct mach_header_64 {
+    uint32_t magic;
+    int32_t  cputype;
+    int32_t  cpusubtype;
+    uint32_t filetype;
+    uint32_t ncmds;
+    uint32_t sizeofcmds;
+    uint32_t flags;
+    uint32_t reserved;
+};
+
+struct load_command {
+    uint32_t cmd;
+    uint32_t cmdsize;
+};
+
+/* Load command carrying manifest location */
+struct macho2_info_command {
+    uint32_t cmd;        /* LC_MACHO2INFO */
+    uint32_t cmdsize;    /* sizeof(struct macho2_info_command) */
+    uint64_t manifest_offset; /* file offset of embedded manifest */
+    uint64_t manifest_size;   /* size of manifest in bytes */
+    uint64_t reserved;        /* for future use */
+};
+
+struct macho2_resource {
+    char     name[32];   /* arbitrary identifier */
+    uint64_t offset;     /* file offset */
+    uint64_t size;       /* size in bytes */
+};
+
+#define MACHO2_MAX_PRIVS 8
+#define MACHO2_MAX_RES   16
+
+struct macho2_manifest {
+    char name[64];
+    char type[16];
+    char version[16];
+    char entry[64];
+    char privileges[MACHO2_MAX_PRIVS][32];
+    uint32_t privilege_count;
+    struct macho2_resource resources[MACHO2_MAX_RES];
+    uint32_t resource_count;
+};
+
+int macho2_load_manifest(const char *path, struct macho2_manifest *out);
+int macho2_extract_resource(const char *path, const struct macho2_resource *res,
+                            void **buf, uint64_t *size);
+
+#endif /* NOS_MACHO2_H */

--- a/tools/macho2.c
+++ b/tools/macho2.c
@@ -1,0 +1,170 @@
+#include "macho2.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Simplistic JSON helpers for manifest parsing */
+static int json_extract_string(const char *json, const char *key,
+                               char *out, size_t out_sz)
+{
+    const char *p = strstr(json, key);
+    if (!p) return -1;
+    p = strchr(p, ':');
+    if (!p) return -1;
+    p++;
+    while (*p && (*p == ' ' || *p == '\t' || *p == '"')) p++;
+    const char *e = strchr(p, '"');
+    if (!e) return -1;
+    size_t n = (size_t)(e - p);
+    if (n >= out_sz) n = out_sz - 1;
+    memcpy(out, p, n);
+    out[n] = 0;
+    return 0;
+}
+
+static uint32_t json_extract_array(const char *json, const char *key,
+                                   char out[][32], uint32_t max)
+{
+    const char *p = strstr(json, key);
+    if (!p) return 0;
+    p = strchr(p, '[');
+    if (!p) return 0;
+    uint32_t count = 0;
+    while (*p && *p != ']') {
+        const char *q = strchr(p, '"');
+        if (!q) break;
+        const char *e = strchr(q + 1, '"');
+        if (!e) break;
+        if (count < max) {
+            size_t n = (size_t)(e - q - 1);
+            if (n >= 31) n = 31;
+            memcpy(out[count], q + 1, n);
+            out[count][n] = 0;
+            count++;
+        }
+        p = e + 1;
+    }
+    return count;
+}
+
+static uint32_t json_extract_resources(const char *json,
+                                       struct macho2_resource *res,
+                                       uint32_t max)
+{
+    const char *p = strstr(json, "resources");
+    if (!p) return 0;
+    p = strchr(p, '[');
+    if (!p) return 0;
+    uint32_t count = 0;
+    while (*p && *p != ']') {
+        const char *name = strstr(p, "name");
+        const char *off  = strstr(p, "offset");
+        const char *sz   = strstr(p, "size");
+        if (!name || !off || !sz) break;
+        if (count < max) {
+            json_extract_string(name, "name", res[count].name,
+                                sizeof(res[count].name));
+            res[count].offset = strtoull(strchr(off, ':') + 1, NULL, 0);
+            res[count].size   = strtoull(strchr(sz, ':') + 1, NULL, 0);
+            count++;
+        }
+        p = strchr(sz, '}');
+        if (!p) break;
+        p++;
+    }
+    return count;
+}
+
+int macho2_load_manifest(const char *path, struct macho2_manifest *out)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return -1;
+    struct mach_header_64 mh;
+    if (fread(&mh, sizeof(mh), 1, f) != 1) { fclose(f); return -1; }
+    if (mh.magic != MH_MAGIC_64) { fclose(f); return -1; }
+
+    uint32_t ncmds = mh.ncmds;
+    uint64_t manifest_off = 0, manifest_sz = 0;
+
+    for (uint32_t i = 0; i < ncmds; ++i) {
+        long pos = ftell(f);
+        struct load_command lc;
+        if (fread(&lc, sizeof(lc), 1, f) != 1) {
+            fclose(f); return -1;
+        }
+        if (lc.cmd == LC_MACHO2INFO) {
+            struct macho2_info_command info;
+            fseek(f, pos, SEEK_SET);
+            if (fread(&info, sizeof(info), 1, f) != 1) {
+                fclose(f); return -1;
+            }
+            manifest_off = info.manifest_offset;
+            manifest_sz  = info.manifest_size;
+            break;
+        }
+        fseek(f, pos + lc.cmdsize, SEEK_SET);
+    }
+
+    if (!manifest_off || !manifest_sz) { fclose(f); return -1; }
+
+    char *buf = malloc(manifest_sz + 1);
+    if (!buf) { fclose(f); return -1; }
+    fseek(f, (long)manifest_off, SEEK_SET);
+    if (fread(buf, 1, manifest_sz, f) != manifest_sz) {
+        free(buf); fclose(f); return -1;
+    }
+    buf[manifest_sz] = '\0';
+    fclose(f);
+
+    memset(out, 0, sizeof(*out));
+    json_extract_string(buf, "name", out->name, sizeof(out->name));
+    json_extract_string(buf, "type", out->type, sizeof(out->type));
+    json_extract_string(buf, "version", out->version, sizeof(out->version));
+    json_extract_string(buf, "entry", out->entry, sizeof(out->entry));
+    out->privilege_count = json_extract_array(buf, "required_privileges",
+                                             out->privileges, MACHO2_MAX_PRIVS);
+    out->resource_count = json_extract_resources(buf, out->resources,
+                                                MACHO2_MAX_RES);
+    free(buf);
+    return 0;
+}
+
+int macho2_extract_resource(const char *path, const struct macho2_resource *res,
+                            void **buf, uint64_t *size)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return -1;
+    if (fseek(f, (long)res->offset, SEEK_SET)) { fclose(f); return -1; }
+    void *b = malloc((size_t)res->size);
+    if (!b) { fclose(f); return -1; }
+    if (fread(b, 1, (size_t)res->size, f) != res->size) {
+        free(b); fclose(f); return -1; }
+    fclose(f);
+    *buf = b;
+    if (size) *size = res->size;
+    return 0;
+}
+
+#ifdef MACHO2_MAIN
+int main(int argc, char **argv)
+{
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <binary>\n", argv[0]);
+        return 1;
+    }
+    struct macho2_manifest m;
+    if (macho2_load_manifest(argv[1], &m)) {
+        fprintf(stderr, "failed to load manifest\n");
+        return 1;
+    }
+    printf("name: %s\nversion: %s\nentry: %s\n", m.name, m.version, m.entry);
+    for (uint32_t i=0;i<m.privilege_count;i++)
+        printf("priv[%u]: %s\n", i, m.privileges[i]);
+    for (uint32_t i=0;i<m.resource_count;i++)
+        printf("res[%u]: %s off=%llu size=%llu\n", i,
+               m.resources[i].name,
+               (unsigned long long)m.resources[i].offset,
+               (unsigned long long)m.resources[i].size);
+    return 0;
+}
+#endif

--- a/tools/mo2c.py
+++ b/tools/mo2c.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+import json, os, struct, sys, shutil
+
+LC_SEGMENT_64 = 0x19
+LC_MACHO2INFO = 0x80000035
+HEADER_SIZE = 32
+INFO_CMD_SIZE = 32
+
+
+def prompt_manifest():
+    name = input('Agent name: ').strip()
+    atype = input('Agent type: ').strip()
+    version = input('Version: ').strip()
+    entry = input('Entry symbol: ').strip()
+    privs = input('Required privileges (comma separated): ').split(',')
+    privs = [p.strip() for p in privs if p.strip()]
+    return {
+        'name': name,
+        'type': atype,
+        'version': version,
+        'entry': entry,
+        'required_privileges': privs,
+        'resources': []
+    }
+
+
+def create_directory(outdir, binary, manifest):
+    os.makedirs(outdir, exist_ok=True)
+    shutil.copy2(binary, os.path.join(outdir, 'binary'))
+    with open(os.path.join(outdir, 'manifest.json'), 'w') as f:
+        json.dump(manifest, f, indent=2)
+    print('Created directory', outdir)
+
+
+def embed_manifest(infile, outfile, manifest):
+    with open(infile, 'rb') as f:
+        data = bytearray(f.read())
+    if len(data) < HEADER_SIZE:
+        print('Input too small')
+        sys.exit(1)
+    magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags, reserved = struct.unpack_from('<IiiIIIII', data, 0)
+    loadcmds = bytearray(data[HEADER_SIZE:HEADER_SIZE+sizeofcmds])
+    body = data[HEADER_SIZE+sizeofcmds:]
+
+    # adjust existing load commands offsets
+    offset = 0
+    while offset < len(loadcmds):
+        cmd, cmdsize = struct.unpack_from('<II', loadcmds, offset)
+        if cmd == LC_SEGMENT_64:
+            fileoff = struct.unpack_from('<Q', loadcmds, offset + 40)[0]
+            if fileoff != 0:
+                struct.pack_into('<Q', loadcmds, offset + 40, fileoff + INFO_CMD_SIZE)
+            nsects = struct.unpack_from('<I', loadcmds, offset + 64)[0]
+            sect_off = offset + 72
+            for _ in range(nsects):
+                sec_off = struct.unpack_from('<I', loadcmds, sect_off + 48)[0]
+                if sec_off != 0:
+                    struct.pack_into('<I', loadcmds, sect_off + 48, sec_off + INFO_CMD_SIZE)
+                sect_off += 80
+        offset += cmdsize
+
+    manifest_bytes = json.dumps(manifest, indent=2).encode('utf-8')
+    new_lc = struct.pack('<IIQQQ', LC_MACHO2INFO, INFO_CMD_SIZE,
+                         0, len(manifest_bytes), 0)
+
+    new_header = struct.pack('<IiiIIIII', magic, cputype, cpusubtype,
+                             filetype, ncmds + 1, sizeofcmds + INFO_CMD_SIZE,
+                             flags, reserved)
+
+    out = bytearray()
+    out += new_header
+    out += loadcmds
+    newcmd_off = len(out)
+    out += new_lc
+    out += body
+    manifest_off = len(out)
+    out += manifest_bytes
+    struct.pack_into('<Q', out, newcmd_off + 8, manifest_off)
+
+    with open(outfile, 'wb') as f:
+        f.write(out)
+    print('Wrote', outfile)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print('usage: mo2c.py <input-macho> <output|outdir.mo2>')
+        return 1
+    infile, outpath = sys.argv[1:]
+    manifest = prompt_manifest()
+    if outpath.endswith('.mo2'):
+        create_directory(outpath, infile, manifest)
+    else:
+        embed_manifest(infile, outpath, manifest)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Document Mach-O2 specification with new LC_MACHO2INFO load command and manifest section
- Provide C headers and parser for extracting manifest and resources from Mach-O2 binaries
- Add `mo2c` tool to generate/embed manifests or create directory containers, plus example loader code

## Testing
- `gcc -DMACHO2_MAIN -Iinclude tools/macho2.c -o /tmp/macho2_test`
- `python3 tools/mo2c.py`
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_6893a64043108333b2766b070fbc81e0