### PR TITLE
Fix module build warnings and add printf stub

### DIFF
--- a/include/printf.h
+++ b/include/printf.h
@@ -1,0 +1,2 @@
+#pragma once
+int printf(const char *fmt, ...);

--- a/nosm/drivers/example/hello/hello_nmod.c
+++ b/nosm/drivers/example/hello/hello_nmod.c
@@ -4,6 +4,8 @@
 static uint32_t g_mod_id;
 static uint64_t g_caps;
 
+__attribute__((used)) void _start(void) {}
+
 static int hello_init(const nosm_env_t *env) {
     g_mod_id = env->mod_id;
     g_caps   = env->caps;
@@ -22,7 +24,7 @@ static void hello_fini(void) {
 static void hello_suspend(void) { /* quiesce hardware */ }
 static void hello_resume(void)  { /* resume */ }
 
-__attribute__((section("__O2INFO,__manifest")))
+__attribute__((used, section("\"__O2INFO,__manifest\"")))
 static const char manifest[] =
 "{\n"
 "  \"name\":\"hello.nmod\",\n"

--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -11,7 +11,7 @@
 #include <stddef.h>
 
 /* Optional embedded manifest for Mach-O2 discovery (won’t be referenced in code) */
-__attribute__((section("__O2INFO,__manifest")))
+__attribute__((used, section("\"__O2INFO,__manifest\"")))
 static const char mo2_manifest[] =
 "{\n"
 "  \"name\": \"init\",\n"

--- a/user/agents/login/agent_entry.c
+++ b/user/agents/login/agent_entry.c
@@ -7,7 +7,7 @@ void login_server(ipc_queue_t *fs_q, uint32_t self_id);
 void thread_yield(void);
 
 // Manifest describing this agent
-__attribute__((section("__O2INFO,__manifest")))
+__attribute__((used, section("\"__O2INFO,__manifest\"")))
 static const char mo2_manifest[] =
 "{\n"
 "  \"name\": \"login\",\n"

--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -158,7 +158,7 @@ void login_server(ipc_queue_t *fs_q, uint32_t self_id)
             current_session.session_id++;
             current_session.active = 1;
             /* write username safely */
-            strlcpy(current_session.username, hit->u, sizeof(current_session.username));
+            strlcpy((char*)current_session.username, hit->u, sizeof(current_session.username));
             break;
         } else {
             puts_out("Login failed\n\n");

--- a/user/libc/libc.c
+++ b/user/libc/libc.c
@@ -1,4 +1,5 @@
 #include "libc.h"
+#include "printf.h"
 #include <stdint.h>
 #include <stddef.h>
 #include <time.h>
@@ -504,5 +505,13 @@ int fseek(FILE *stream, long offset, int whence) {
         return -1;
     long ret = syscall3(SYS_LSEEK, stream->fd, offset, whence);
     return ret < 0 ? -1 : 0;
+}
+
+__attribute__((weak)) int printf(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    va_end(ap);
+    (void)fmt;
+    return 0;
 }
 

--- a/user/rt/rt0_user.S
+++ b/user/rt/rt0_user.S
@@ -8,3 +8,5 @@ _start:
 .hang:
     hlt
     jmp .hang
+
+section .note.GNU-stack noalloc


### PR DESCRIPTION
## Summary
- Add minimal `printf` declaration and weak stub implementation
- Mark embedded manifests as used to silence linker and compiler warnings
- Provide module `_start` stub and GNU-stack note to fix build diagnostics

## Testing
- `make kernel modules bins`

------
https://chatgpt.com/codex/tasks/task_b_689726a344b08333b973a1348409f5f8