### PR TITLE
Fix unit tests and allow login server exit during tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,7 +4,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
     -I../user/agents/nosfs -I../user/agents/login -I../user/agents/ftp \
     -I../user/libc -I../nosm/drivers/IO -I../nosm/drivers/Audio \
     -I../nosm/drivers/Net -I../kernel/arch/GDT
-LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c
+LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c uaccess_stub.c
 UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx
 
 all: $(UNIT_TESTS)
@@ -17,11 +17,11 @@ test_pmm: unit/test_pmm.c ../kernel/VM/pmm_buddy.c ../kernel/VM/numa.c $(LIBC_SR
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_login: unit/test_login.c ../user/agents/login/login.c $(LIBC_SRC) ../kernel/IPC/ipc.c ../kernel/agent.c
-	$(CC) $(CFLAGS) $^ -o $@
+	$(CC) $(CFLAGS) -DLOGIN_UNIT_TEST $^ -o $@
 
 test_login_keyboard: unit/test_login_keyboard.c ../user/agents/login/login.c \
 ../nosm/drivers/IO/tty.c $(LIBC_SRC) ../kernel/IPC/ipc.c ../kernel/agent.c
-	$(CC) $(CFLAGS) $^ -o $@
+	$(CC) $(CFLAGS) -DLOGIN_UNIT_TEST $^ -o $@
 
 test_ftp: unit/test_ftp.c ../user/agents/ftp/ftp.c ../kernel/IPC/ipc.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@

--- a/tests/uaccess_stub.c
+++ b/tests/uaccess_stub.c
@@ -1,0 +1,4 @@
+#include <stdint.h>
+void __kernel_panic_noncanonical(uint64_t addr, const char* file, int line) {
+    (void)addr; (void)file; (void)line;
+}

--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -169,6 +169,8 @@ void login_server(ipc_queue_t *fs_q, uint32_t self_id)
     /* Launch NitroShell; pass NULL queues for now (keep ABI stable). */
     nsh_main(NULL, NULL, NULL, self_id);
 
-    /* nsh_main should not return; if it does, idle safely */
+    /* nsh_main should not return; in unit tests allow graceful exit */
+#ifndef LOGIN_UNIT_TEST
     for (;;) thread_yield();
+#endif
 }


### PR DESCRIPTION
## Summary
- Add uaccess panic stub to satisfy regx unit test linking
- Let login server return under unit test builds
- Run login tests with `LOGIN_UNIT_TEST` and include new stub in test Makefile

## Testing
- `make -C tests`
- `for t in test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx; do echo Running $t; ./$t >/tmp/$t.log 2>&1; echo Exit:$?; done`
- `pytest tests/integration/test_qemu.py::test_boot_sequence -q`

------
https://chatgpt.com/codex/tasks/task_b_68982e50267c83339eb582a7cd46038b