### PR TITLE
Resolve FILE type conflicts in libc

### DIFF
--- a/user/libc/libc.c
+++ b/user/libc/libc.c
@@ -1,5 +1,4 @@
 #include "libc.h"
-#include "printf.h"
 #include <stdint.h>
 #include <stddef.h>
 #include <time.h>
@@ -462,9 +461,9 @@ time_t time(time_t *t) {
 // ================== FILE I/O (NOSFS) ===================
 // Minimal syscall-backed FILE I/O implementation.
 
-typedef struct FILE {
+struct FILE {
     int fd;
-} FILE;
+};
 
 #define O_RDONLY 0
 #define O_WRONLY 1

--- a/user/libc/libc.h
+++ b/user/libc/libc.h
@@ -31,7 +31,10 @@ int pthread_mutex_destroy(pthread_mutex_t *mutex);
 // ===================
 // FILE API
 // ===================
+#ifndef __FILE_defined
 typedef struct FILE FILE;
+#define __FILE_defined 1
+#endif
 
 // Basic file I/O functions (implemented in your libc.c)
 FILE   *fopen(const char *path, const char *mode);


### PR DESCRIPTION
## Summary
- avoid pulling in host stdio definitions by dropping the printf header
- define a minimal FILE struct for NOS
- guard FILE typedef in libc.h to prevent conflicts with system headers

## Testing
- `make libc`


------
https://chatgpt.com/codex/tasks/task_b_68988192f26c8333affe59c16e93c200