### PR TITLE
Expand design docs for memory, CPU, and tasking

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,6 +99,34 @@ typedef struct {
 } nosfs_superblock_t;
 ```
 
+## Memory Management
+
+The N2 kernel relies on a two-tiered memory system. A physical memory manager
+initializes from the UEFI map and hands out frames via a buddy allocator, while
+the virtual memory manager builds per-task page tables with NX, SMEP and SMAP
+protection. 4 KiB and 2 MiB pages are mixed to balance granularity with TLB
+pressure. Copy‑on‑write and NUMA‑aware placement are planned to support large
+multi-socket machines. See [MEMORY_MANAGEMENT.md](MEMORY_MANAGEMENT.md) for the
+full design.
+
+## CPU Handling and Caches
+
+CPUs are enumerated through ACPI and `CPUID` and brought online with the local
+APIC. Each core maintains its own scheduler data and per‑CPU structure. Memory
+operations use explicit barriers and shootdowns to keep caches coherent; TLBs
+are flushed on context switches and inter‑processor interrupts coordinate page
+table updates. Future revisions will explore cache coloring and non‑temporal
+loads for IO‑heavy agents.
+
+## Threading & Tasking
+
+Threads run inside task address spaces managed by the scheduler. Each CPU has a
+run queue with round‑robin time slicing, and tasks may spawn multiple threads
+that share an IPC mail box. Context switches save and restore full register
+state, including FPU and SIMD units. Priorities and more advanced policies such
+as affinity or fair scheduling are planned. Additional details live in
+[CPU_THREADING_TASKING.md](CPU_THREADING_TASKING.md).
+
 ## System Calls & Tools
 
 The kernel exposes a small syscall surface that userland tools build upon.

--- a/docs/CPU_THREADING_TASKING.md
+++ b/docs/CPU_THREADING_TASKING.md
@@ -1,0 +1,33 @@
+# CPU Handling, Caches, Threading and Tasking
+
+This document details how NitrOS manages processor resources, cache coherence
+and the execution of tasks and threads.
+
+## CPU Handling
+
+- CPUs are discovered via ACPI tables and `CPUID` feature probes.
+- The bootstrap processor initializes paging and brings up application
+  processors using the local APIC.
+- Each core owns a per-CPU structure with scheduler state, current task pointer
+  and statistics counters.
+- Future work includes NUMA-aware core groups and topology hints for agents.
+
+## Cache Strategy
+
+- N2 assumes hardware cache coherence but uses memory barriers around MMIO and
+  shared structures to prevent reordering.
+- Page table changes trigger TLB shootdowns via inter-processor interrupts so
+  all cores observe new mappings.
+- Planned optimizations include cache coloring and use of non-temporal moves for
+  bulk transfers.
+
+## Threading & Tasking
+
+- Tasks provide isolated address spaces while threads represent schedulable
+  contexts within a task.
+- Each CPU maintains a run queue; the scheduler performs round-robin
+  time slicing and context switches by updating CR3 and saving registers.
+- Threads may communicate through IPC mail boxes and shared memory regions.
+- An idle thread per core executes `hlt` when no runnable work exists.
+- Priority and affinity scheduling policies are on the roadmap.
+

--- a/docs/MEMORY_MANAGEMENT.md
+++ b/docs/MEMORY_MANAGEMENT.md
@@ -41,7 +41,14 @@ This document outlines a proposed secure and optimized memory mapping and manage
    - Reference counting shared frames to minimize copy
    - Batch TLB flushes where possible (e.g., per-task CR3 switch)
 
-6. **Recent Additions**
+6. **Cache Management**
+   - Separate per-CPU page caches reduce contention and take advantage of
+     cache locality
+   - TLB shootdowns are coordinated via IPIs when mappings change
+   - Planned support for cache coloring and non-temporal copies for IO
+     heavy workloads
+
+7. **Recent Additions**
    - Copy-on-write tracking with a simple page fault handler
    - Experimental NUMA region discovery from the boot memory map
    - IPC shared memory buffers protected by rights masks


### PR DESCRIPTION
## Summary
- Expand architecture blueprint with sections on memory management, CPU/caching, and threading/tasking
- Document cache policy in memory management design
- Add CPU/threading/tasking design document

## Testing
- `cd tests && make clean`
- `cd tests && make`

------
https://chatgpt.com/codex/tasks/task_b_689aaa4c3a0c83339fa7232508465bec