### PR TITLE
Fix O2 boot entry calling convention

### DIFF
--- a/boot/nboot.c
+++ b/boot/nboot.c
@@ -159,8 +159,9 @@ EFI_STATUS EFIAPI efi_main(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable
     print_hex(SystemTable, (uint64_t)(uintptr_t)bi); print_ascii(SystemTable, "\r\n");
     print_ascii(SystemTable, "[nboot] Jumping to O2.bin...\r\n");
 
-    // --- Call O2.bin's entry (must be a valid entry point!) ---
-    void (*o2_entry)(bootinfo_t *) = (void (*)(bootinfo_t *))o2_buf;
+    // --- Call O2.bin's entry (SysV ABI) ---
+    typedef void (__attribute__((sysv_abi)) *o2_entry_t)(bootinfo_t *);
+    o2_entry_t o2_entry = (o2_entry_t)o2_buf;
     o2_entry(bi);
 
     return EFI_SUCCESS;


### PR DESCRIPTION
## Summary
- ensure nboot calls O2.bin using SysV ABI so stage0 gets valid bootinfo

## Testing
- `pytest tests/integration/test_qemu.py::test_boot_sequence -q` *(fails: [O2] missing or out of order)*

------
https://chatgpt.com/codex/tasks/task_b_68955847fa4883339cfa9fa1331f736a