### PR TITLE
Avoid early yield before init agent launch

### DIFF
--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -65,7 +65,6 @@ static void spawn_init_once(void) {
         return;
 
     for (;;) {
-        thread_yield();
         kprintf("[regx] launching init (boot:init:regx)\n");
         int rc = agent_loader_run_from_path("/agents/init.mo2", 200);
         if (rc >= 0) {
@@ -73,6 +72,7 @@ static void spawn_init_once(void) {
             break;
         }
         kprintf("[regx] failed to launch /agents/init.mo2 rc=%d; retrying...\n", rc);
+        thread_yield();
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent premature scheduler yield before loading the init agent
- ensures init agent attempts to load before yielding

## Testing
- `cd tests && make`


------
https://chatgpt.com/codex/tasks/task_b_6898987968a083339018dfe9e1471ffc