### PR TITLE
refactor: begin agent architecture migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,9 @@ O2_CFLAGS := $(filter-out -no-pie,$(CFLAGS)) -fpie
 all: libc kernel boot disk.img
 
 # ===== Standalone Agents on Disk =====
-AGENT_DIRS_ALL := $(filter-out user/agents/login,$(wildcard user/agents/*))
-# Exclude agents that are kernel-linked or need IPC/net shims
-AGENT_DIRS_EXCL := user/agents/nosm user/agents/nosfs user/agents/audio user/agents/cp user/agents/ftp user/agents/nosfsctl
-AGENT_DIRS := $(filter-out $(AGENT_DIRS_EXCL),$(AGENT_DIRS_ALL))
-AGENT_DIRS_NONEMPTY := $(foreach d,$(AGENT_DIRS),$(if $(wildcard $(d)/*.c),$(d),))
-AGENT_NAMES := $(notdir $(AGENT_DIRS_NONEMPTY))
+AGENT_DIRS := user/agents/login
+AGENT_DIRS_NONEMPTY := $(AGENT_DIRS)
+AGENT_NAMES := $(notdir $(AGENT_DIRS))
 AGENT_ELFS  := $(foreach n,$(AGENT_NAMES),out/agents/$(n).elf)
 AGENT_BINS  := $(foreach n,$(AGENT_NAMES),out/agents/$(n).bin)
 AGENT_C_SRCS := $(foreach d,$(AGENT_DIRS_NONEMPTY),$(wildcard $(d)/*.c))

--- a/bin/cp.c
+++ b/bin/cp.c
@@ -1,18 +1,24 @@
-#include "cp.h"
-#include "../../../kernel/drivers/IO/serial.h"
-#include "../../libc/libc.h"
-#include "../../../kernel/IPC/ipc.h"
+#include "../user/libc/libc.h"
 
-void cp_main(ipc_queue_t *q, uint32_t self_id) {
-    (void)q; (void)self_id;
+// Minimal copy implementation using project libc only.
+int main(void) {
     FILE *src = fopen("src", "r");
-    if (!src) { serial_puts("cp: src not found\n"); return; }
+    if (!src) return 1;
+
     FILE *dst = fopen("dst", "w");
-    if (!dst) { serial_puts("cp: dst create fail\n"); fclose(src); return; }
-    unsigned char buf[IPC_MSG_DATA_MAX];
-    size_t n = fread(buf, 1, sizeof(buf), src);
-    if (n > 0) fwrite(buf, 1, n, dst);
+    if (!dst) {
+        fclose(src);
+        return 1;
+    }
+
+    unsigned char buf[512];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), src)) > 0) {
+        fwrite(buf, 1, n, dst);
+    }
+
     fclose(src);
     fclose(dst);
-    serial_puts("cp: done\n");
+    return 0;
 }
+

--- a/bin/cp.h
+++ b/bin/cp.h
@@ -1,3 +1,0 @@
-#pragma once
-#include "../../../kernel/IPC/ipc.h"
-void cp_main(ipc_queue_t *q, uint32_t self_id);

--- a/bin/grep.c
+++ b/bin/grep.c
@@ -1,17 +1,16 @@
-#include "grep.h"
-#include "../../../kernel/drivers/IO/serial.h"
-#include "../../libc/libc.h"
-#include "../../../kernel/IPC/ipc.h"
+#include "../user/libc/libc.h"
 
-void grep_main(ipc_queue_t *q, uint32_t self_id) {
-    (void)q; (void)self_id;
+// Simple grep-like tool: returns 0 if pattern is found in file "src".
+int main(void) {
     const char *pattern = "foo";
     FILE *f = fopen("src", "r");
-    if (!f) { serial_puts("grep: file not found\n"); return; }
-    char buf[IPC_MSG_DATA_MAX + 1];
-    size_t n = fread(buf, 1, IPC_MSG_DATA_MAX, f);
+    if (!f) return 1;
+
+    char buf[512];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
     buf[n] = '\0';
-    if (strstr(buf, pattern))
-        serial_puts(buf);
     fclose(f);
+
+    return strstr(buf, pattern) ? 0 : 1;
 }
+

--- a/bin/grep.h
+++ b/bin/grep.h
@@ -1,3 +1,0 @@
-#pragma once
-#include "../../../kernel/IPC/ipc.h"
-void grep_main(ipc_queue_t *q, uint32_t self_id);

--- a/bin/mv.c
+++ b/bin/mv.c
@@ -1,12 +1,7 @@
-#include "mv.h"
-#include "../../../kernel/drivers/IO/serial.h"
-#include "../../libc/libc.h"
-#include "../../../kernel/IPC/ipc.h"
+#include "../user/libc/libc.h"
 
-void mv_main(ipc_queue_t *q, uint32_t self_id) {
-    (void)q; (void)self_id;
-    if (rename("src", "dst") != 0)
-        serial_puts("mv: rename failed\n");
-    else
-        serial_puts("mv: done\n");
+// Rename "src" to "dst" using project libc only.
+int main(void) {
+    return rename("src", "dst");
 }
+

--- a/bin/mv.h
+++ b/bin/mv.h
@@ -1,3 +1,0 @@
-#pragma once
-#include "../../../kernel/IPC/ipc.h"
-void mv_main(ipc_queue_t *q, uint32_t self_id);

--- a/user/agents/login/agent_entry.c
+++ b/user/agents/login/agent_entry.c
@@ -1,0 +1,24 @@
+#include "../../libc/libc.h"
+#include "../../../kernel/IPC/ipc.h"
+#include "login.h"
+
+// Real entry implemented in login.c
+void login_server(ipc_queue_t *fs_q, uint32_t self_id);
+void thread_yield(void);
+
+// Manifest describing this agent
+__attribute__((section("__O2INFO,__manifest")))
+static const char mo2_manifest[] =
+"{\n"
+"  \"name\": \"login\",\n"
+"  \"type\": \"service\",\n"
+"  \"version\": \"1.0.0\",\n"
+"  \"entry\": \"agent_main\"\n"
+"}\n";
+
+// Single entry point expected by the loader
+void agent_main(void) {
+    login_server(NULL, 0);
+    for (;;) thread_yield();
+}
+

--- a/user/agents/login/login.h
+++ b/user/agents/login/login.h
@@ -1,7 +1,7 @@
 #ifndef LOGIN_H
 #define LOGIN_H
 
-#include <stdint.h>
+#include "../../libc/libc.h"
 #include "../../../kernel/IPC/ipc.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- start migrating to freestanding agent architecture by wiring Makefile to build the login agent separately
- convert cp/grep/mv to standalone user binaries using project libc only
- add login agent entry shim and manifest, dropping system headers

## Testing
- `make agents`
- `make bins` (fails: undefined reference to fopen/fwrite etc.)

------
https://chatgpt.com/codex/tasks/task_b_68971370a6708333bea119c877a96f80