### PR TITLE
fix: ensure init loads login agent

### DIFF
--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -130,20 +130,16 @@ static int load_manifest_from_disk(const AgentAPI *api,
 
 /* ---------- fallback defaults ---------- */
 static int default_manifest(svc_spec_t *out, int max_out) {
+    /* Only include agents that ship on the current disk image.
+       Loading non-existent services (e.g., pkg or update) caused
+       init to stall before reaching the login agent. */
     static const char *paths[] = {
-        "/agents/pkg.bin",
-        "/agents/update.bin",
         "/agents/login.bin",
-        /* add more as they’re ready:
-           "/agents/ssh.bin",
-           "/agents/ftp.bin",
-           "/agents/vnc.bin",
-        */
     };
-    int n=0;
-    for (size_t i=0; i<sizeof(paths)/sizeof(paths[0]) && n<max_out; ++i) {
-        snprintf(out[n].path,sizeof(out[n].path),"%s",paths[i]);
-        out[n].args[0]=0;
+    int n = 0;
+    for (size_t i = 0; i < sizeof(paths)/sizeof(paths[0]) && n < max_out; ++i) {
+        snprintf(out[n].path, sizeof(out[n].path), "%s", paths[i]);
+        out[n].args[0] = 0;
         n++;
     }
     return n;


### PR DESCRIPTION
## Summary
- Avoid loading nonexistent pkg and update agents in init's default manifest
- Load login agent by default so system boots to login prompt

## Testing
- `make agents`


------
https://chatgpt.com/codex/tasks/task_b_6899bf20069483339fb0edacbc74ba06