### PR TITLE
Ensure init agent runs and launches login

### DIFF
--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -181,6 +181,9 @@ void regx_main(void){
     // Kick off init agent once we're online
     spawn_init_once();
 
+    // Yield so the newly spawned init agent can run
+    thread_yield();
+
     // Idle loop; halt CPU while regx waits for work
     for(;;) __asm__ volatile("hlt");
 }


### PR DESCRIPTION
## Summary
- Yield after spawning init so it can execute
- Pass a functional AgentAPI to new threads, enabling init to load further agents

## Testing
- `make kernel`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6899bf20069483339fb0edacbc74ba06