### PR TITLE
Fix N2 kernel entry to use SysV ABI

### DIFF
--- a/kernel/n2_entry.asm
+++ b/kernel/n2_entry.asm
@@ -6,9 +6,8 @@ extern n2_main
 
 _start:
     cld
-    ; Bootloader passes bootinfo via RCX (Microsoft x64 ABI).
-    ; Move it to RDI for System V calling convention expected by n2_main.
-    mov rdi, rcx
+    ; Bootloader passes bootinfo in RDI (SysV x86_64 ABI),
+    ; so it's already in the correct register for n2_main.
     xor rbp, rbp
     call n2_main
 


### PR DESCRIPTION
## Summary
- handle N2 bootinfo pointer using SysV calling convention

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689560b1cc8c83339f5508850a9628eb