### PR TITLE
Bridge regx launch logging through serial_vprintf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ clean:
 	    nosm/drivers/IO/pit.o nosm/drivers/IO/block.o nosm/drivers/IO/sata.o nosm/drivers/Net/e1000.o nosm/drivers/Net/netstack.o \
 	    nosm/drivers/example/hello/hello_nmod.o out/modules/hello.elf out/modules/hello.mo2 \
 	    kernel/login_bin.h \
-	    loader/elf_paged_loader.o src/agents/regx/regx_launch_elf_paged.o \
+            loader/elf_paged_loader.o regx/regx_launch_elf_paged.o \
 	    kernel/arch/ud_handler_patch.o
 	rm -rf out
 	make -C boot clean

--- a/regx/regx_launch_adapters.c
+++ b/regx/regx_launch_adapters.c
@@ -3,14 +3,16 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdarg.h>
+
+#include "drivers/IO/serial.h"
 
 // ====== EDIT THESE externs to match your kernel ======
 // Create a user-mode stack, return top-of-stack (or pointer your thread API expects)
 extern void* proc_create_user_stack(size_t size);
 // Spawn a user thread at RIP with given stack top & prio; returns 0 on success
 extern int   thread_spawn_user(uintptr_t rip, void* user_stack_top, uint32_t prio, uint32_t* out_tid);
-// Logging utility
-extern void  klogf(const char* fmt, ...);
+// No explicit logging extern; we'll bridge to serial_vprintf
 
 // ====== Adapters with the names regx_launch_elf_paged.c expects ======
 void*  create_user_stack(size_t sz) { return proc_create_user_stack(sz); }
@@ -18,10 +20,8 @@ int    thread_spawn(uintptr_t rip, void* user_stack_top, uint32_t prio, uint32_t
     return thread_spawn_user(rip, user_stack_top, prio, out_tid);
 }
 void   log(const char* fmt, ...) {
-    // Forward to klogf variadically
-    __builtin_va_list ap; __builtin_va_start(ap, fmt);
-    // If you have vprintf-like, use it; otherwise, provide a small vsnprintf bridge.
-    // For now, call klogf (assumes it handles varargs).
-    klogf(fmt, ap);
-    __builtin_va_end(ap);
+    va_list ap;
+    va_start(ap, fmt);
+    serial_vprintf(fmt, ap);
+    va_end(ap);
 }


### PR DESCRIPTION
## Summary
- Route regx launch logging through `serial_vprintf` so kernel-side launches can format messages correctly.
- Fix Makefile clean target to remove the new regx launch object from the proper path.

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689bf780dd188333a8388ecaca7e6ee4