### PR TITLE
Implement serial-based kprintf to enable kernel agent logging

### DIFF
--- a/include/printf.h
+++ b/include/printf.h
@@ -1,2 +1,3 @@
 #pragma once
 int printf(const char *fmt, ...);
+int kprintf(const char *fmt, ...);

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -9,3 +9,11 @@ int printf(const char *fmt, ...) {
     return 0;
 }
 
+int kprintf(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    serial_vprintf(fmt, ap);
+    va_end(ap);
+    return 0;
+}
+

--- a/kernel/stubs.c
+++ b/kernel/stubs.c
@@ -20,5 +20,3 @@ int fs_read_all(const char *path, void **out, size_t *out_sz) { (void)path; if(o
 
 void nosfs_server(ipc_queue_t *q, uint32_t self_id) { (void)q; (void)self_id; }
 void nosm_entry(void) {}
-
-int kprintf(const char *fmt, ...) { (void)fmt; return 0; }


### PR DESCRIPTION
## Summary
- Add real `kprintf` implementation backed by the serial driver so kernel agents can emit logs
- Remove no-op `kprintf` stub and expose prototype in `printf.h`

## Testing
- `make kernel`
- `for t in tests/test_*; do timeout 5 $t; done`


------
https://chatgpt.com/codex/tasks/task_b_68972c67ffa08333a228d25758c73507