### PR TITLE
Use real serial driver for N2 boot output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ kernel: libc agents bins
 	$(CC) $(CFLAGS) -c kernel/IPC/ipc.c -o kernel/IPC/ipc.o
 	$(CC) $(CFLAGS) -c kernel/Task/thread.c -o kernel/Task/thread.o
 	$(CC) $(CFLAGS) -c kernel/stubs.c -o kernel/stubs.o
+	$(CC) $(CFLAGS) -c nosm/drivers/IO/serial.c -o nosm/drivers/IO/serial.o
 	
 	# Linked-in security gate + core agents:
 	$(CC) $(CFLAGS) -c src/agents/regx/regx.c   -o src/agents/regx/regx.o
@@ -127,7 +128,7 @@ kernel: libc agents bins
 
 	$(LD) -T kernel/n2.ld kernel/n2_entry.o kernel/n2_main.o kernel/builtin_nosfs.o \
 	    kernel/agent.o kernel/agent_loader.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/Task/context_switch.o kernel/arch/CPU/smp.o kernel/arch/CPU/lapic.o kernel/macho2.o kernel/printf.o kernel/nosm.o \
-            kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o kernel/VM/kheap.o kernel/stubs.o \
+            kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o kernel/VM/kheap.o nosm/drivers/IO/serial.o kernel/stubs.o \
     src/agents/regx/regx.o user/agents/nosfs/nosfs.o \
     user/libc/libc.o -o kernel.bin
 
@@ -167,7 +168,7 @@ clean:
             $(AGENT_OBJS) $(AGENT_ELFS) $(AGENT_BINS) $(BIN_OBJS) $(BIN_ELFS) $(BIN_BINS) \
             src/agents/regx/regx.o user/agents/nosfs/nosfs.o \
             user/rt/rt0_user.o user/rt/rt0_agent.o \
-            nosm/drivers/example/hello/hello_nmod.o out/modules/hello.elf out/modules/hello.mo2
+            nosm/drivers/IO/serial.o nosm/drivers/example/hello/hello_nmod.o out/modules/hello.elf out/modules/hello.mo2
 	rm -rf out
 	make -C boot clean
 

--- a/kernel/stubs.c
+++ b/kernel/stubs.c
@@ -4,14 +4,6 @@
 
 typedef struct ipc_queue ipc_queue_t;
 
-void serial_init(void) {}
-void serial_write(char c) { (void)c; }
-void serial_puts(const char *s) { (void)s; }
-void serial_puthex(uint32_t v) { (void)v; }
-void serial_vprintf(const char *fmt, va_list ap) { (void)fmt; (void)ap; }
-void serial_printf(const char *fmt, ...) { (void)fmt; }
-int  serial_read(void) { return -1; }
-
 void usb_init(void) {}
 void usb_kbd_init(void) {}
 void video_init(const void *fb) { (void)fb; }


### PR DESCRIPTION
## Summary
- Remove serial stubs so the kernel can use the real serial driver.
- Compile and link the nosm serial driver into the kernel build and clean targets.

## Testing
- `make disk.img`
- `timeout 10 qemu-system-x86_64 -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd -drive if=pflash,format=raw,file=OVMF_VARS.fd -drive file=disk.img,format=raw -m 512M -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -serial stdio -display none`


------
https://chatgpt.com/codex/tasks/task_b_6897295cf1008333878c60befeb14c96