### PR TITLE
Expand libc heap for larger agent images

### DIFF
--- a/user/libc/libc.c
+++ b/user/libc/libc.c
@@ -296,7 +296,7 @@ void *sbrk(long inc) { return (void *)syscall3(SYS_SBRK, inc, 0, 0); }
 // ================== THREADING: RECURSIVE MUTEX ===================
 
 // ================== MALLOC FAMILY: THREAD-SAFE ===================
-#define HEAP_SIZE (1024 * 1024)
+#define HEAP_SIZE (2 * 1024 * 1024)  // enlarged for larger agent images
 #define HEAP_MAGIC 0xC0DECAFE
 
 typedef struct block_header {


### PR DESCRIPTION
## Summary
- enlarge user-mode heap to 2 MiB so the init agent's ELF image fits in memory

## Testing
- `make -C tests`
- custom allocation program allocating 1,065,008 bytes


------
https://chatgpt.com/codex/tasks/task_b_68989a2c09ac8333a2d30ba50b27f65e