### PR TITLE
Add VM/PMM shims and thread adapters for ELF loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,12 +179,10 @@ endif
 	    nosm/drivers/Net/e1000.o nosm/drivers/Net/netstack.o \
 	    src/agents/regx/regx.o user/agents/nosfs/nosfs.o user/agents/nosfs/nosfs_server.o user/agents/nosm/nosm.o \
 	    user/libc/libc.o \
-	    $(if $(wildcard kernel/arch/ud_handler_patch.o),kernel/arch/ud_handler_patch.o,) \
-		# link (near the other kernel objects)
-	    kernel/loader_vm_pmm_shims.o \
-    	regx/regx_launch_adapters.o \
-	
-	    -o kernel.bin
+            $(if $(wildcard kernel/arch/ud_handler_patch.o),kernel/arch/ud_handler_patch.o,) \
+            kernel/loader_vm_pmm_shims.o \
+            regx/regx_launch_adapters.o \
+            -o kernel.bin
 
 	cp kernel.bin n2.bin
 

--- a/regx/regx_launch_adapters.c
+++ b/regx/regx_launch_adapters.c
@@ -6,19 +6,24 @@
 #include <stdarg.h>
 
 #include "drivers/IO/serial.h"
+#include "../kernel/VM/legacy_heap.h"
+#include "../kernel/Task/thread.h"
 
-// ====== EDIT THESE externs to match your kernel ======
-// Create a user-mode stack, return top-of-stack (or pointer your thread API expects)
-extern void* proc_create_user_stack(size_t size);
-// Spawn a user thread at RIP with given stack top & prio; returns 0 on success
-extern int   thread_spawn_user(uintptr_t rip, void* user_stack_top, uint32_t prio, uint32_t* out_tid);
-// No explicit logging extern; we'll bridge to serial_vprintf
-
-// ====== Adapters with the names regx_launch_elf_paged.c expects ======
-void*  create_user_stack(size_t sz) { return proc_create_user_stack(sz); }
-int    thread_spawn(uintptr_t rip, void* user_stack_top, uint32_t prio, uint32_t* out_tid) {
-    return thread_spawn_user(rip, user_stack_top, prio, out_tid);
+// Allocate a simple stack for user threads
+void* create_user_stack(size_t size) {
+    return legacy_kmalloc(size);
 }
+
+// Spawn a thread to run at `rip` with given priority
+int thread_spawn(uintptr_t rip, void* user_stack_top, uint32_t prio, uint32_t* out_tid) {
+    (void)user_stack_top; // current kernel lacks separate user stacks
+    thread_t* t = thread_create_with_priority((void(*)(void))rip, prio);
+    if (!t) return -1;
+    if (out_tid) *out_tid = t->id;
+    return 0;
+}
+
+// Provide log() using serial_vprintf for regx_launch_elf_paged.c
 void   log(const char* fmt, ...) {
     va_list ap;
     va_start(ap, fmt);


### PR DESCRIPTION
## Summary
- Implement VM/PMM shim layer to match kernel paging and memory APIs
- Provide simple thread, stack, and log adapters for regx ELF launch support
- Ensure kernel link includes shim and adapter objects

## Testing
- `make kernel`

------
https://chatgpt.com/codex/tasks/task_b_689bfad3fd78833381a7c609aeba3589