### PR TITLE
Fix init agent startup manifest and logging

### DIFF
--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -64,8 +64,11 @@ static void spawn_init_once(void) {
     if (!atomic_compare_exchange_strong(&init_spawned, &expected, 1))
         return;
     kprintf("[regx] launching init (boot:init:regx)\n");
-    if (agent_loader_run_from_path("/agents/init.mo2", 200) < 0)
-        kprintf("[regx] failed to launch /agents/init.mo2\n");
+    int rc = agent_loader_run_from_path("/agents/init.mo2", 200);
+    if (rc < 0)
+        kprintf("[regx] failed to launch /agents/init.mo2 rc=%d\n", rc);
+    else
+        kprintf("[regx] init agent launched rc=%d\n", rc);
 }
 
 static void watchdog_thread(void){

--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -15,7 +15,7 @@ __attribute__((used, section("\"__O2INFO,__manifest\"")))
 static const char mo2_manifest[] =
 "{\n"
 "  \"name\": \"init\",\n"
-"  \"type\": \"service_launcher\",\n"
+"  \"type\": 4,\n"
 "  \"version\": \"1.0.0\",\n"
 "  \"entry\": \"agent_main\"\n"
 "}\n";


### PR DESCRIPTION
## Summary
- Use numeric registry type in init agent manifest so loader can register it correctly
- Add return-code logging when regx launches init agent

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_6898952523188333820f2f2bf1cd107e