### PR TITLE
Ensure PMM accounts for partial pages

### DIFF
--- a/kernel/VM/pmm.c
+++ b/kernel/VM/pmm.c
@@ -73,7 +73,9 @@ void pmm_init(const bootinfo_t *bootinfo) {
         if (end > PMM_MAX_ADDR)
             end = PMM_MAX_ADDR;
         uint64_t s = start / PAGE_SIZE;
-        uint64_t e = end / PAGE_SIZE;
+        uint64_t e = (end + PAGE_SIZE - 1) / PAGE_SIZE;
+        if (e > total_frames)
+            e = total_frames;
         for (uint64_t f = s; f < e; ++f)
             bit_clear(f);
         free_frames += (e - s);


### PR DESCRIPTION
## Summary
- Include tail fragments of memory map entries when initializing the physical memory manager

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_b_68958f3287288333b8680f6993861220