### PR TITLE
Fix login agent manifest type

### DIFF
--- a/user/agents/login/agent_entry.c
+++ b/user/agents/login/agent_entry.c
@@ -11,7 +11,7 @@ __attribute__((used, section("\"__O2INFO,__manifest\"")))
 static const char mo2_manifest[] =
 "{\n"
 "  \"name\": \"login\",\n"
-"  \"type\": \"service\",\n"
+"  \"type\": 4,\n"
 "  \"version\": \"1.0.0\",\n"
 "  \"entry\": \"_start\"\n"
 "}\n";


### PR DESCRIPTION
## Summary
- Ensure login agent manifest uses numeric service type to match loader expectations.

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689a4f79efd88333898245538bef2ff8