### PR TITLE
Scaffold NitroHeap allocator framework

### DIFF
--- a/docs/nitroheap.md
+++ b/docs/nitroheap.md
@@ -1,0 +1,13 @@
+# NitroHeap
+
+NitroHeap is a planned replacement for the simple buddy-backed kernel heap.  This
+initial skeleton introduces the build- and boot-time plumbing so the allocator
+can be selected at runtime.
+
+* `CONFIG_NITRO_HEAP=1` enables NitroHeap by default at build time.
+* A boot argument `heap=nitro` or `heap=legacy` overrides the build default.
+* Public APIs are provided via `kernel/VM/heap.h` with `kmalloc`, `kfree`, and
+  `krealloc`.
+
+The current implementation delegates to the legacy buddy allocator while the
+full NitroHeap with size classes, magazines, and span management is developed.

--- a/kernel/VM/heap.h
+++ b/kernel/VM/heap.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <stddef.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void kheap_parse_bootarg(const char* cmdline);
+void kheap_init(void);
+void* kmalloc(size_t sz, size_t align);
+void  kfree(void* p);
+void* krealloc(void* p, size_t newsz, size_t align);
+void  kheap_dump_stats(const char* tag);
+void  kheap_trim(void);
+
+#define kalloc(sz) kmalloc((sz), 0)
+
+#ifdef __cplusplus
+}
+#endif

--- a/kernel/VM/heap_select.c
+++ b/kernel/VM/heap_select.c
@@ -1,0 +1,56 @@
+#include "heap.h"
+#include "legacy_heap.h"
+#include "nitroheap/nitroheap.h"
+#include <string.h>
+
+static int use_nitro =
+#ifdef CONFIG_NITRO_HEAP
+1;
+#else
+0;
+#endif
+
+void kheap_parse_bootarg(const char* cmdline) {
+    if (!cmdline) return;
+    if (strstr(cmdline, "heap=nitro"))
+        use_nitro = 1;
+    else if (strstr(cmdline, "heap=legacy"))
+        use_nitro = 0;
+}
+
+void kheap_init(void) {
+    if (use_nitro)
+        nitroheap_init();
+    else
+        legacy_kheap_init();
+}
+
+void* kmalloc(size_t sz, size_t align) {
+    if (use_nitro)
+        return nitro_kmalloc(sz, align);
+    return legacy_kmalloc(sz);
+}
+
+void kfree(void* p) {
+    if (use_nitro)
+        nitro_kfree(p);
+    else
+        legacy_kfree(p);
+}
+
+void* krealloc(void* p, size_t newsz, size_t align) {
+    if (use_nitro)
+        return nitro_krealloc(p, newsz, align);
+    return legacy_krealloc(p, newsz);
+}
+
+void kheap_dump_stats(const char* tag) {
+    if (use_nitro)
+        nitro_kheap_dump_stats(tag);
+    (void)tag; // legacy heap has no stats
+}
+
+void kheap_trim(void) {
+    if (use_nitro)
+        nitro_kheap_trim();
+}

--- a/kernel/VM/legacy_heap.c
+++ b/kernel/VM/legacy_heap.c
@@ -1,14 +1,18 @@
-#include "kheap.h"
+#include "legacy_heap.h"
 #include "pmm_buddy.h"
 #include "numa.h"
 #include <stdint.h>
 #include <stddef.h>
+#include <string.h>
+#ifndef PMM_PAGE_SHIFT
+#define PMM_PAGE_SHIFT 12
+#endif
 
 #define HEAP_MIN_ORDER   0 // 4K
 #define HEAP_MAX_ORDER   PMM_BUDDY_MAX_ORDER
 
 // Simple heap: prefix each allocation with its buddy order for kfree.
-void *kalloc(size_t sz) {
+void *legacy_kmalloc(size_t sz) {
     uint32_t order = 0;
     size_t x = PAGE_SIZE;
     size_t total = sz + sizeof(uint32_t);
@@ -22,7 +26,7 @@ void *kalloc(size_t sz) {
     return block + sizeof(uint32_t);
 }
 
-void kfree(void *ptr) {
+void legacy_kfree(void *ptr) {
     if (!ptr)
         return;
     uint8_t *block = (uint8_t*)ptr - sizeof(uint32_t);
@@ -30,6 +34,26 @@ void kfree(void *ptr) {
     buddy_free(block, order, current_cpu_node());
 }
 
-void kheap_init(void) {
+static size_t legacy_alloc_size(const void *ptr) {
+    const uint8_t *block = (const uint8_t*)ptr - sizeof(uint32_t);
+    uint32_t order = *((const uint32_t*)block);
+    return ((size_t)1 << (order + PMM_PAGE_SHIFT)) - sizeof(uint32_t);
+}
+
+void *legacy_krealloc(void *ptr, size_t newsz) {
+    if (!ptr)
+        return legacy_kmalloc(newsz);
+    size_t oldsz = legacy_alloc_size(ptr);
+    if (newsz <= oldsz)
+        return ptr;
+    void *n = legacy_kmalloc(newsz);
+    if (!n)
+        return NULL;
+    memcpy(n, ptr, oldsz < newsz ? oldsz : newsz);
+    legacy_kfree(ptr);
+    return n;
+}
+
+void legacy_kheap_init(void) {
     // Nothing to do if using buddy directly; for a slab/quicklist heap, initialize here
 }

--- a/kernel/VM/legacy_heap.h
+++ b/kernel/VM/legacy_heap.h
@@ -7,9 +7,10 @@
 extern "C" {
 #endif
 
-void *kalloc(size_t sz);
-void  kfree(void *ptr);
-void  kheap_init(void);
+void *legacy_kmalloc(size_t sz);
+void  legacy_kfree(void *ptr);
+void *legacy_krealloc(void *ptr, size_t newsz);
+void  legacy_kheap_init(void);
 
 #ifdef __cplusplus
 }

--- a/kernel/VM/nitroheap/classes.c
+++ b/kernel/VM/nitroheap/classes.c
@@ -1,0 +1,31 @@
+#include "classes.h"
+
+const nh_size_class_t nh_size_classes[] = {
+    {8,8}, {16,16}, {24,16}, {32,16}, {40,16}, {48,16}, {56,16}, {64,64},
+    {80,64}, {96,64}, {112,64}, {128,128},
+    {160,128}, {192,128}, {224,128}, {256,256},
+    {320,256}, {384,256}, {448,256}, {512,512},
+    {640,512}, {768,512}, {896,512}, {1024,1024},
+    {1280,1024}, {1536,1024}, {1792,1024}, {2048,2048},
+    {2560,2048}, {3072,2048}, {3584,2048}, {4096,4096},
+    {5120,4096}, {6144,4096}, {7168,4096}, {8192,8192},
+    {12288,8192}, {16384,16384}
+};
+
+const size_t nh_size_class_count = sizeof(nh_size_classes)/sizeof(nh_size_classes[0]);
+
+int size_class_for(size_t sz, size_t align) {
+    for (size_t i = 0; i < nh_size_class_count; ++i) {
+        size_t csz = nh_size_classes[i].size;
+        size_t cal = nh_size_classes[i].align;
+        if (csz >= sz && cal >= align)
+            return (int)i;
+    }
+    return -1;
+}
+
+size_t class_align(int cls) {
+    if (cls < 0 || (size_t)cls >= nh_size_class_count)
+        return 0;
+    return nh_size_classes[cls].align;
+}

--- a/kernel/VM/nitroheap/classes.h
+++ b/kernel/VM/nitroheap/classes.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <stddef.h>
+
+typedef struct {
+    size_t size;
+    size_t align;
+} nh_size_class_t;
+
+extern const nh_size_class_t nh_size_classes[];
+extern const size_t nh_size_class_count;
+
+int size_class_for(size_t sz, size_t align);
+size_t class_align(int cls);

--- a/kernel/VM/nitroheap/nitroheap.c
+++ b/kernel/VM/nitroheap/nitroheap.c
@@ -1,0 +1,25 @@
+#include "nitroheap.h"
+#include "../legacy_heap.h"
+
+// Temporary stub implementation: delegate to legacy heap.
+void nitroheap_init(void) {}
+
+void* nitro_kmalloc(size_t sz, size_t align) {
+    (void)align;
+    return legacy_kmalloc(sz);
+}
+
+void nitro_kfree(void* p) {
+    legacy_kfree(p);
+}
+
+void* nitro_krealloc(void* p, size_t newsz, size_t align) {
+    (void)align;
+    return legacy_krealloc(p, newsz);
+}
+
+void nitro_kheap_dump_stats(const char* tag) {
+    (void)tag;
+}
+
+void nitro_kheap_trim(void) {}

--- a/kernel/VM/nitroheap/nitroheap.h
+++ b/kernel/VM/nitroheap/nitroheap.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <stddef.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+void nitroheap_init(void);
+void* nitro_kmalloc(size_t sz, size_t align);
+void  nitro_kfree(void* p);
+void* nitro_krealloc(void* p, size_t newsz, size_t align);
+void  nitro_kheap_dump_stats(const char* tag);
+void  nitro_kheap_trim(void);
+#ifdef __cplusplus
+}
+#endif

--- a/kernel/agent_loader.c
+++ b/kernel/agent_loader.c
@@ -6,7 +6,7 @@
 
 #include "elf.h"
 #include "agent_loader.h"
-#include "VM/kheap.h"
+#include "VM/heap.h"
 #include "drivers/IO/serial.h"
 
 // Some tree headers provide these; define minimally if missing.

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -17,7 +17,7 @@
 #include "Task/thread.h"
 #include "VM/numa.h"
 #include "VM/pmm_buddy.h"
-#include "VM/kheap.h"
+#include "VM/heap.h"
 #include "arch/CPU/lapic.h"
 #include "uaccess.h"
 #include "symbols.h"
@@ -81,6 +81,7 @@ void n2_main(bootinfo_t *bootinfo) {
 
     numa_init(bootinfo);
     buddy_init(bootinfo);
+    kheap_parse_bootarg(bootinfo->cmdline);
     kheap_init();
 
     __asm__ volatile("cli");


### PR DESCRIPTION
## Summary
- introduce build flag `CONFIG_NITRO_HEAP` and heap boot arg plumbing
- add NitroHeap skeleton with runtime selection and size-class table
- document NitroHeap design and expose kmalloc-based API shim

## Testing
- `make kernel`
- `make kernel CONFIG_NITRO_HEAP=1`


------
https://chatgpt.com/codex/tasks/task_b_689a89c43b4483338e1310d65685beac