### PR TITLE
Fix builtin init fallback format

### DIFF
--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -77,7 +77,7 @@ static void spawn_init_once(void) {
         int rc = agent_loader_run_from_path("/agents/init.mo2", 200);
         if (rc < 0) {
         kprintf("[regx] falling back to built-in init image\n");
-        rc = load_agent(init_bin, init_bin_len, AGENT_FORMAT_ELF);
+        rc = load_agent(init_bin, init_bin_len, AGENT_FORMAT_MACHO2);
         }
         if (rc >= 0) {
             kprintf("[regx] init agent launched rc=%d\n", rc);


### PR DESCRIPTION
## Summary
- use MACHO2 format when loading embedded init agent so fallback succeeds

## Testing
- `make kernel`
- `make -C tests test_regx`
- `./tests/test_regx`


------
https://chatgpt.com/codex/tasks/task_b_6899947b1074833390984ea9e97285c8