### PR TITLE
Harden agent capability lookups

### DIFF
--- a/kernel/agent.c
+++ b/kernel/agent.c
@@ -64,7 +64,12 @@ const n2_agent_t *n2_agent_find_capability(const char *cap) {
         return NULL;
     for (size_t i = 0; i < registry_count; ++i) {
         const char *man = (const char *)registry[i].manifest;
-        if (man && strstr(man, cap))
+        if (!man)
+            continue;
+        /* Only treat manifest as a string if a NUL appears within 256 bytes. */
+        if (!memchr(man, '\0', 256))
+            continue;
+        if (strstr(man, cap))
             return &registry[i];
     }
     return NULL;

--- a/kernel/nosm.c
+++ b/kernel/nosm.c
@@ -64,7 +64,8 @@ void *nosm_load(const void *image, size_t size)
     memcpy(agent.name, manifest->name, sizeof(agent.name));
     memcpy(agent.version, manifest->version, sizeof(agent.version));
     agent.entry = entry;
-    agent.manifest = manifest;
+    /* NOSM modules have no capabilities; use an empty string for manifest. */
+    agent.manifest = "";
     n2_agent_register(&agent);
 
     entry();


### PR DESCRIPTION
## Summary
- Ensure capability searches only scan valid manifest strings
- Prevent NOSM loader from exposing non-string manifests

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_68957c39173c8333bdb6670f0755b1a1