### PR TITLE
Improve task subsystem primitives

### DIFF
--- a/kernel/Task/context_switch.asm
+++ b/kernel/Task/context_switch.asm
@@ -1,13 +1,14 @@
 global context_switch
 ; void context_switch(uint64_t *old_rsp, uint64_t new_rsp);
-; rdi = pointer to save old rsp
-; rsi = new rsp value
+;   rdi = pointer to save old rsp (may be NULL if caller doesn't care)
+;   rsi = new rsp value to load
 
 section .text
 context_switch:
-    push rax        ; Maintain 16-byte stack alignment
-    pushfq          ; Save flags
-    cli             ; Disable interrupts (if kernel context switch)
+    push rax        ; Maintain 16-byte alignment of the stack
+    pushfq          ; Save caller's rflags and disable interrupts while switching
+    cli
+    ; Save callee-saved registers as per System V ABI
     push rbp
     push rbx
     push r12
@@ -15,17 +16,23 @@ context_switch:
     push r14
     push r15
 
-    mov [rdi], rsp  ; Save current stack pointer
+    ; Store the old stack pointer if requested
+    test rdi, rdi
+    jz .Lnosave
+    mov [rdi], rsp
+.Lnosave:
 
-    mov rsp, rsi    ; Switch to new stack
+    ; Load the new stack pointer
+    mov rsp, rsi
 
+    ; Restore saved registers
     pop r15
     pop r14
     pop r13
     pop r12
     pop rbx
     pop rbp
-    popfq           ; Restore flags (including IF)
+    popfq           ; Restore rflags (including IF)
     pop rax         ; Discard alignment placeholder
 
     ret

--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -180,6 +180,37 @@ void thread_kill(thread_t *t) {
     add_to_zombie_list(t);
 }
 
+void thread_set_priority(thread_t *t, int priority) {
+    if (!t || t->magic != THREAD_MAGIC)
+        return;
+
+    if (priority < MIN_PRIORITY) priority = MIN_PRIORITY;
+    if (priority > MAX_PRIORITY) priority = MAX_PRIORITY;
+
+    int old = t->priority;
+    t->priority = priority;
+
+    thread_t *cur = thread_current();
+    /*
+     * If we boosted another thread above the current thread's priority,
+     * or lowered the current thread, invoke the scheduler to give other
+     * runnable threads a chance.
+     */
+    if ((t != cur && t->priority > cur->priority && t->state == THREAD_READY) ||
+        (t == cur && priority < old)) {
+        schedule();
+    }
+}
+
+void thread_join(thread_t *t) {
+    if (!t || t->magic != THREAD_MAGIC)
+        return;
+
+    while (thread_is_alive(t)) {
+        thread_yield();
+    }
+}
+
 void thread_yield(void) {
     schedule();
 }

--- a/kernel/Task/thread.h
+++ b/kernel/Task/thread.h
@@ -87,6 +87,18 @@ int thread_is_alive(thread_t *t);
 void thread_kill(thread_t *t);
 
 /**
+ * Adjust the priority of a thread. Priority is clamped to the valid range
+ * and the scheduler is invoked if the change should cause pre-emption.
+ */
+void thread_set_priority(thread_t *t, int priority);
+
+/**
+ * Block until the supplied thread has exited. This simple join primitive
+ * is cooperative and repeatedly yields the processor while waiting.
+ */
+void thread_join(thread_t *t);
+
+/**
  * Yield CPU to next ready thread (cooperative scheduling).
  */
 void thread_yield(void);

--- a/kernel/Task/user_mode.asm
+++ b/kernel/Task/user_mode.asm
@@ -28,16 +28,10 @@ enter_user_mode:
     ; Prepare iretq frame: SS, RSP, RFLAGS, CS, RIP (in that order, bottom to top)
     push GDT_SEL_USER_DATA_R3  ; User SS
     push rax                   ; User RSP
-    pushfq                     ; RFLAGS (current flags, but be sure IF=1)
+    mov  rdx, 0x202            ; RFLAGS with IF set
+    push rdx                   ; User RFLAGS
     push GDT_SEL_USER_CODE_R3  ; User CS
     push rcx                   ; User RIP
-
-    ; Double-check: ensure IF=1 (interrupts enabled) in RFLAGS
-    ; This is optional, but safest if you want user code to see interrupts
-    ; (Uncomment if needed:)
-    ; pop rdx
-    ; or  rdx, 0x200      ; Set IF
-    ; push rdx
 
     ; Far return to user mode, privilege transition!
     iretq


### PR DESCRIPTION
## Summary
- add thread priority tuning and join helper
- harden context switch to optionally skip saving
- ensure user-mode entry enables interrupts

## Testing
- `make kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_6896b604dc64833386dc2d4df47d8451