### PR TITLE
Validate built-in agent pointers to avoid early GP faults

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -97,8 +97,11 @@ void n2_main(bootinfo_t *bootinfo) {
     } else {
         vprint("[N2] Builtin NOSFS image missing or invalid\r\n");
     }
-    if ((uintptr_t)my_mach_agent_image > 0x1000 && my_mach_agent_size > 0) {
+    if ((uintptr_t)my_mach_agent_image > 0x1000 && my_mach_agent_size > 0 &&
+        (uintptr_t)my_mach_agent_image < 0x100000000ULL) {
         load_agent(my_mach_agent_image, my_mach_agent_size, AGENT_FORMAT_MACHO2);
+    } else if ((uintptr_t)my_mach_agent_image || my_mach_agent_size) {
+        vprint("[N2] Builtin Mach agent image missing or invalid\r\n");
     }
 
     for (uint32_t i = 0; i < bootinfo->module_count; ++i)


### PR DESCRIPTION
## Summary
- verify built-in NOSFS and Mach agent pointers before passing them to `load_agent`
- log a warning when an optional Mach agent image is missing or invalid

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_68958b9c75d48333bab7c5b4f1367c44