### PR TITLE
Halt kernel when filesystem agent is missing

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -97,6 +97,8 @@ void n2_main(bootinfo_t *bootinfo) {
         vprint("[N2] Filesystem agent active: "); vprint(fs->name); vprint("\r\n");
     } else {
         vprint("[N2] No filesystem agent found!\r\n");
+        // Halting to avoid crashes when filesystem agent is missing
+        for (;;) asm volatile("hlt");
     }
 
     // Enumerate registered filesystem agents via RegX


### PR DESCRIPTION
## Summary
- stop N2 kernel from crashing by halting if no filesystem agent is present

## Testing
- `make`
- `for t in test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm; do echo Running $t; ./$t; echo exit=$?; done`
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_6895675c09048333876185c2896ffb8f