### PR TITLE
Ensure login service is part of boot sequence

### DIFF
--- a/tests/integration/test_qemu.py
+++ b/tests/integration/test_qemu.py
@@ -43,7 +43,7 @@ def run_qemu():
 @pytest.mark.skipif(shutil.which("qemu-system-x86_64") is None, reason="qemu-system-x86_64 not installed")
 def test_boot_sequence():
     out = run_qemu()
-    sequence = ["[nboot]", "[O2]", "[N2]", "[regx]", "[init]"]
+    sequence = ["[nboot]", "[O2]", "[N2]", "[regx]", "[init]", "[login]"]
     last = -1
     for marker in sequence:
         idx = out.find(marker)


### PR DESCRIPTION
## Summary
- launch a simple login service from the init thread to complete the boot chain
- extend integration test to verify boot reaches login stage

## Testing
- `make -C tests`
- `pytest tests/integration/test_qemu.py -q` *(skipped: qemu-system-x86_64 not installed)*

------
https://chatgpt.com/codex/tasks/task_b_689433c378c883338ea0d91da5e2680c