### PR TITLE
Integrate VM subsystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ kernel: libc
 	$(CC) $(CFLAGS) -c kernel/macho2.c -o kernel/macho2.o
 	$(CC) $(CFLAGS) -c kernel/printf.c -o kernel/printf.o
 	$(CC) $(CFLAGS) -c kernel/nosm.c -o kernel/nosm.o
+	$(CC) $(CFLAGS) -c kernel/VM/pmm.c -o kernel/VM/pmm.o
+	$(CC) $(CFLAGS) -c kernel/VM/paging.c -o kernel/VM/paging.o
+	$(CC) $(CFLAGS) -c kernel/VM/cow.c -o kernel/VM/cow.o
+	$(CC) $(CFLAGS) -c kernel/VM/numa.c -o kernel/VM/numa.o
 	$(CC) $(CFLAGS) -c kernel/drivers/IO/ps2.c -o kernel/drivers/IO/ps2.o
 	$(CC) $(CFLAGS) -c kernel/drivers/IO/keyboard.c -o kernel/drivers/IO/keyboard.o
 	$(CC) $(CFLAGS) -c kernel/drivers/IO/mouse.c -o kernel/drivers/IO/mouse.o
@@ -50,8 +54,9 @@ kernel: libc
 	    kernel/drivers/IO/video.o kernel/drivers/IO/tty.o \
 	    kernel/drivers/IO/block.o kernel/drivers/IO/sata.o kernel/drivers/IO/usb.o kernel/drivers/IO/usbkbd.o \
 	    kernel/drivers/IO/pci.o kernel/drivers/IO/pic.o \
-	    kernel/drivers/IO/pit.o \
-	    kernel/drivers/Net/netstack.o kernel/drivers/Net/e1000.o \
+            kernel/drivers/IO/pit.o \
+            kernel/VM/pmm.o kernel/VM/paging.o kernel/VM/cow.o kernel/VM/numa.o \
+            kernel/drivers/Net/netstack.o kernel/drivers/Net/e1000.o \
     user/libc/libc.o -o kernel.bin
 	cp kernel.bin n2.bin
 	$(CC) $(O2_CFLAGS) -static -nostdlib -pie kernel/O2.o -o O2.elf
@@ -76,9 +81,10 @@ clean:
 	    kernel/drivers/IO/ps2.o kernel/drivers/IO/keyboard.o \
 	    kernel/drivers/IO/mouse.o kernel/drivers/IO/serial.o \
 	    kernel/drivers/IO/video.o kernel/drivers/IO/tty.o \
-	    kernel/drivers/IO/block.o kernel/drivers/IO/sata.o kernel/drivers/IO/usb.o kernel/drivers/IO/usbkbd.o \
-	    kernel/drivers/IO/pci.o kernel/drivers/IO/pic.o kernel/drivers/IO/pit.o \
-	    kernel/drivers/Net/netstack.o kernel/drivers/Net/e1000.o
+            kernel/drivers/IO/block.o kernel/drivers/IO/sata.o kernel/drivers/IO/usb.o kernel/drivers/IO/usbkbd.o \
+            kernel/drivers/IO/pci.o kernel/drivers/IO/pic.o kernel/drivers/IO/pit.o \
+            kernel/VM/pmm.o kernel/VM/paging.o kernel/VM/cow.o kernel/VM/numa.o \
+            kernel/drivers/Net/netstack.o kernel/drivers/Net/e1000.o
 	make -C boot clean
 
 run: disk.img

--- a/kernel/VM/cow.c
+++ b/kernel/VM/cow.c
@@ -147,6 +147,6 @@ void handle_page_fault(uint64_t err, uint64_t addr) {
     }
 
     serial_puts("[cow] unhandled pfault: addr=0x");
-    // Optional: print the address as hex
+    serial_printf("%016lx\n", (uint64_t)addr);
     for(;;) __asm__("hlt");
 }


### PR DESCRIPTION
## Summary
- build virtual memory modules alongside kernel sources
- log full address for unhandled copy-on-write page faults

## Testing
- `make kernel`
- `make -C tests clean && make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_68958d81df6883338a8eca0558d3aedc