### PR TITLE
Guard RegX prefix parsing against missing terminators

### DIFF
--- a/kernel/regx.c
+++ b/kernel/regx.c
@@ -39,7 +39,8 @@ size_t regx_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max)
 
     if (sel && sel->name_prefix[0]) {
         prefix = sel->name_prefix;
-        prefix_len = strlen(prefix);
+        while (prefix_len < sizeof(sel->name_prefix) && prefix[prefix_len])
+            prefix_len++;
     }
 
     for (size_t i = 0; i < regx_count && n < max; ++i) {

--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -43,9 +43,13 @@ size_t regx_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max)
                 continue;
             if (sel->parent_id && regx_registry[i].parent_id != sel->parent_id)
                 continue;
-            if (sel->name_prefix[0] &&
-                strncmp(regx_registry[i].manifest.name, sel->name_prefix, strlen(sel->name_prefix)) != 0)
-                continue;
+            if (sel->name_prefix[0]) {
+                size_t prefix_len = 0;
+                while (prefix_len < sizeof(sel->name_prefix) && sel->name_prefix[prefix_len])
+                    prefix_len++;
+                if (strncmp(regx_registry[i].manifest.name, sel->name_prefix, prefix_len) != 0)
+                    continue;
+            }
         }
         out[n++] = regx_registry[i];
     }


### PR DESCRIPTION
## Summary
- Avoid unbounded `strlen` on RegX selectors by manually bounding prefix length
- Harden RegX service against unterminated `name_prefix` values

## Testing
- `make`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6895778bf33483338003bf3404b3199e