### PR TITLE
Enable SSE setup before N2 kernel starts

### DIFF
--- a/kernel/n2_entry.asm
+++ b/kernel/n2_entry.asm
@@ -6,8 +6,15 @@ extern n2_main
 
 _start:
     cld
-    ; Bootloader passes bootinfo in RDI (SysV x86_64 ABI),
-    ; so it's already in the correct register for n2_main.
+    ; Enable SSE/FXSR before any C code runs
+    mov rax, cr0
+    and eax, 0xFFFFFFFB  ; clear EM
+    or  eax, 0x2         ; set MP
+    mov cr0, rax
+    mov rax, cr4
+    or  eax, 0x600       ; set OSFXSR | OSXMMEXCPT
+    mov cr4, rax
+    ; Bootloader passes bootinfo in RDI (SysV x86_64 ABI)
     xor rbp, rbp
     call n2_main
 


### PR DESCRIPTION
## Summary
- configure SSE/FXSR in early assembly startup before handing control to the C kernel
- revert IPC receive memcpy experiment that caused regressions

## Testing
- `make -C tests`
- `qemu-system-x86_64 -bios /usr/share/ovmf/OVMF.fd -drive file=disk.img,format=raw -m 512M -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -serial stdio -display none -no-reboot -no-shutdown` *(fails: X64 Exception Type - 06 (#UD - Invalid Opcode))*

------
https://chatgpt.com/codex/tasks/task_b_6896cd52cdec8333adb2acbb37184ebb