### PR TITLE
Initialize IDT before enabling interrupts

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -15,6 +15,7 @@
 #include "drivers/IO/usb.h"
 #include "drivers/IO/usbkbd.h"
 #include "Task/thread.h"
+#include "arch/IDT/idt.h"
 #include "arch/GDT/tss.h"
 #include "VM/numa.h"
 #include "VM/pmm_buddy.h"
@@ -74,6 +75,9 @@ void n2_main(bootinfo_t *bootinfo) {
 
     // Guard: probe/log IDT very early (no SSE, see idt_guard.c)
     if (idt_guard_init_once) idt_guard_init_once();
+
+    // Install our full ISR/IRQ table before enabling interrupts
+    idt_install();
 
     print_acpi_info(bootinfo);
     print_cpu_topology(bootinfo);


### PR DESCRIPTION
## Summary
- Load full interrupt descriptor table during kernel boot
- Prevent timer interrupt from triggering reboot loops

## Testing
- `make -C tests` *(fails: drivers/IO/serial.h: No such file or directory)*
- `make test_thread` (from tests directory)
- `./test_thread`


------
https://chatgpt.com/codex/tasks/task_b_689c04d244b48333a40a3d769fe561a1