### PR TITLE
Package login agent as Mach-O2

### DIFF
--- a/kernel/stubs.c
+++ b/kernel/stubs.c
@@ -42,7 +42,7 @@ int fs_read_all(const char *path, void **out, size_t *out_sz) {
         *out_sz = init_bin_len;
         return 0;
     }
-    if (strcmp(path, "/agents/login.bin") == 0) {
+    if (strcmp(path, "/agents/login.mo2") == 0) {
         *out = (void *)login_bin;
         *out_sz = login_bin_len;
         return 0;

--- a/tests/thread_test_stubs.c
+++ b/tests/thread_test_stubs.c
@@ -11,3 +11,5 @@ int fs_read_all(const char *path, void **out, size_t *out_sz) { (void)path; (voi
 void agent_loader_set_read(int (*reader)(const char*, void**, size_t*), void (*freer)(void*)) { (void)reader; (void)freer; }
 void ipc_init(void *q) { (void)q; }
 void ipc_grant(void *q, uint32_t id, uint32_t caps) { (void)q; (void)id; (void)caps; }
+int agent_loader_run_from_path(const char *path, int prio) { (void)path; (void)prio; return -1; }
+void serial_puts(const char *s) { (void)s; }

--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -134,7 +134,7 @@ static int default_manifest(svc_spec_t *out, int max_out) {
        Loading non-existent services (e.g., pkg or update) caused
        init to stall before reaching the login agent. */
     static const char *paths[] = {
-        "/agents/login.bin",
+        "/agents/login.mo2",
     };
     int n = 0;
     for (size_t i = 0; i < sizeof(paths)/sizeof(paths[0]) && n < max_out; ++i) {

--- a/user/agents/nosfs/nosfs_server.c
+++ b/user/agents/nosfs/nosfs_server.c
@@ -38,7 +38,7 @@ void nosfs_server(ipc_queue_t *q, uint32_t self_id) {
     int h = nosfs_create(&nosfs_root, "agents/init.mo2", init_bin_len, 0);
     if (h >= 0) (void)nosfs_write(&nosfs_root, h, 0, init_bin, init_bin_len);
 
-    h = nosfs_create(&nosfs_root, "agents/login.bin", login_bin_len, 0);
+    h = nosfs_create(&nosfs_root, "agents/login.mo2", login_bin_len, 0);
     if (h >= 0) (void)nosfs_write(&nosfs_root, h, 0, login_bin, login_bin_len);
 
     // Make filesystem contents visible to other threads


### PR DESCRIPTION
## Summary
- build login agent as a `.mo2` container and package it on the disk image
- update init defaults and nosfs stubs to reference `login.mo2`
- adjust tests with stubs to link cleanly

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_6899c5f139548333a5caa9ba9ab26445