### PR TITLE
Add guard for builtin agents and fix PMM test

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -100,13 +100,13 @@ void n2_main(bootinfo_t *bootinfo) {
     // dereferenced by load_agent. Guard against that by insisting the pointer
     // is non‑NULL and outside the low identity‑mapped area.
     if ((uintptr_t)nosfs_image > 0x1000 && nosfs_size > 0 &&
-        (uintptr_t)nosfs_image < 0x100000000ULL) {
+        (uintptr_t)nosfs_image + nosfs_size < 0x100000000ULL) {
         load_agent(nosfs_image, nosfs_size, AGENT_FORMAT_NOSM);
     } else {
         vprint("[N2] Builtin NOSFS image missing or invalid\r\n");
     }
     if ((uintptr_t)my_mach_agent_image > 0x1000 && my_mach_agent_size > 0 &&
-        (uintptr_t)my_mach_agent_image < 0x100000000ULL) {
+        (uintptr_t)my_mach_agent_image + my_mach_agent_size < 0x100000000ULL) {
         load_agent(my_mach_agent_image, my_mach_agent_size, AGENT_FORMAT_MACHO2);
     } else if ((uintptr_t)my_mach_agent_image || my_mach_agent_size) {
         vprint("[N2] Builtin Mach agent image missing or invalid\r\n");

--- a/tests/unit/test_pmm.c
+++ b/tests/unit/test_pmm.c
@@ -8,8 +8,9 @@
 #endif
 
 int main(void) {
+    static uint8_t region[4 * PAGE_SIZE];
     bootinfo_memory_t mmap[1] = {
-        { .addr = 512*PAGE_SIZE, .len = 4*PAGE_SIZE, .type = 7, .reserved = 0 }
+        { .addr = (uint64_t)(uintptr_t)region, .len = sizeof(region), .type = 7, .reserved = 0 }
     };
     bootinfo_t bi = {0};
     bi.mmap = mmap;


### PR DESCRIPTION
## Summary
- Avoid #GP by validating builtin agent image pointers before loading
- Back PMM unit test with in-process memory to prevent segfaults

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_68959b0e79888333a4055fbb4f260983