### PR TITLE
Add guidance when filesystem agent missing

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -97,6 +97,7 @@ void n2_main(bootinfo_t *bootinfo) {
         vprint("[N2] Filesystem agent active: "); vprint(fs->name); vprint("\r\n");
     } else {
         vprint("[N2] No filesystem agent found!\r\n");
+        vprint("make sure regx is starting and that the filesystem agent is started early in the boot\r\n");
         // Halting to avoid crashes when filesystem agent is missing
         for (;;) asm volatile("hlt");
     }


### PR DESCRIPTION
## Summary
- print a helpful troubleshooting hint when the N2 kernel can't find a filesystem agent

## Testing
- `cd tests && make`

------
https://chatgpt.com/codex/tasks/task_b_689568ae4b7c8333b65347bbeb46aadf