### PR TITLE
Fix init loading fallback and memory allocation

### DIFF
--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -77,7 +77,7 @@ static void spawn_init_once(void) {
         int rc = agent_loader_run_from_path("/agents/init.mo2", 200);
         if (rc < 0) {
         kprintf("[regx] falling back to built-in init image\n");
-        rc = load_agent(init_bin, init_bin_len, AGENT_FORMAT_ELF);
+        rc = load_agent_auto(init_bin, init_bin_len);
         }
         if (rc >= 0) {
             kprintf("[regx] init agent launched rc=%d\n", rc);


### PR DESCRIPTION
## Summary
- Fix init agent fallback to auto-detect format when filesystem load fails
- Allow ELF loader to allocate builtin init even when heap lacks large contiguous blocks, with buffer fallback and stack alignment

## Testing
- `make kernel`
- `timeout 60s qemu-system-x86_64 -drive format=raw,file=disk.img -bios OVMF.fd -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -serial stdio -display none`

------
https://chatgpt.com/codex/tasks/task_b_6899acdf3a58833397481245e3d78170