### PR TITLE
Initialize bootstrap thread stack pointer

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -131,6 +131,10 @@ void threads_early_init(void) {
     main_thread.priority = MIN_PRIORITY;
     main_thread.next     = &main_thread;
 
+    uint64_t rsp;
+    __asm__ volatile("mov %%rsp, %0" : "=r"(rsp));
+    main_thread.rsp = rsp;
+
     current_cpu[0] = &main_thread;
     tail_cpu[0]    = &main_thread;
 }


### PR DESCRIPTION
## Summary
- Initialize the bootstrap "main" thread's stack pointer so the scheduler never switches to a zero RSP, preventing invalid-opcode faults during early boot.

## Testing
- `make -C tests`
- `./test_regx`
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_6896eb97ca948333acf0f778a825ab5b