### PR TITLE
Refactor kernel output and registries

### DIFF
--- a/kernel/agent.c
+++ b/kernel/agent.c
@@ -11,6 +11,15 @@ void n2_agent_registry_reset(void) {
 int n2_agent_register(const n2_agent_t *agent) {
     if (!agent || registry_count >= N2_MAX_AGENTS)
         return -1;
+
+    /* ensure name is null-terminated within the buffer */
+    if (!memchr(agent->name, '\0', sizeof(agent->name)))
+        return -1;
+
+    /* avoid duplicate registrations */
+    if (n2_agent_get(agent->name))
+        return -1;
+
     registry[registry_count] = *agent;
     registry[registry_count].id = (uint32_t)registry_count;
     registry_count++;
@@ -18,6 +27,9 @@ int n2_agent_register(const n2_agent_t *agent) {
 }
 
 const n2_agent_t *n2_agent_get(const char *name) {
+    if (!name)
+        return NULL;
+
     for (size_t i = 0; i < registry_count; ++i) {
         if (strncmp(registry[i].name, name, sizeof(registry[i].name)) == 0)
             return &registry[i];

--- a/kernel/agent_loader.c
+++ b/kernel/agent_loader.c
@@ -38,6 +38,13 @@ static struct {
 static size_t entry_count = 0;
 
 void agent_loader_register_entry(const char *name, agent_entry_t fn) {
+    if (!name || !fn)
+        return;
+
+    for (size_t i = 0; i < entry_count; ++i)
+        if (strcmp(entry_registry[i].name, name) == 0)
+            return; /* already registered */
+
     if (entry_count < MAX_ENTRIES) {
         entry_registry[entry_count].name = name;
         entry_registry[entry_count].fn = fn;

--- a/kernel/drivers/IO/serial.c
+++ b/kernel/drivers/IO/serial.c
@@ -73,10 +73,7 @@ static void serial_print_uint(uint64_t value, int base, int width, int pad_zero)
         serial_write(buf[j]);
 }
 
-void serial_printf(const char *fmt, ...) {
-    va_list ap;
-    va_start(ap, fmt);
-
+void serial_vprintf(const char *fmt, va_list ap) {
     for (const char *p = fmt; *p; ++p) {
         if (*p != '%') {
             if (*p == '\n')
@@ -143,7 +140,12 @@ void serial_printf(const char *fmt, ...) {
             break;
         }
     }
+}
 
+void serial_printf(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    serial_vprintf(fmt, ap);
     va_end(ap);
 }
 

--- a/kernel/drivers/IO/serial.h
+++ b/kernel/drivers/IO/serial.h
@@ -1,9 +1,11 @@
 #pragma once
 #include <stdint.h>
+#include <stdarg.h>
 
 void serial_init(void);
 void serial_write(char c);
 void serial_puts(const char *s);
 void serial_puthex(uint32_t value);
+void serial_vprintf(const char *fmt, va_list ap);
 void serial_printf(const char *fmt, ...);
 int serial_read(void);

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -1,9 +1,10 @@
 #include <stdarg.h>
+#include "drivers/IO/serial.h"
 
 int printf(const char *fmt, ...) {
-    (void)fmt;
     va_list ap;
     va_start(ap, fmt);
+    serial_vprintf(fmt, ap);
     va_end(ap);
     return 0;
 }


### PR DESCRIPTION
## Summary
- Prevent duplicate entries in the agent loader and agent registry
- Route `printf` through serial output via new `serial_vprintf` helper

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_6894146b9b5883339699fff56338957d