### PR TITLE
Use safe capabilities field for agent registration

### DIFF
--- a/include/agent.h
+++ b/include/agent.h
@@ -12,6 +12,7 @@ typedef struct {
     char version[16];
     void *entry;
     const void *manifest;
+    char capabilities[64];  // safe capabilities string
 } n2_agent_t;
 
 int n2_agent_register(const n2_agent_t *agent);

--- a/kernel/agent.c
+++ b/kernel/agent.c
@@ -63,13 +63,8 @@ const n2_agent_t *n2_agent_find_capability(const char *cap) {
     if (!cap)
         return NULL;
     for (size_t i = 0; i < registry_count; ++i) {
-        const char *man = (const char *)registry[i].manifest;
-        if (!man)
-            continue;
-        /* Only treat manifest as a string if a NUL appears within 256 bytes. */
-        if (!memchr(man, '\0', 256))
-            continue;
-        if (strstr(man, cap))
+        const char *caps = registry[i].capabilities;
+        if (caps[0] && strstr(caps, cap))
             return &registry[i];
     }
     return NULL;

--- a/kernel/agent_loader.c
+++ b/kernel/agent_loader.c
@@ -2,7 +2,6 @@
 #include "agent.h"
 #include <string.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 // Provide a simple implementation of memmem for environments where it is
 // unavailable. This performs a byte-wise search of `needle` within `haystack`.
@@ -42,15 +41,6 @@ static int json_extract_int(const char *json, const char *key) {
     if (!p) return -1;
     p += strlen(pattern);
     return (int)strtol(p, NULL, 10);
-}
-
-// strdup is not provided by our minimal libc, so implement a local helper.
-static char *strdup_local(const char *s) {
-    size_t len = strlen(s) + 1;
-    char *d = (char *)malloc(len);
-    if (d)
-        memcpy(d, s, len);
-    return d;
 }
 
 // ---- Internal entry registry ------------------------------------------------
@@ -154,9 +144,8 @@ static int register_from_manifest(const char *json) {
         snprintf(agent.name, sizeof(agent.name), "%s", m.name);
         snprintf(agent.version, sizeof(agent.version), "%s", m.version);
         agent.entry = fn;
-        const char *caps = m.capabilities[0] ? m.capabilities : "";
-        char *cap_copy = caps[0] ? strdup_local(caps) : NULL;
-        agent.manifest = cap_copy ? (const void *)cap_copy : (const void *)caps;
+        snprintf(agent.capabilities, sizeof(agent.capabilities), "%s", m.capabilities);
+        agent.manifest = NULL;
         n2_agent_register(&agent);
         fn();
     } else {

--- a/kernel/nosm.c
+++ b/kernel/nosm.c
@@ -64,8 +64,9 @@ void *nosm_load(const void *image, size_t size)
     memcpy(agent.name, manifest->name, sizeof(agent.name));
     memcpy(agent.version, manifest->version, sizeof(agent.version));
     agent.entry = entry;
-    /* NOSM modules have no capabilities; use an empty string for manifest. */
-    agent.manifest = "";
+    /* NOSM modules have no capabilities; clear fields and ignore manifest. */
+    agent.manifest = NULL;
+    agent.capabilities[0] = '\0';
     n2_agent_register(&agent);
 
     entry();

--- a/user/agents/nosfs/nosfs_server.c
+++ b/user/agents/nosfs/nosfs_server.c
@@ -20,7 +20,8 @@ static n2_agent_t nosfs_agent = {
     .name = "NOSFS",
     .version = "1.0.0",
     .entry = nosfs_server,
-    .manifest = nosfs_manifest_str
+    .manifest = nosfs_manifest_str,
+    .capabilities = "filesystem,snapshot,rollback"
 };
 
 /* Register with the kernel agent registry at module load time. */


### PR DESCRIPTION
## Summary
- Add a null-terminated `capabilities` string to `n2_agent_t` for safe capability storage.
- Store capabilities directly when registering agents and simplify capability lookup.
- Clear capability data for NOSM modules and update NOSFS agent to declare its capabilities.

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_6895808a0dfc8333a7ddf36dc0694b9f