### PR TITLE
Scrub segments and enforce GDT-only selectors

### DIFF
--- a/kernel/Task/user_mode.asm
+++ b/kernel/Task/user_mode.asm
@@ -10,6 +10,13 @@ extern assert_selector_gdt
 
 section .text
 enter_user_mode:
+    ; Scrub segment registers to known-good kernel data selector
+    mov  ax, GDT_SEL_KERNEL_DATA
+    mov  ds, ax
+    mov  es, ax
+    mov  fs, ax
+    mov  gs, ax
+
     ; Stash args in callee-saved regs
     mov  rbx, rdi     ; rbx = user RIP
     mov  r12, rsi     ; r12 = user RSP (should be canonical & 16B aligned)

--- a/kernel/arch/GDT/gdt.c
+++ b/kernel/arch/GDT/gdt.c
@@ -114,20 +114,6 @@ static void gdt_fill_core_segments(void)
     gdt_set_gate(SEL2IDX(GDT_SEL_KERNEL_CODE), 0, 0xFFFFF, ACC_CODE64_DPL0, GRAN_CODE64);
     gdt_set_gate(SEL2IDX(GDT_SEL_KERNEL_DATA), 0, 0xFFFFF, ACC_DATA_DPL0,  GRAN_DATA);
 
-    /* Optional ring1/2 (if you defined them in segments.h) */
-#ifdef GDT_SEL_RING1_CODE
-    gdt_set_gate(SEL2IDX(GDT_SEL_RING1_CODE),  0, 0xFFFFF, (ACC_CODE64_DPL0 | ACC_DPL(1)), GRAN_CODE64);
-#endif
-#ifdef GDT_SEL_RING1_DATA
-    gdt_set_gate(SEL2IDX(GDT_SEL_RING1_DATA),  0, 0xFFFFF, (ACC_DATA_DPL0   | ACC_DPL(1)), GRAN_DATA);
-#endif
-#ifdef GDT_SEL_RING2_CODE
-    gdt_set_gate(SEL2IDX(GDT_SEL_RING2_CODE),  0, 0xFFFFF, (ACC_CODE64_DPL0 | ACC_DPL(2)), GRAN_CODE64);
-#endif
-#ifdef GDT_SEL_RING2_DATA
-    gdt_set_gate(SEL2IDX(GDT_SEL_RING2_DATA),  0, 0xFFFFF, (ACC_DATA_DPL0   | ACC_DPL(2)), GRAN_DATA);
-#endif
-
     /* User ring 3 */
     gdt_set_gate(SEL2IDX(GDT_SEL_USER_CODE),   0, 0xFFFFF, ACC_CODE64_DPL3, GRAN_CODE64);
     gdt_set_gate(SEL2IDX(GDT_SEL_USER_DATA),   0, 0xFFFFF, ACC_DATA_DPL3,   GRAN_DATA);

--- a/kernel/arch/GDT/segments.h
+++ b/kernel/arch/GDT/segments.h
@@ -3,20 +3,12 @@
 /* ---------------- GDT selectors (byte values) ---------------- */
 #define GDT_SEL_KERNEL_CODE  0x08
 #define GDT_SEL_KERNEL_DATA  0x10
-#define GDT_SEL_USER_CODE    0x18
-#define GDT_SEL_USER_DATA    0x20
-#define GDT_SEL_RING1_CODE   0x28
-#define GDT_SEL_RING1_DATA   0x30
-#define GDT_SEL_RING2_CODE   0x38
-#define GDT_SEL_RING2_DATA   0x40
+#define GDT_SEL_USER_CODE    0x1B
+#define GDT_SEL_USER_DATA    0x23
 
-/* RPL-tagged convenience forms (same entry, different CPL on load) */
-#define GDT_SEL_RING1_CODE_R1 (GDT_SEL_RING1_CODE | 1)
-#define GDT_SEL_RING1_DATA_R1 (GDT_SEL_RING1_DATA | 1)
-#define GDT_SEL_RING2_CODE_R2 (GDT_SEL_RING2_CODE | 2)
-#define GDT_SEL_RING2_DATA_R2 (GDT_SEL_RING2_DATA | 2)
-#define GDT_SEL_USER_CODE_R3  (GDT_SEL_USER_CODE  | 3)
-#define GDT_SEL_USER_DATA_R3  (GDT_SEL_USER_DATA  | 3)
+/* RPL-tagged convenience forms (same value, explicit for legacy call sites) */
+#define GDT_SEL_USER_CODE_R3  GDT_SEL_USER_CODE
+#define GDT_SEL_USER_DATA_R3  GDT_SEL_USER_DATA
 
 /* Optional: 64-bit TSS selector (system descriptor, 16 bytes total) */
 #define GDT_SEL_TSS           0x48

--- a/kernel/arch/GDT/segments.inc
+++ b/kernel/arch/GDT/segments.inc
@@ -9,16 +9,12 @@
 ; ---------------------------
 %define GDT_SEL_KERNEL_CODE  0x08
 %define GDT_SEL_KERNEL_DATA  0x10
-%define GDT_SEL_USER_CODE    0x18
-%define GDT_SEL_USER_DATA    0x20
-%define GDT_SEL_RING1_CODE   0x28
-%define GDT_SEL_RING1_DATA   0x30
-%define GDT_SEL_RING2_CODE   0x38
-%define GDT_SEL_RING2_DATA   0x40
+%define GDT_SEL_USER_CODE    0x1B
+%define GDT_SEL_USER_DATA    0x23
 
 ; RPL=3 aliases for convenience (same table entry, different CPL on load)
-%define GDT_SEL_USER_CODE_R3 (GDT_SEL_USER_CODE | 3)
-%define GDT_SEL_USER_DATA_R3 (GDT_SEL_USER_DATA | 3)
+%define GDT_SEL_USER_CODE_R3 GDT_SEL_USER_CODE
+%define GDT_SEL_USER_DATA_R3 GDT_SEL_USER_DATA
 
 ; ---------------------------
 ; Optional system selectors
@@ -36,10 +32,6 @@
 %define GDT_IDX(sel)         ((sel) >> 3)
 %define GDT_IDX_KERNEL_CODE  GDT_IDX(GDT_SEL_KERNEL_CODE)
 %define GDT_IDX_KERNEL_DATA  GDT_IDX(GDT_SEL_KERNEL_DATA)
-%define GDT_IDX_RING1_CODE   GDT_IDX(GDT_SEL_RING1_CODE)
-%define GDT_IDX_RING1_DATA   GDT_IDX(GDT_SEL_RING1_DATA)
-%define GDT_IDX_RING2_CODE   GDT_IDX(GDT_SEL_RING2_CODE)
-%define GDT_IDX_RING2_DATA   GDT_IDX(GDT_SEL_RING2_DATA)
 %define GDT_IDX_USER_CODE    GDT_IDX(GDT_SEL_USER_CODE)
 %define GDT_IDX_USER_DATA    GDT_IDX(GDT_SEL_USER_DATA)
 %define GDT_IDX_TSS          GDT_IDX(GDT_SEL_TSS)

--- a/kernel/arch/IDT/isr.c
+++ b/kernel/arch/IDT/isr.c
@@ -129,12 +129,17 @@ void isr_gpf_handler(struct isr_context *ctx) {
     __asm__ volatile("mov %%es,%0" : "=r"(es));
     __asm__ volatile("mov %%fs,%0" : "=r"(fs));
     __asm__ volatile("mov %%gs,%0" : "=r"(gs));
-    serial_printf("LDTR=%04x CS=%04x SS=%04x DS=%04x ES=%04x FS=%04x GS=%04x\n",
-                  ldtr, cs, ss, ds, es, fs, gs);
+  serial_printf("LDTR=%04x CS=%04x SS=%04x DS=%04x ES=%04x FS=%04x GS=%04x\n",
+                ldtr, cs, ss, ds, es, fs, gs);
 
-    uint64_t *sp = (uint64_t *)(uintptr_t)ctx->rsp;
-    serial_printf("Stack5: %016lx %016lx %016lx %016lx %016lx\n",
-                  sp[0], sp[1], sp[2], sp[3], sp[4]);
+  const uint8_t *rip_bytes = (const uint8_t *)(uintptr_t)ctx->rip;
+  serial_printf("Bytes at RIP: ");
+  for (int i = 0; i < 16; ++i) serial_printf("%02x ", rip_bytes[i]);
+  serial_puts("\n");
+
+  uint64_t *sp = (uint64_t *)(uintptr_t)ctx->rsp;
+  serial_printf("Stack5: %016lx %016lx %016lx %016lx %016lx\n",
+                sp[0], sp[1], sp[2], sp[3], sp[4]);
 
     backtrace_rbp(ctx->rbp, 16);
 

--- a/tests/unit/test_gdt.c
+++ b/tests/unit/test_gdt.c
@@ -4,29 +4,24 @@
 
 /* Stub for gdt_flush from assembly */
 void gdt_flush(uint64_t ptr) { (void)ptr; }
+void gdt_flush_with_tr(uint64_t ptr, uint16_t sel) { (void)ptr; (void)sel; }
+void serial_printf(const char *fmt, ...) { (void)fmt; }
+void panic(const char *fmt, ...) { (void)fmt; }
 
 int main(void) {
     gdt_install();
     struct gdt_entry entry;
 
-    gdt_get_entry(GDT_SEL_RING1_CODE >> 3, &entry);
-    assert((entry.access & 0x60) == 0x20);
+    /* Kernel code should be DPL0 */
+    gdt_get_entry(GDT_SEL_KERNEL_CODE >> 3, &entry);
+    assert((entry.access & 0x60) == 0x00);
 
-    /* Ensure ring 1 selectors carry the correct RPL */
-    assert((GDT_SEL_RING1_CODE_R1 & 0x3) == 1);
-
-    gdt_get_entry(GDT_SEL_RING2_CODE >> 3, &entry);
-    assert((entry.access & 0x60) == 0x40);
-
-    /* Ensure ring 2 selectors carry the correct RPL */
-    assert((GDT_SEL_RING2_CODE_R2 & 0x3) == 2);
+    /* User code should be DPL3 */
+    gdt_get_entry(GDT_SEL_USER_CODE >> 3, &entry);
+    assert((entry.access & 0x60) == 0x60);
 
     /* Data segments must not set the 64-bit flag */
     gdt_get_entry(GDT_SEL_KERNEL_DATA >> 3, &entry);
-    assert((entry.granularity & 0x20) == 0);
-    gdt_get_entry(GDT_SEL_RING1_DATA >> 3, &entry);
-    assert((entry.granularity & 0x20) == 0);
-    gdt_get_entry(GDT_SEL_RING2_DATA >> 3, &entry);
     assert((entry.granularity & 0x20) == 0);
     gdt_get_entry(GDT_SEL_USER_DATA >> 3, &entry);
     assert((entry.granularity & 0x20) == 0);


### PR DESCRIPTION
## Summary
- Ensure user-mode trampoline clears DS/ES/FS/GS and validates GDT selectors before `iretq`.
- Trim the GDT to the standard four 64-bit segments and update selector constants accordingly.
- Enhance `#GP` handler with instruction-byte dumps and refresh unit tests for the new segment layout.

## Testing
- `make kernel`
- `gcc -I include -I kernel/arch/GDT tests/unit/test_gdt.c kernel/arch/GDT/gdt.c -o /tmp/test_gdt && /tmp/test_gdt`


------
https://chatgpt.com/codex/tasks/task_b_689c150df37c8333b9c450bc3fee7149