### PR TITLE
Fix buddy allocator initialization for large agent loads

### DIFF
--- a/tests/unit/test_pmm.c
+++ b/tests/unit/test_pmm.c
@@ -8,7 +8,7 @@
 #endif
 
 int main(void) {
-    static uint8_t region[4 * PAGE_SIZE];
+    static uint8_t region[128 * PAGE_SIZE];
     bootinfo_memory_t mmap[1] = {
         { .addr = (uint64_t)(uintptr_t)region, .len = sizeof(region), .type = 7, .reserved = 0 }
     };
@@ -17,16 +17,20 @@ int main(void) {
     bi.mmap_entries = 1;
     numa_init(&bi);
     buddy_init(&bi);
-    assert(buddy_free_frames_total() == 4);
-    void *p1 = buddy_alloc(0, 0, 0);
-    assert(buddy_free_frames_total() == 3);
-    void *p2 = buddy_alloc(0, 0, 0);
-    assert(buddy_free_frames_total() == 2);
-    assert(p1 && p2 && p1 != p2);
-    buddy_free(p1, 0, 0);
-    assert(buddy_free_frames_total() == 3);
-    void *p3 = buddy_alloc(0, 0, 0);
-    assert(buddy_free_frames_total() == 2);
-    assert(p3 == p1);
+    assert(buddy_free_frames_total() == 128);
+
+    void *p1 = buddy_alloc(6, 0, 0); // 64-page block
+    assert(p1);
+    assert(buddy_free_frames_total() == 64);
+
+    void *p2 = buddy_alloc(5, 0, 0); // 32-page block
+    assert(p2);
+    assert(buddy_free_frames_total() == 32);
+
+    buddy_free(p1, 6, 0);
+    assert(buddy_free_frames_total() == 96);
+    buddy_free(p2, 5, 0);
+    assert(buddy_free_frames_total() == 128);
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- partition each NUMA zone into power-of-two blocks so high-order allocations succeed
- decrement order while splitting to avoid infinite loop in buddy allocator
- expand PMM unit test to cover multi-page allocations

## Testing
- `cd tests && make test_pmm test_login test_login_keyboard`
- `./test_pmm`
- `./test_login`
- `./test_login_keyboard`


------
https://chatgpt.com/codex/tasks/task_b_689a7a735cd88333b25bed7d7ac8856a