### PR TITLE
Fix disk image rule indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,13 +149,13 @@ disk.img: boot kernel agents bins modules
 	mmd -i disk.img ::/EFI/BOOT
 	mcopy -i disk.img boot/nboot.efi ::/EFI/BOOT/BOOTX64.EFI
 	mcopy -i disk.img O2.bin ::/
-        mcopy -i disk.img n2.bin ::/
-        mmd -i disk.img ::/agents || true
+	mcopy -i disk.img n2.bin ::/
+	mmd -i disk.img ::/agents || true
 	$(foreach b,$(AGENT_BINS), mcopy -i disk.img $(b) ::/agents/$(notdir $(b));)
-        mmd -i disk.img ::/bin || true
+	mmd -i disk.img ::/bin || true
 	$(foreach b,$(BIN_BINS), mcopy -i disk.img $(b) ::/bin/$(notdir $(b));)
-        mmd -i disk.img ::/modules || true
-        mcopy -i disk.img out/modules/hello.mo2 ::/modules/hello.mo2
+	mmd -i disk.img ::/modules || true
+	mcopy -i disk.img out/modules/hello.mo2 ::/modules/hello.mo2
 
 # ===== utility =====
 clean:


### PR DESCRIPTION
## Summary
- Fix disk image rule indentation so make no longer interprets recipe lines as targets

## Testing
- `make disk.img` *(fails: clang: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68971ddfca188333b0d42d933d2c427d