### PR TITLE
Include stdlib for strtol in agent loader

### DIFF
--- a/kernel/agent_loader.c
+++ b/kernel/agent_loader.c
@@ -2,6 +2,7 @@
 #include "agent.h"
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 // Provide a simple implementation of memmem for environments where it is
 // unavailable. This performs a byte-wise search of `needle` within `haystack`.


### PR DESCRIPTION
## Summary
- include `<stdlib.h>` so `strtol` is declared in agent loader

## Testing
- `gcc -Wall -Wextra -Iinclude -Ikernel -c kernel/agent_loader.c -o /tmp/agent_loader.o`
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689584d47a708333a6602d89288b7abe