### PR TITLE
Harden user pointer access and add diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ kernel: libc agents bins
 	$(CC) $(CFLAGS) -c kernel/agent.c -o kernel/agent.o
 	$(CC) $(CFLAGS) -c kernel/agent_loader.c -o kernel/agent_loader.o
 	$(CC) $(CFLAGS) -c kernel/regx.c -o kernel/regx.o
+	$(CC) $(CFLAGS) -c kernel/trap.c -o kernel/trap.o
+	$(CC) $(CFLAGS) -c kernel/uaccess.c -o kernel/uaccess.o
+	$(CC) $(CFLAGS) -c kernel/proc_launch.c -o kernel/proc_launch.o
 	$(CC) $(CFLAGS) -c kernel/IPC/ipc.c -o kernel/IPC/ipc.o
 	$(CC) $(CFLAGS) -c kernel/Task/thread.c -o kernel/Task/thread.o
 	$(CC) $(CFLAGS) -c kernel/stubs.c -o kernel/stubs.o
@@ -128,9 +131,9 @@ kernel: libc agents bins
 
 	$(LD) -T kernel/n2.ld kernel/n2_entry.o kernel/n2_main.o kernel/builtin_nosfs.o \
 	    kernel/agent.o kernel/agent_loader.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/Task/context_switch.o kernel/arch/CPU/smp.o kernel/arch/CPU/lapic.o kernel/macho2.o kernel/printf.o kernel/nosm.o \
-            kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o kernel/VM/kheap.o nosm/drivers/IO/serial.o kernel/stubs.o \
-    src/agents/regx/regx.o user/agents/nosfs/nosfs.o \
-    user/libc/libc.o -o kernel.bin
+	kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o kernel/VM/kheap.o kernel/uaccess.o kernel/proc_launch.o kernel/trap.o nosm/drivers/IO/serial.o kernel/stubs.o \
+	src/agents/regx/regx.o user/agents/nosfs/nosfs.o \
+	user/libc/libc.o -o kernel.bin
 
 	cp kernel.bin n2.bin
 
@@ -164,7 +167,7 @@ clean:
 	rm -f kernel/n2_entry.o kernel/Task/context_switch.o kernel/n2_main.o kernel/builtin_nosfs.o kernel/agent.o \
             kernel/nosm.o kernel/agent_loader.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/stubs.o kernel/arch/CPU/smp.o kernel/arch/CPU/lapic.o \
             kernel/macho2.o kernel/printf.o kernel.bin n2.bin O2.elf O2.bin user/libc/libc.o disk.img \
-            kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o kernel/VM/kheap.o \
+            kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o kernel/VM/kheap.o kernel/uaccess.o kernel/proc_launch.o kernel/trap.o \
             $(AGENT_OBJS) $(AGENT_ELFS) $(AGENT_BINS) $(BIN_OBJS) $(BIN_ELFS) $(BIN_BINS) \
             src/agents/regx/regx.o user/agents/nosfs/nosfs.o \
             user/rt/rt0_user.o user/rt/rt0_agent.o \

--- a/include/abi.h
+++ b/include/abi.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+
+typedef struct {
+    int32_t  op;
+    int32_t  _pad0;
+    uint64_t buffer;
+    uint64_t length;
+} ipc_msg_t;
+
+_Static_assert(sizeof(ipc_msg_t) == 24, "ipc_msg_t size must be 24 bytes LP64");

--- a/include/abi_sanitize.h
+++ b/include/abi_sanitize.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "uaccess.h"
+#include "abi.h"
+
+static inline int abi_get_user_ptr_u64(const uint64_t raw, uintptr_t *out) {
+    uintptr_t p = (uintptr_t)raw;
+    if (!is_user_addr(p)) return -14;
+    *out = p;
+    return 0;
+}

--- a/include/uaccess.h
+++ b/include/uaccess.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#define USER_TOP   0x00007FFFFFFFFFFFULL
+#define HIGH_MASK  0xFFFF000000000000ULL
+
+static inline bool is_canonical_u64(uint64_t x) {
+    uint64_t top = x >> 48;
+    return (top == 0x0000ULL) || (top == 0xFFFFULL);
+}
+
+static inline bool is_user_addr(uint64_t x) {
+    return is_canonical_u64(x) && x <= USER_TOP;
+}
+
+static inline bool range_add_ok(uint64_t a, size_t n) {
+    if (n == 0) return true;
+    uint64_t end = a + (n - 1U);
+    return end >= a; /* no wrap */
+}
+
+__attribute__((weak))
+bool range_is_mapped_user(uint64_t start, size_t len) {
+    (void)start; (void)len;
+    return true;
+}
+
+#define CANONICAL_GUARD(p) do { \
+    uintptr_t __p = (uintptr_t)(p); \
+    if ((__p & HIGH_MASK) == HIGH_MASK && __p <= 0xFFFFFFFFFFFFFFFFULL) { \
+        __kernel_panic_noncanonical(__p, __FILE__, __LINE__); \
+    } \
+} while (0)
+
+void __kernel_panic_noncanonical(uint64_t addr, const char* file, int line);
+
+int copy_from_user(void *dst, const void *user_src, size_t n);
+int copy_to_user(void *user_dst, const void *src, size_t n);

--- a/kernel/IPC/ipc.c
+++ b/kernel/IPC/ipc.c
@@ -211,10 +211,10 @@ int ipc_peek_type(ipc_queue_t *q) {
 #ifdef IPC_SMP
     size_t head = load_head(q), tail = load_tail(q);
     if (head == tail) return -1;
-    return q->msgs[tail].type;
+    return (int)q->msgs[tail].type;
 #else
     if (q->tail == q->head) return -1;
-    return q->msgs[q->tail].type;
+    return (int)q->msgs[q->tail].type;
 #endif
 }
 

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -18,6 +18,7 @@
 #include "VM/pmm_buddy.h"
 #include "VM/kheap.h"
 #include "arch/CPU/lapic.h"
+#include "uaccess.h"
 
 // ... (previous kprint, strcspn_local, syscall infrastructure, sandboxing, module loading helpers, hardware/system query helpers, scheduler_loop, etc unchanged) ...
 
@@ -49,8 +50,14 @@ void n2_main(bootinfo_t *bootinfo) {
     vprint("\r\n[N2] NitrOS agent kernel booting...\r\n");
     vprint("[N2] Booted by: ");
     const char *bl = bootinfo->bootloader_name;
-    if (bl && ((uintptr_t)bl < 0x100000000ULL)) {
-        vprint(bl);
+    if (bl) {
+        uintptr_t p = (uintptr_t)bl;
+        if (is_user_addr(p)) {
+            CANONICAL_GUARD(p);
+            vprint((const char *)p);
+        } else {
+            vprint("unknown");
+        }
     } else {
         vprint("unknown");
     }

--- a/kernel/proc_launch.c
+++ b/kernel/proc_launch.c
@@ -1,0 +1,30 @@
+#include "uaccess.h"
+#include "abi_sanitize.h"
+#include "abi.h"
+
+__attribute__((weak))
+int create_user_process(uintptr_t entry, uintptr_t user_stack_top,
+                        const char* const *argv, const char* const *envp) {
+    (void)entry; (void)user_stack_top; (void)argv; (void)envp; return -1;
+}
+extern void kprintf(const char *fmt, ...);
+
+int launch_init_from_registry(const ipc_msg_t *msg) {
+    uintptr_t entry = 0;
+    int rc = abi_get_user_ptr_u64(msg->buffer, &entry);
+    if (rc) {
+        kprintf("[regx] bad entry ptr 0x%llx\n", (unsigned long long)msg->buffer);
+        return rc;
+    }
+    CANONICAL_GUARD(entry);
+    return create_user_process(entry, 0, NULL, NULL);
+}
+
+int copy_args_to_user(uintptr_t user_sp, const char *src, size_t len) {
+    if (!range_add_ok(user_sp, len) || !is_user_addr(user_sp) ||
+        !range_is_mapped_user(user_sp, len)) {
+        return -14;
+    }
+    CANONICAL_GUARD(user_sp);
+    return copy_to_user((void*)user_sp, src, len);
+}

--- a/kernel/regx.c
+++ b/kernel/regx.c
@@ -1,6 +1,7 @@
 #include <regx.h>
 #include <string.h>
 #include "Task/thread.h"
+#include "uaccess.h"
 
 extern int kprintf(const char *fmt, ...);
 
@@ -41,6 +42,7 @@ static size_t regx_count = 0;
 static uint64_t regx_next_id = 1;
 
 uint64_t regx_register(const regx_manifest_t *m, uint64_t parent_id) {
+    CANONICAL_GUARD(m);
     lock_acquire("registry");
     if (regx_count >= REGX_MAX_ENTRIES) {
         lock_release("registry");
@@ -82,6 +84,8 @@ const regx_entry_t *regx_query(uint64_t id) {
 }
 
 size_t regx_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max) {
+    CANONICAL_GUARD(sel);
+    CANONICAL_GUARD(out);
     if (!out || max == 0)
         return 0;
 

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+#include "uaccess.h"
+
+extern void kprintf(const char *fmt, ...);
+
+typedef struct {
+    uint64_t rip, cs, rflags, rsp, ss;
+    uint64_t rax, rbx, rcx, rdx, rsi, rdi, rbp, r8, r9, r10, r11, r12, r13, r14, r15;
+    uint64_t err;
+} regs_t;
+
+static inline uint64_t read_cr2(void) {
+    uint64_t v;
+    __asm__ __volatile__("mov %%cr2,%0" : "=r"(v));
+    return v;
+}
+
+void isr_page_fault(regs_t* r) {
+    uint64_t cr2 = read_cr2();
+    kprintf("!!!! #PF err=%llx CR2=%016llx RIP=%016llx CS=%04llx RFLAGS=%016llx\n",
+            (unsigned long long)r->err, (unsigned long long)cr2,
+            (unsigned long long)r->rip, (unsigned long long)r->cs,
+            (unsigned long long)r->rflags);
+    if (!is_canonical_u64(cr2)) {
+        kprintf("[pf] NON-CANONICAL CR2 — likely sign-extended 32-bit pointer\n");
+    }
+}

--- a/kernel/uaccess.c
+++ b/kernel/uaccess.c
@@ -1,0 +1,49 @@
+#include "uaccess.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+extern void *memcpy(void *dst, const void *src, size_t n);
+extern void *memset(void *dst, int c, size_t n);
+extern void kprintf(const char *fmt, ...);
+
+int copy_from_user(void *dst, const void *user_src, size_t n) {
+    uintptr_t a = (uintptr_t)user_src;
+    if (!range_add_ok(a, n) || !is_user_addr(a) || !range_is_mapped_user(a, n)) {
+        return -14; /* -EFAULT */
+    }
+    memcpy(dst, (const void *)a, n);
+    return 0;
+}
+
+int copy_to_user(void *user_dst, const void *src, size_t n) {
+    uintptr_t a = (uintptr_t)user_dst;
+    if (!range_add_ok(a, n) || !is_user_addr(a) || !range_is_mapped_user(a, n)) {
+        return -14; /* -EFAULT */
+    }
+    memcpy((void *)a, src, n);
+    return 0;
+}
+
+void __kernel_panic_noncanonical(uint64_t addr, const char* file, int line) {
+    kprintf("[uaccess] NON-CANONICAL PTR: 0x%016llx at %s:%d\n",
+            (unsigned long long)addr, file, line);
+    for (;;) {
+        __asm__ __volatile__("cli; hlt");
+    }
+}
+
+#ifdef UACCESS_SELFTEST
+void uaccess_selftest(void) {
+    char buf[4];
+    int rc;
+    rc = copy_from_user(buf, (const void*)0x1000, sizeof(buf));
+    kprintf("[selftest] low rc=%d\n", rc);
+    rc = copy_from_user(buf, (const void*)(USER_TOP + 1ULL), sizeof(buf));
+    kprintf("[selftest] past_top rc=%d\n", rc);
+    rc = copy_from_user(buf, (const void*)0xFFFF000000000000ULL, sizeof(buf));
+    kprintf("[selftest] noncanon rc=%d\n", rc);
+    bool ok = range_add_ok(UINT64_MAX - 1ULL, 4U);
+    kprintf("[selftest] wrap_ok=%d\n", ok ? 1 : 0);
+}
+#endif


### PR DESCRIPTION
## Summary
- add `uaccess` helpers to validate user addresses and copy memory safely
- sanitize ABI pointer fields and use guards when launching init or enumerating registry
- log page faults with CR2 canonical checks and wire new sources into build

## Testing
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_6898097a5ffc8333b85e9b2d4a9b9ea3