### PR TITLE
Include TSS support in N2 kernel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,9 @@ endif
 
 	$(CC) $(CFLAGS) -c kernel/arch/CPU/smp.c -o kernel/arch/CPU/smp.o
 	$(CC) $(CFLAGS) -c kernel/arch/CPU/lapic.c -o kernel/arch/CPU/lapic.o
+	$(NASM) -f elf64 -I kernel/arch/GDT/ kernel/arch/GDT/gdt.asm -o kernel/arch/GDT/gdt_flush.o
+	$(CC) $(CFLAGS) -c kernel/arch/GDT/gdt.c -o kernel/arch/GDT/gdt.o
+	$(CC) $(CFLAGS) -c kernel/arch/GDT/tss.c -o kernel/arch/GDT/tss.o
 	$(CC) $(CFLAGS) -c kernel/macho2.c -o kernel/macho2.o
 	$(CC) $(CFLAGS) -c kernel/printf.c -o kernel/printf.o
 	$(CC) $(CFLAGS) -c kernel/nosm.c -o kernel/nosm.o
@@ -163,8 +166,8 @@ endif
 	
 
 	$(LD) -T kernel/n2.ld -Map kernel.map kernel/n2_entry.o kernel/n2_main.o kernel/builtin_nosfs.o \
-	    kernel/agent.o kernel/agent_loader.o kernel/agent_loader_pub.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/Task/context_switch.o \
-	    kernel/arch/CPU/smp.o kernel/arch/CPU/lapic.o kernel/macho2.o kernel/printf.o kernel/nosm.o \
+            kernel/agent.o kernel/agent_loader.o kernel/agent_loader_pub.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/Task/context_switch.o \
+            kernel/arch/CPU/smp.o kernel/arch/CPU/lapic.o kernel/arch/GDT/gdt.o kernel/arch/GDT/tss.o kernel/arch/GDT/gdt_flush.o kernel/macho2.o kernel/printf.o kernel/nosm.o \
             kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o \
             kernel/VM/heap_select.o kernel/VM/legacy_heap.o \
             kernel/VM/nitroheap/nitroheap.o kernel/VM/nitroheap/classes.o kernel/uaccess.o \
@@ -214,11 +217,11 @@ disk.img: boot kernel agents bins modules
 # ===== utility =====
 clean:
 	rm -f kernel/n2_entry.o kernel/Task/context_switch.o kernel/n2_main.o kernel/builtin_nosfs.o kernel/agent.o \
-	    kernel/nosm.o kernel/agent_loader.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/stubs.o kernel/arch/CPU/smp.o kernel/arch/CPU/lapic.o \
-	    kernel/macho2.o kernel/printf.o kernel.bin n2.bin O2.elf O2.bin user/libc/libc.o disk.img \
-            kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o \
-            kernel/VM/heap_select.o kernel/VM/legacy_heap.o kernel/VM/nitroheap/nitroheap.o kernel/VM/nitroheap/classes.o \
-            kernel/uaccess.o kernel/proc_launch.o kernel/trap.o \
+	            kernel/nosm.o kernel/agent_loader.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/stubs.o kernel/arch/CPU/smp.o kernel/arch/CPU/lapic.o kernel/arch/GDT/gdt.o kernel/arch/GDT/tss.o kernel/arch/GDT/gdt_flush.o \
+	            kernel/macho2.o kernel/printf.o kernel.bin n2.bin O2.elf O2.bin user/libc/libc.o disk.img \
+	            kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o \
+	            kernel/VM/heap_select.o kernel/VM/legacy_heap.o kernel/VM/nitroheap/nitroheap.o kernel/VM/nitroheap/classes.o \
+	            kernel/uaccess.o kernel/proc_launch.o kernel/trap.o \
 	    kernel/symbols.o kernel/arch/idt_guard.o \
 	    $(AGENT_OBJS) $(AGENT_ELFS) $(AGENT_MO2) $(BIN_OBJS) $(BIN_ELFS) $(BIN_BINS) \
 	    src/agents/regx/regx.o user/agents/nosfs/nosfs.o user/agents/nosfs/nosfs_server.o user/agents/nosm/nosm.o \

--- a/kernel/arch/GDT/gdt.asm
+++ b/kernel/arch/GDT/gdt.asm
@@ -30,7 +30,7 @@ gdt_flush:
     lea rax, [rel .after]
     push qword 0x08           ; GDT_SEL_KERNEL_CODE
     push rax
-    lretq
+    retfq
 .after:
     pop rax
     ret
@@ -63,7 +63,7 @@ gdt_flush_with_tr:
     lea rax, [rel .after_flush_cs_tr]
     push qword GDT_SEL_KERNEL_CODE
     push rax
-    lretq
+    retfq
 
 .after_flush_cs_tr:
     pop rcx

--- a/kernel/arch/GDT/gdt.c
+++ b/kernel/arch/GDT/gdt.c
@@ -2,7 +2,7 @@
 #include "segments.h"
 #include <stdint.h>
 #include <string.h>
-#include "../../drivers/IO/serial.h"
+#include "drivers/IO/serial.h"
 
 /* ----- GDTR ----- */
 struct gdt_ptr {

--- a/kernel/arch/GDT/tss.c
+++ b/kernel/arch/GDT/tss.c
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include "tss.h"
 #include "gdt.h"
-#include "../../drivers/IO/serial.h"
+#include "drivers/IO/serial.h"
 
 static struct tss64 tss;
 static uint8_t tss_stack[4096];


### PR DESCRIPTION
## Summary
- compile and link GDT and TSS code along with the rest of the kernel
- correct serial header paths and assembly far-return usage for GDT/TSS

## Testing
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_689c017a22348333836ac800c111bab5