### PR TITLE
Handle null buffers in regx enumerate

### DIFF
--- a/kernel/regx.c
+++ b/kernel/regx.c
@@ -33,6 +33,9 @@ const regx_entry_t *regx_query(uint64_t id) {
 }
 
 size_t regx_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max) {
+    if (!out || max == 0)
+        return 0;
+
     size_t n = 0;
     const char *prefix = NULL;
     size_t prefix_len = 0;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
     -I../user/libc -I../kernel/drivers/IO -I../kernel/drivers/Audio \
     -I../kernel/drivers/Net -I../kernel/arch/GDT
 LIBC_SRC=../user/libc/libc.c thread_stub.c
-UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs
+UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx
 
 all: $(UNIT_TESTS)
 	for t in $(UNIT_TESTS); do ./$$t; done
@@ -37,6 +37,9 @@ test_nosfs: unit/test_nosfs.c ../user/agents/nosfs/nosfs.c \
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_nosm: unit/test_nosm.c ../kernel/nosm.c ../kernel/agent.c $(LIBC_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_regx: unit/test_regx.c ../kernel/regx.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
 clean:

--- a/tests/unit/test_regx.c
+++ b/tests/unit/test_regx.c
@@ -1,0 +1,23 @@
+#include "../../include/regx.h"
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+    regx_manifest_t m = {0};
+    snprintf(m.name, sizeof(m.name), "%s", "fs");
+    m.type = REGX_TYPE_FILESYSTEM;
+    assert(regx_register(&m, 0) != 0);
+
+    regx_selector_t sel = {0};
+    sel.type = REGX_TYPE_FILESYSTEM;
+
+    /* Ensure enumeration with NULL output is safe */
+    assert(regx_enumerate(&sel, NULL, 10) == 0);
+
+    /* Normal enumeration returns the entry */
+    regx_entry_t out[1];
+    size_t n = regx_enumerate(&sel, out, 1);
+    assert(n == 1);
+    assert(out[0].manifest.type == REGX_TYPE_FILESYSTEM);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Avoid null pointer dereferences in `regx_enumerate` by validating output buffer and size
- Add regression test covering enumeration with `NULL` buffer and include in test suite

## Testing
- `make` (in `tests`)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68959e9f51908333b66e71a973a57c6c