### PR TITLE
Start nosfs earlier so init.mo2 loads cleanly

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -241,21 +241,20 @@ void threads_init(void){
 
     agent_loader_set_read(agentfs_read_all, agentfs_free);
 
-    // Start the security gate first
+    // Bring up NOSFS before other core agents so init.mo2 can be served.
+    thread_t *t_nosfs = thread_create_with_priority(nosfs_thread_wrapper, 230);
     thread_t *t_regx  = thread_create_with_priority(regx_thread_wrapper, 220);
-    // Bring core helpers alongside
     thread_t *t_nosm  = thread_create_with_priority(nosm_thread_wrapper, 210);
-    thread_t *t_nosfs = thread_create_with_priority(nosfs_thread_wrapper, 200);
 
+    if(!t_nosfs) kprintf("[boot] failed to spawn nosfs\n");
     if(!t_regx){ kprintf("[boot] failed to spawn regx\n"); for(;;)__asm__ volatile("hlt"); }
     if(!t_nosm)  kprintf("[boot] failed to spawn nosm\n");
-    if(!t_nosfs) kprintf("[boot] failed to spawn nosfs\n");
 
-    ipc_grant(&regx_queue, t_regx->id, IPC_CAP_SEND | IPC_CAP_RECV);
     if (t_nosfs){
         ipc_grant(&fs_queue,   t_nosfs->id, IPC_CAP_SEND | IPC_CAP_RECV);
         ipc_grant(&regx_queue, t_nosfs->id, IPC_CAP_SEND | IPC_CAP_RECV);
     }
+    ipc_grant(&regx_queue, t_regx->id, IPC_CAP_SEND | IPC_CAP_RECV);
     if (t_nosm){
         ipc_grant(&nosm_queue, t_nosm->id, IPC_CAP_SEND | IPC_CAP_RECV);
         ipc_grant(&regx_queue, t_nosm->id, IPC_CAP_SEND | IPC_CAP_RECV);

--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -8,6 +8,7 @@
 #include "../../kernel/agent_loader.h"
 #include "../../kernel/init_bin.h"
 #include "../../kernel/login_bin.h"
+#include "../../user/agents/nosfs/nosfs_server.h"
 extern void serial_putc(char c);
 
 // Kernel console
@@ -66,6 +67,10 @@ static void spawn_init_once(void) {
     int expected = 0;
     if (!atomic_compare_exchange_strong(&init_spawned, &expected, 1))
         return;
+
+    // Wait until the filesystem server has preloaded core agents.
+    while (!nosfs_is_ready())
+        thread_yield();
 
     for (;;) {
         kprintf("[regx] launching init (boot:init:regx)\n");

--- a/user/agents/nosfs/nosfs_server.h
+++ b/user/agents/nosfs/nosfs_server.h
@@ -18,4 +18,7 @@ enum {
 
 void nosfs_server(ipc_queue_t *q, uint32_t self_id);
 
+// Returns non-zero once nosfs_server has initialized and preloaded files.
+int nosfs_is_ready(void);
+
 #endif // NOSFS_SERVER_H


### PR DESCRIPTION
## Summary
- Start the NOSFS server before other agents and raise its priority so init can read from the filesystem
- Expose a nosfs readiness flag and wait for it before launching init

## Testing
- `make kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689984647e14833383f05cdcce2b104e