### PR TITLE
Fix serial vprintf size_t support

### DIFF
--- a/nosm/drivers/IO/serial.c
+++ b/nosm/drivers/IO/serial.c
@@ -96,7 +96,7 @@ void serial_vprintf(const char *fmt, va_list ap) {
         }
 
         int long_flag = 0;
-        if (*p == 'l') {
+        if (*p == 'l' || *p == 'z') {
             long_flag = 1;
             ++p;
         }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,7 +4,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
     -I../user/agents/nosfs -I../user/agents/login -I../user/agents/ftp \
     -I../user/libc -I../nosm/drivers/IO -I../nosm/drivers/Audio \
     -I../nosm/drivers/Net -I../kernel/arch/GDT
-LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c
+LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c
 UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx
 
 all: $(UNIT_TESTS)

--- a/tests/kprintf_stub.c
+++ b/tests/kprintf_stub.c
@@ -1,0 +1,5 @@
+#include <stdarg.h>
+int kprintf(const char *fmt, ...) {
+    (void)fmt;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Handle `%z` length modifier in serial_vprintf so size_t formatting doesn't corrupt varargs
- Add kprintf stub to tests to support building unit tests

## Testing
- `for t in test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx; do make $t >/tmp/${t}_build.log && printf '\n' | timeout 5s ./$t >/tmp/${t}_run.log && tail -n 5 /tmp/${t}_run.log; done`

------
https://chatgpt.com/codex/tasks/task_b_6897fc6897c88333888cd9b96244c657