### PR TITLE
Initialize thread scheduler state before interrupts

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -31,6 +31,20 @@ ipc_queue_t upd_queue;
 ipc_queue_t init_queue;
 ipc_queue_t regx_queue;
 
+// Ensure scheduler state is in a known reset state before any interrupts run.
+// Some early boot paths may trigger timer interrupts before `threads_init()`
+// executes which previously left these globals holding garbage and led to
+// crashes when the scheduler tried to traverse bogus run queues.  This helper
+// explicitly zeros all bookkeeping so spurious interrupts are harmless.
+void threads_early_init(void) {
+    zombie_list = NULL;
+    next_id = 1;
+    for (int i = 0; i < MAX_CPUS; ++i) {
+        current_cpu[i] = NULL;
+        tail_cpu[i] = NULL;
+    }
+}
+
 // Utility: Convert unsigned int to decimal string (for logging)
 static void utoa_dec(uint32_t val, char *buf) {
     char tmp[20];

--- a/kernel/Task/thread.h
+++ b/kernel/Task/thread.h
@@ -30,6 +30,11 @@ typedef struct thread {
 extern thread_t *current_cpu[MAX_CPUS];
 
 /**
+ * Reset scheduler bookkeeping before interrupts might fire.
+ */
+void threads_early_init(void);
+
+/**
  * Retrieve pointer to currently running thread on this CPU.
  */
 thread_t *thread_current(void);

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -47,6 +47,7 @@ void n2_main(bootinfo_t *bootinfo) {
     if (!bootinfo || bootinfo->magic != BOOTINFO_MAGIC_UEFI)
         return;
 
+    threads_early_init();
     serial_init();
     vprint("\r\n[N2] NitrOS agent kernel booting...\r\n");
     vprint("[N2] Booted by: ");


### PR DESCRIPTION
## Summary
- Reset thread scheduler globals in `threads_early_init` to avoid garbage run-queue pointers
- Invoke `threads_early_init` at kernel entry to handle stray early interrupts safely

## Testing
- `make kernel`
- `cd tests && make`

------
https://chatgpt.com/codex/tasks/task_b_68958206d3a48333ab49d331f636284d