### PR TITLE
Refactor init binary linkage

### DIFF
--- a/kernel/stubs.c
+++ b/kernel/stubs.c
@@ -2,8 +2,10 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include "../user/libc/libc.h"
-#include "init_bin.h"
-#include "login_bin.h"
+extern unsigned char init_bin[];
+extern unsigned int init_bin_len;
+extern unsigned char login_bin[];
+extern unsigned int login_bin_len;
 
 /* Basic kernel logging helper */
 extern int kprintf(const char *fmt, ...);


### PR DESCRIPTION
## Summary
- avoid duplicate init/login binary definitions by centralizing arrays in regx agent
- loosen regx gate for in-memory agents and load built-in init via explicit ELF loader

## Testing
- `make disk.img`
- `qemu-system-x86_64 -bios OVMF.fd -drive file=disk.img,format=raw -m 512M -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -serial stdio -display none` *(page fault, no shell)*

------
https://chatgpt.com/codex/tasks/task_b_68996424aa1c8333836ca57755728a37