### PR TITLE
Fix lld-link output path in boot Makefile

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -12,7 +12,7 @@ LDFLAGS=/entry:efi_main \
         /nodefaultlib \
         /base:0 \
         /filealign:32 \
-        /out:n nboot.efi
+        /out:nboot.efi
 
 # Build all C sources in this directory. The original build assumed sources
 # lived under a `src/` subdirectory, but `nboot.c` now resides at the top level


### PR DESCRIPTION
## Summary
- Fix boot Makefile to pass the correct `/out:nboot.efi` flag to lld-link

## Testing
- `make -C boot`


------
https://chatgpt.com/codex/tasks/task_b_68954d92bdc48333885428e5dff53109