### PR TITLE
Fix manifest parsing for agents

### DIFF
--- a/kernel/agent_loader.c
+++ b/kernel/agent_loader.c
@@ -138,8 +138,10 @@ int extract_manifest_macho2(const void *image,size_t size,char *out_json,size_t 
     if(!image || !out_json || out_sz==0) return -1;
     const unsigned char *d=(const unsigned char*)image;
     const char *s=(const char*)memchr(d,'{',size);
-    const char *e=(const char*)memchr(d,'}',size);
-    if(!s||!e||e<=s||(size_t)(e-s+2)>out_sz) return -1;
+    if(!s) return -1;
+    size_t remain = size - (size_t)(s - (const char*)d);
+    const char *e=(const char*)memchr(s,'}',remain);
+    if(!e || e<=s || (size_t)(e-s+2)>out_sz) return -1;
     memcpy(out_json,s,(size_t)(e-s+1));
     out_json[e-s+1]=0;
     return 0;
@@ -149,8 +151,10 @@ int extract_manifest_elf(const void *image,size_t size,char *out_json,size_t out
     if(!image || !out_json || out_sz==0) return -1;
     const unsigned char *d=(const unsigned char*)image;
     const char *s=(const char*)memchr(d,'{',size);
-    const char *e=(const char*)memchr(d,'}',size);
-    if(!s||!e||e<=s||(size_t)(e-s+2)>out_sz) return -1;
+    if(!s) return -1;
+    size_t remain = size - (size_t)(s - (const char*)d);
+    const char *e=(const char*)memchr(s,'}',remain);
+    if(!e || e<=s || (size_t)(e-s+2)>out_sz) return -1;
     memcpy(out_json,s,(size_t)(e-s+1));
     out_json[e-s+1]=0;
     return 0;


### PR DESCRIPTION
## Summary
- Correct manifest scanning for Mach-O2 and ELF agent images
- Enables loader to locate embedded manifests and launch agents such as `/agents/init.mo2`

## Testing
- `make kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689890b9dd8c8333864be6f56b32ac2b