### PR TITLE
Fix regx definitions and add kernel registry

### DIFF
--- a/kernel/regx.c
+++ b/kernel/regx.c
@@ -1,0 +1,51 @@
+#include "../src/agents/regx/regx.h"
+#include <string.h>
+
+static regx_entry_t regx_registry[REGX_MAX_ENTRIES];
+static size_t regx_count = 0;
+static uint64_t regx_next_id = 1;
+
+uint64_t regx_register(const regx_manifest_t *m, uint64_t parent_id) {
+    if (regx_count >= REGX_MAX_ENTRIES)
+        return 0;
+    regx_entry_t *e = &regx_registry[regx_count++];
+    e->id = regx_next_id++;
+    e->parent_id = parent_id;
+    e->manifest = *m;
+    return e->id;
+}
+
+int regx_unregister(uint64_t id) {
+    for (size_t i = 0; i < regx_count; ++i) {
+        if (regx_registry[i].id == id) {
+            regx_registry[i] = regx_registry[--regx_count];
+            return 0;
+        }
+    }
+    return -1;
+}
+
+const regx_entry_t *regx_query(uint64_t id) {
+    for (size_t i = 0; i < regx_count; ++i)
+        if (regx_registry[i].id == id)
+            return &regx_registry[i];
+    return NULL;
+}
+
+size_t regx_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max) {
+    size_t n = 0;
+    for (size_t i = 0; i < regx_count && n < max; ++i) {
+        if (sel) {
+            if (sel->type && regx_registry[i].manifest.type != sel->type)
+                continue;
+            if (sel->parent_id && regx_registry[i].parent_id != sel->parent_id)
+                continue;
+            if (sel->name_prefix[0] &&
+                strncmp(regx_registry[i].manifest.name, sel->name_prefix,
+                        strlen(sel->name_prefix)) != 0)
+                continue;
+        }
+        out[n++] = regx_registry[i];
+    }
+    return n;
+}

--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -1,4 +1,4 @@
-a#include "regx.h"
+#include "regx.h"
 #include <string.h>
 #include <stdio.h>
 

--- a/src/agents/regx/regx.h
+++ b/src/agents/regx/regx.h
@@ -1,12 +1,21 @@
 #pragma once
+#include <stddef.h>
 #include <stdint.h>
+
 #define REGX_MAX_ENTRIES 256
 
-size_t regx_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max);
+/* Registry entry types */
+#define REGX_TYPE_ANY        0
+#define REGX_TYPE_DEVICE     1
+#define REGX_TYPE_DRIVER     2
+#define REGX_TYPE_AGENT      3
+#define REGX_TYPE_SERVICE    4
+#define REGX_TYPE_BUS        5
+#define REGX_TYPE_FILESYSTEM 6
 
 typedef struct {
     char name[32];
-    int  type;                // 1=device, 2=driver, 3=agent, 4=service, 5=bus
+    int  type;                /* one of REGX_TYPE_* */
     char version[16];
     char abi[16];
     char capabilities[64];
@@ -14,12 +23,17 @@ typedef struct {
 
 typedef struct regx_entry {
     uint64_t id;
-    uint64_t parent_id;      // 0=root
+    uint64_t parent_id;      /* 0=root */
     regx_manifest_t manifest;
 } regx_entry_t;
 
 typedef struct {
-    int type;                // 0=any
-    uint64_t parent_id;      // 0=any
-    char name_prefix[16];    // ""=any
+    int type;                /* REGX_TYPE_ANY to match any */
+    uint64_t parent_id;      /* 0=any */
+    char name_prefix[16];    /* ""=any */
 } regx_selector_t;
+
+uint64_t regx_register(const regx_manifest_t *m, uint64_t parent_id);
+int      regx_unregister(uint64_t id);
+const regx_entry_t *regx_query(uint64_t id);
+size_t   regx_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max);


### PR DESCRIPTION
## Summary
- define RegX types and constants, including filesystem selector
- add prototypes and a simple kernel-side registry implementation
- clean up stray include in the RegX source

## Testing
- `make kernel`

------
https://chatgpt.com/codex/tasks/task_b_6893ca307184833395b1510b27d9a59f