### PR TITLE
Add universal agent loader demo

### DIFF
--- a/agent_loader_demo/Makefile
+++ b/agent_loader_demo/Makefile
@@ -1,0 +1,16 @@
+CC ?= gcc
+CFLAGS ?= -std=c11 -Wall -Wextra -pedantic -g
+OBJS = agent_loader.o regx.o json.o demo.o
+
+all: demo
+
+demo: $(OBJS)
+	$(CC) $(CFLAGS) -o demo $(OBJS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) demo
+
+.PHONY: all clean

--- a/agent_loader_demo/agent_loader.c
+++ b/agent_loader_demo/agent_loader.c
@@ -1,0 +1,148 @@
+#include "agent_loader.h"
+#include "regx.h"
+#include "json.h"
+#include <stdio.h>
+#include <string.h>
+
+/* Stub implementations. Real kernel would map segments and create threads. */
+int map_segment(const void *data, size_t size, uint64_t vaddr) {
+    (void)data; (void)size; (void)vaddr;
+    return 0;
+}
+
+int spawn_thread(void (*entry)(void)) {
+    if (entry) entry();
+    return 0;
+}
+
+/* Entry registry --------------------------------------------------------- */
+typedef struct { const char *name; agent_entry_t fn; } entry_map_t;
+#define MAX_ENTRY_FUNCS 16
+static entry_map_t entry_map[MAX_ENTRY_FUNCS];
+static size_t entry_map_count = 0;
+
+int agent_loader_register_entry(const char *name, agent_entry_t fn) {
+    if (entry_map_count >= MAX_ENTRY_FUNCS) return -1;
+    entry_map[entry_map_count].name = name;
+    entry_map[entry_map_count].fn = fn;
+    entry_map_count++;
+    return 0;
+}
+
+agent_entry_t agent_loader_find_entry(const char *name) {
+    for (size_t i = 0; i < entry_map_count; ++i) {
+        if (strcmp(entry_map[i].name, name) == 0)
+            return entry_map[i].fn;
+    }
+    return NULL;
+}
+
+/* Format detection ------------------------------------------------------- */
+agent_format_t detect_agent_format(const void *image, size_t size) {
+    if (!image || size < 4) return AGENT_FORMAT_UNKNOWN;
+    const unsigned char *p = image;
+    if (p[0] == 0x7f && p[1] == 'E' && p[2] == 'L' && p[3] == 'F')
+        return AGENT_FORMAT_ELF;
+    uint32_t magic = *(const uint32_t *)p;
+    if (magic == 0xfeedface || magic == 0xcefaedfe ||
+        magic == 0xfeedfacf || magic == 0xcffaedfe)
+        return AGENT_FORMAT_MACHO;
+    if (magic == 0x4e4f534d) /* 'NOSM' */
+        return AGENT_FORMAT_NOSM;
+    if (p[0] == '{')
+        return AGENT_FORMAT_MACHO2; /* JSON header */
+    return AGENT_FORMAT_FLAT;
+}
+
+/* Manifest helpers ------------------------------------------------------- */
+int extract_manifest_macho2(const void *image, size_t size,
+                            char *out_json, size_t out_size) {
+    if (!image || !out_json || out_size == 0) return -1;
+    if (size >= out_size) size = out_size - 1;
+    memcpy(out_json, image, size);
+    out_json[size] = '\0';
+    return 0;
+}
+
+int extract_manifest_elf(const void *image, size_t size,
+                         char *out_json, size_t out_size) {
+    if (!image || !out_json || out_size == 0) return -1;
+    const unsigned char *p = image;
+    for (size_t i = 0; i < size; ++i) {
+        if (p[i] == '{') {
+            size_t rem = size - i;
+            if (rem >= out_size) rem = out_size - 1;
+            memcpy(out_json, p + i, rem);
+            out_json[rem] = '\0';
+            return 0;
+        }
+    }
+    return -1;
+}
+
+/* Internal helper to parse manifest and start agent. */
+static int load_from_manifest(const char *json) {
+    regx_manifest_t m;
+    memset(&m, 0, sizeof(m));
+    if (json_get_string(json, "name", m.name, sizeof(m.name))) return -1;
+    json_get_string(json, "type", m.type, sizeof(m.type));
+    json_get_string(json, "version", m.version, sizeof(m.version));
+    json_get_string(json, "abi", m.abi, sizeof(m.abi));
+    json_get_string(json, "capabilities", m.capabilities, sizeof(m.capabilities));
+    json_get_string(json, "entry", m.entry, sizeof(m.entry));
+
+    regx_register(&m, 0);
+    agent_entry_t fn = agent_loader_find_entry(m.entry);
+    if (fn)
+        spawn_thread(fn);
+    return 0;
+}
+
+/* Loader implementations ------------------------------------------------- */
+int load_agent_macho2(const void *image, size_t size) {
+    char manifest[512];
+    if (extract_manifest_macho2(image, size, manifest, sizeof(manifest)))
+        return -1;
+    return load_from_manifest(manifest);
+}
+
+int load_agent_elf(const void *image, size_t size) {
+    char manifest[512];
+    if (extract_manifest_elf(image, size, manifest, sizeof(manifest)))
+        return -1;
+    return load_from_manifest(manifest);
+}
+
+int load_agent_macho(const void *image, size_t size) {
+    (void)image; (void)size;
+    /* Real implementation would parse Mach-O headers and symbols. */
+    return -1;
+}
+
+int load_agent_flat(const void *image, size_t size) {
+    (void)image; (void)size;
+    /* Flat binaries would start executing at the buffer start. */
+    return -1;
+}
+
+int load_agent_nosm(const void *image, size_t size) {
+    (void)image; (void)size;
+    return -1;
+}
+
+int load_agent_auto(const void *image, size_t size) {
+    switch (detect_agent_format(image, size)) {
+    case AGENT_FORMAT_ELF:
+        return load_agent_elf(image, size);
+    case AGENT_FORMAT_MACHO:
+        return load_agent_macho(image, size);
+    case AGENT_FORMAT_MACHO2:
+        return load_agent_macho2(image, size);
+    case AGENT_FORMAT_FLAT:
+        return load_agent_flat(image, size);
+    case AGENT_FORMAT_NOSM:
+        return load_agent_nosm(image, size);
+    default:
+        return -1;
+    }
+}

--- a/agent_loader_demo/agent_loader.h
+++ b/agent_loader_demo/agent_loader.h
@@ -1,0 +1,49 @@
+#ifndef AGENT_LOADER_H
+#define AGENT_LOADER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Universal agent loader for NitrOS.
+ *
+ * This loader only performs format detection, minimal manifest extraction
+ * and stubbed loading of agents. Real OS integration would replace the
+ * mapping and threading stubs with kernel implementations.
+ */
+
+typedef enum {
+    AGENT_FORMAT_ELF,
+    AGENT_FORMAT_MACHO,
+    AGENT_FORMAT_MACHO2,
+    AGENT_FORMAT_FLAT,
+    AGENT_FORMAT_NOSM,
+    AGENT_FORMAT_UNKNOWN
+} agent_format_t;
+
+/* Map segment stub - real kernel would map memory pages. */
+int map_segment(const void *data, size_t size, uint64_t vaddr);
+/* Spawn thread stub - real kernel would create new task/thread. */
+int spawn_thread(void (*entry)(void));
+
+/* Entry registry used by the demo to resolve manifest symbols. */
+typedef void (*agent_entry_t)(void);
+int agent_loader_register_entry(const char *name, agent_entry_t fn);
+agent_entry_t agent_loader_find_entry(const char *name);
+
+/* Format detection and loaders. */
+agent_format_t detect_agent_format(const void *image, size_t size);
+int load_agent_auto(const void *image, size_t size);
+int load_agent_elf(const void *image, size_t size);
+int load_agent_macho(const void *image, size_t size);
+int load_agent_macho2(const void *image, size_t size);
+int load_agent_flat(const void *image, size_t size);
+int load_agent_nosm(const void *image, size_t size);
+
+/* Manifest extraction helpers. */
+int extract_manifest_macho2(const void *image, size_t size,
+                            char *out_json, size_t out_size);
+int extract_manifest_elf(const void *image, size_t size,
+                         char *out_json, size_t out_size);
+
+#endif /* AGENT_LOADER_H */

--- a/agent_loader_demo/demo.c
+++ b/agent_loader_demo/demo.c
@@ -1,0 +1,43 @@
+#include "agent_loader.h"
+#include "regx.h"
+#include <stdio.h>
+#include <string.h>
+
+/* Dummy entry functions for demonstration */
+void elf_agent_main(void) {
+    printf("ELF agent executed\n");
+}
+void macho2_agent_main(void) {
+    printf("Mach-O2 agent executed\n");
+}
+
+int main(void) {
+    /* Register entry points */
+    agent_loader_register_entry("elf_agent_main", elf_agent_main);
+    agent_loader_register_entry("macho2_agent_main", macho2_agent_main);
+
+    /* Construct a fake Mach-O2 image consisting solely of a manifest JSON. */
+    const char macho2_manifest[] =
+        "{\"name\":\"macho2_demo\",\"type\":\"demo\",\"version\":\"1.0\"," \
+        "\"abi\":\"none\",\"capabilities\":\"example\",\"entry\":\"macho2_agent_main\"}";
+    load_agent_auto(macho2_manifest, sizeof(macho2_manifest));
+
+    /* Construct a fake ELF image: ELF magic followed by manifest JSON. */
+    const char elf_manifest[] =
+        "{\"name\":\"elf_demo\",\"type\":\"demo\",\"version\":\"1.0\"," \
+        "\"abi\":\"none\",\"capabilities\":\"example\",\"entry\":\"elf_agent_main\"}";
+    unsigned char elf_image[4 + sizeof(elf_manifest)];
+    memcpy(elf_image, "\x7F" "ELF", 4);
+    memcpy(elf_image + 4, elf_manifest, sizeof(elf_manifest));
+    load_agent_auto(elf_image, sizeof(elf_image));
+
+    /* Enumerate registry entries */
+    regx_entry_t entries[8];
+    size_t count = regx_enumerate(NULL, entries, 8);
+    printf("Registered agents:%zu\n", count);
+    for (size_t i = 0; i < count; ++i) {
+        printf(" - %s (id %llu)\n", entries[i].manifest.name,
+               (unsigned long long)entries[i].id);
+    }
+    return 0;
+}

--- a/agent_loader_demo/json.c
+++ b/agent_loader_demo/json.c
@@ -1,0 +1,53 @@
+#include "json.h"
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+static const char *skip_ws(const char *p) {
+    while (*p && isspace((unsigned char)*p)) p++;
+    return p;
+}
+
+int json_get_string(const char *json, const char *key,
+                    char *out, size_t out_size) {
+    char pattern[64];
+    snprintf(pattern, sizeof(pattern), "\"%s\"", key);
+    const char *p = strstr(json, pattern);
+    if (!p) return -1;
+    p += strlen(pattern);
+    p = strchr(p, ':');
+    if (!p) return -1;
+    p++;
+    p = skip_ws(p);
+    if (*p != '"') return -1;
+    p++;
+    const char *end = strchr(p, '"');
+    if (!end) return -1;
+    size_t len = (size_t)(end - p);
+    if (len + 1 > out_size) return -1;
+    memcpy(out, p, len);
+    out[len] = '\0';
+    return 0;
+}
+
+int json_get_int(const char *json, const char *key, int *out_value) {
+    char pattern[64];
+    snprintf(pattern, sizeof(pattern), "\"%s\"", key);
+    const char *p = strstr(json, pattern);
+    if (!p) return -1;
+    p += strlen(pattern);
+    p = strchr(p, ':');
+    if (!p) return -1;
+    p++;
+    p = skip_ws(p);
+    int sign = 1;
+    if (*p == '-') { sign = -1; p++; }
+    int val = 0;
+    if (!isdigit((unsigned char)*p)) return -1;
+    while (isdigit((unsigned char)*p)) {
+        val = val * 10 + (*p - '0');
+        p++;
+    }
+    *out_value = val * sign;
+    return 0;
+}

--- a/agent_loader_demo/json.h
+++ b/agent_loader_demo/json.h
@@ -1,0 +1,13 @@
+#ifndef MINIMAL_JSON_H
+#define MINIMAL_JSON_H
+
+#include <stddef.h>
+
+/* Minimal JSON helper capable of extracting string and integer values
+ * from flat key/value objects. */
+
+int json_get_string(const char *json, const char *key,
+                    char *out, size_t out_size);
+int json_get_int(const char *json, const char *key, int *out_value);
+
+#endif /* MINIMAL_JSON_H */

--- a/agent_loader_demo/regx.c
+++ b/agent_loader_demo/regx.c
@@ -1,0 +1,38 @@
+#include "regx.h"
+#include <string.h>
+
+#define REGX_MAX_ENTRIES 16
+
+static regx_entry_t registry[REGX_MAX_ENTRIES];
+static size_t registry_count = 0;
+static uint64_t next_id = 1;
+
+uint64_t regx_register(const regx_manifest_t *manifest, uint64_t parent_id) {
+    if (registry_count >= REGX_MAX_ENTRIES) return 0;
+    regx_entry_t *e = &registry[registry_count];
+    e->id = next_id++;
+    e->parent_id = parent_id;
+    e->manifest = *manifest;
+    registry_count++;
+    return e->id;
+}
+
+const regx_entry_t *regx_query(uint64_t id) {
+    for (size_t i = 0; i < registry_count; ++i) {
+        if (registry[i].id == id)
+            return &registry[i];
+    }
+    return NULL;
+}
+
+size_t regx_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max) {
+    size_t n = 0;
+    for (size_t i = 0; i < registry_count && n < max; ++i) {
+        if (sel && sel->type && sel->type[0]) {
+            if (strcmp(registry[i].manifest.type, sel->type) != 0)
+                continue;
+        }
+        out[n++] = registry[i];
+    }
+    return n;
+}

--- a/agent_loader_demo/regx.h
+++ b/agent_loader_demo/regx.h
@@ -1,0 +1,32 @@
+#ifndef REGX_H
+#define REGX_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Simple RegX registry holding agent manifests. */
+
+typedef struct {
+    char name[64];
+    char type[32];
+    char version[32];
+    char abi[32];
+    char capabilities[128];
+    char entry[64];
+} regx_manifest_t;
+
+typedef struct {
+    uint64_t id;
+    uint64_t parent_id;
+    regx_manifest_t manifest;
+} regx_entry_t;
+
+typedef struct {
+    const char *type; /* optional filter by type */
+} regx_selector_t;
+
+uint64_t regx_register(const regx_manifest_t *manifest, uint64_t parent_id);
+const regx_entry_t *regx_query(uint64_t id);
+size_t regx_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max);
+
+#endif /* REGX_H */


### PR DESCRIPTION
## Summary
- implement minimal RegX registry and JSON parser
- add portable agent loader capable of detecting Mach-O2, ELF, and more
- provide demo program showcasing loading of in-memory ELF and Mach-O2 agents

## Testing
- `cd agent_loader_demo && make`
- `cd agent_loader_demo && ./demo`

------
https://chatgpt.com/codex/tasks/task_b_6893be17770c83339e80024093921598