### PR TITLE
Handle invalid bootloader name pointer

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -38,7 +38,14 @@ void n2_main(bootinfo_t *bootinfo) {
 
     serial_init();
     kprint("\r\n[N2] NitrOS agent kernel booting...\r\n");
-    kprint("[N2] Booted by: "); kprint(bootinfo->bootloader_name); kprint("\r\n");
+    kprint("[N2] Booted by: ");
+    const char *bl = bootinfo->bootloader_name;
+    if (bl && ((uintptr_t)bl < 0x100000000ULL)) {
+        kprint(bl);
+    } else {
+        kprint("unknown");
+    }
+    kprint("\r\n");
 
     // Framebuffer, ACPI, CPU, modules, memory map, etc.
     print_acpi_info(bootinfo);


### PR DESCRIPTION
## Summary
- Safely handle bootloader name pointer in `n2_main` by validating address before use

## Testing
- `make`
- `timeout 5 qemu-system-x86_64 -bios /usr/share/ovmf/OVMF.fd -drive file=disk.img,format=raw -m 512M -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -serial stdio -display none >/tmp/qemu.log 2>&1 || true`
- `strings /tmp/qemu.log | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_6893ee8db7dc8333b00cc6d08b63442f