### PR TITLE
Fix kernel_segment_t redefinition in O2 loader

### DIFF
--- a/kernel/O2.c
+++ b/kernel/O2.c
@@ -5,13 +5,6 @@
 // ========== Settings ==========
 
 #define STAGE1_MODULE_NAME "n2.bin"
-#define MAX_KERNEL_SEGMENTS 16
-
-typedef struct {
-    uint64_t vaddr, paddr, filesz, memsz;
-    uint32_t flags;
-    char name[17];
-} kernel_segment_t;
 
 // ========== Minimal stdlib ==========
 


### PR DESCRIPTION
## Summary
- Remove redundant `kernel_segment_t` typedef from `kernel/O2.c` to rely on the `bootinfo.h` definition and avoid conflicting types during kernel build.

## Testing
- `make kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_68954c09685883338d9237dd64da6609