### PR TITLE
Use snprintf for agent field copy

### DIFF
--- a/kernel/agent_loader.c
+++ b/kernel/agent_loader.c
@@ -140,8 +140,10 @@ static int register_from_manifest(const char *json) {
     agent_entry_t fn = find_entry_fn(entry);
     if (fn) {
         n2_agent_t agent = {0};
-        strncpy(agent.name, m.name, sizeof(agent.name) - 1);
-        strncpy(agent.version, m.version, sizeof(agent.version) - 1);
+        // Use snprintf to ensure strings are always null-terminated without
+        // triggering truncation warnings from strncpy.
+        snprintf(agent.name, sizeof(agent.name), "%s", m.name);
+        snprintf(agent.version, sizeof(agent.version), "%s", m.version);
         agent.entry = fn;
         agent.manifest = json;
         n2_agent_register(&agent);


### PR DESCRIPTION
## Summary
- copy manifest name and version into agent struct using `snprintf` for safe null-terminated strings

## Testing
- `make kernel`

------
https://chatgpt.com/codex/tasks/task_b_689573cfc5448333bf7e5461d8500a58