### PR TITLE
Fix RegX type enum and agent manifest storage

### DIFF
--- a/include/regx.h
+++ b/include/regx.h
@@ -10,8 +10,9 @@ typedef enum {
     REGX_TYPE_DEVICE = 1,
     REGX_TYPE_DRIVER = 2,
     REGX_TYPE_AGENT  = 3,
-    REGX_TYPE_FILESYSTEM = 4,  // add this
-    /* other types … */
+    REGX_TYPE_SERVICE = 4,
+    REGX_TYPE_BUS = 5,
+    REGX_TYPE_FILESYSTEM = 6,
 } regx_type_t;
 
 /* Registry entry types */


### PR DESCRIPTION
## Summary
- Align regx_type_t enum with defined REGX_TYPE_* macros, including SERVICE, BUS, and FILESYSTEM values
- Persist agent capability strings by duplicating them onto the heap instead of referencing stack JSON buffers

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_68957639aa348333854643675c1f446b