### PR TITLE
Remove debug logging from thread management

### DIFF
--- a/kernel/Task/thread.h
+++ b/kernel/Task/thread.h
@@ -34,7 +34,6 @@ typedef struct thread {
 
 extern thread_t *current_cpu[MAX_CPUS];
 
-static void utoa_dec(uint32_t val, char *buf);
 
 /**
  * Reset scheduler bookkeeping before interrupts might fire.


### PR DESCRIPTION
## Summary
- strip serial logging and unused helpers from kernel thread management code
- simplify thread scheduler and service threads to run without console noise
- drop unused utoa_dec prototype from thread API

## Testing
- `make kernel`

------
https://chatgpt.com/codex/tasks/task_b_6895f2bd98208333b339a64b3d1e25c2