### PR TITLE
Fix long long formatting in serial console

### DIFF
--- a/nosm/drivers/IO/serial.c
+++ b/nosm/drivers/IO/serial.c
@@ -96,7 +96,13 @@ void serial_vprintf(const char *fmt, va_list ap) {
         }
 
         int long_flag = 0;
-        if (*p == 'l' || *p == 'z') {
+        if (*p == 'l') {
+            long_flag = 1;
+            ++p;
+            if (*p == 'l') {
+                ++p;
+            }
+        } else if (*p == 'z') {
             long_flag = 1;
             ++p;
         }


### PR DESCRIPTION
## Summary
- handle `ll` and `z` modifiers in `serial_vprintf`

## Testing
- `make kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_6898396b8fec8333a4d26b54455440ab