### PR TITLE
Scrub segment selectors and tighten GDT

### DIFF
--- a/kernel/Task/user_mode.asm
+++ b/kernel/Task/user_mode.asm
@@ -22,6 +22,13 @@ enter_user_mode:
     lea  rsi, [rel .str_cs]
     call assert_selector_gdt
 
+    ; Scrub segment registers to known-good kernel data selector
+    mov  ax, GDT_SEL_KERNEL_DATA
+    mov  ds, ax
+    mov  es, ax
+    mov  fs, ax
+    mov  gs, ax
+
     ; Build iretq frame: SS,RSP,RFLAGS,CS,RIP
     push GDT_SEL_USER_DATA_R3   ; SS (RPL=3)
     push r12                    ; RSP

--- a/kernel/arch/GDT/gdt.c
+++ b/kernel/arch/GDT/gdt.c
@@ -114,20 +114,6 @@ static void gdt_fill_core_segments(void)
     gdt_set_gate(SEL2IDX(GDT_SEL_KERNEL_CODE), 0, 0xFFFFF, ACC_CODE64_DPL0, GRAN_CODE64);
     gdt_set_gate(SEL2IDX(GDT_SEL_KERNEL_DATA), 0, 0xFFFFF, ACC_DATA_DPL0,  GRAN_DATA);
 
-    /* Optional ring1/2 (if you defined them in segments.h) */
-#ifdef GDT_SEL_RING1_CODE
-    gdt_set_gate(SEL2IDX(GDT_SEL_RING1_CODE),  0, 0xFFFFF, (ACC_CODE64_DPL0 | ACC_DPL(1)), GRAN_CODE64);
-#endif
-#ifdef GDT_SEL_RING1_DATA
-    gdt_set_gate(SEL2IDX(GDT_SEL_RING1_DATA),  0, 0xFFFFF, (ACC_DATA_DPL0   | ACC_DPL(1)), GRAN_DATA);
-#endif
-#ifdef GDT_SEL_RING2_CODE
-    gdt_set_gate(SEL2IDX(GDT_SEL_RING2_CODE),  0, 0xFFFFF, (ACC_CODE64_DPL0 | ACC_DPL(2)), GRAN_CODE64);
-#endif
-#ifdef GDT_SEL_RING2_DATA
-    gdt_set_gate(SEL2IDX(GDT_SEL_RING2_DATA),  0, 0xFFFFF, (ACC_DATA_DPL0   | ACC_DPL(2)), GRAN_DATA);
-#endif
-
     /* User ring 3 */
     gdt_set_gate(SEL2IDX(GDT_SEL_USER_CODE),   0, 0xFFFFF, ACC_CODE64_DPL3, GRAN_CODE64);
     gdt_set_gate(SEL2IDX(GDT_SEL_USER_DATA),   0, 0xFFFFF, ACC_DATA_DPL3,   GRAN_DATA);

--- a/kernel/arch/GDT/segments.h
+++ b/kernel/arch/GDT/segments.h
@@ -5,21 +5,13 @@
 #define GDT_SEL_KERNEL_DATA  0x10
 #define GDT_SEL_USER_CODE    0x18
 #define GDT_SEL_USER_DATA    0x20
-#define GDT_SEL_RING1_CODE   0x28
-#define GDT_SEL_RING1_DATA   0x30
-#define GDT_SEL_RING2_CODE   0x38
-#define GDT_SEL_RING2_DATA   0x40
 
 /* RPL-tagged convenience forms (same entry, different CPL on load) */
-#define GDT_SEL_RING1_CODE_R1 (GDT_SEL_RING1_CODE | 1)
-#define GDT_SEL_RING1_DATA_R1 (GDT_SEL_RING1_DATA | 1)
-#define GDT_SEL_RING2_CODE_R2 (GDT_SEL_RING2_CODE | 2)
-#define GDT_SEL_RING2_DATA_R2 (GDT_SEL_RING2_DATA | 2)
 #define GDT_SEL_USER_CODE_R3  (GDT_SEL_USER_CODE  | 3)
 #define GDT_SEL_USER_DATA_R3  (GDT_SEL_USER_DATA  | 3)
 
 /* Optional: 64-bit TSS selector (system descriptor, 16 bytes total) */
-#define GDT_SEL_TSS           0x48
+#define GDT_SEL_TSS           0x28
 
 /* Handy aliases used elsewhere */
 #define KERNEL_CS GDT_SEL_KERNEL_CODE

--- a/kernel/arch/GDT/segments.inc
+++ b/kernel/arch/GDT/segments.inc
@@ -11,10 +11,6 @@
 %define GDT_SEL_KERNEL_DATA  0x10
 %define GDT_SEL_USER_CODE    0x18
 %define GDT_SEL_USER_DATA    0x20
-%define GDT_SEL_RING1_CODE   0x28
-%define GDT_SEL_RING1_DATA   0x30
-%define GDT_SEL_RING2_CODE   0x38
-%define GDT_SEL_RING2_DATA   0x40
 
 ; RPL=3 aliases for convenience (same table entry, different CPL on load)
 %define GDT_SEL_USER_CODE_R3 (GDT_SEL_USER_CODE | 3)
@@ -23,9 +19,9 @@
 ; ---------------------------
 ; Optional system selectors
 ; ---------------------------
-; 64-bit TSS descriptor (16 bytes) lives at 0x48..0x4F (low 8) and 0x50..0x57 (high 8)
+; 64-bit TSS descriptor (16 bytes) lives at 0x28..0x2F (low 8) and 0x30..0x37 (high 8)
 ; If you install a TSS in the GDT, use this selector with LTR.
-%define GDT_SEL_TSS          0x48
+%define GDT_SEL_TSS          0x28
 
 ; (If you ever add an LDT: it’s another 16-byte system descriptor)
 ;%define GDT_SEL_LDT          0x58
@@ -36,10 +32,6 @@
 %define GDT_IDX(sel)         ((sel) >> 3)
 %define GDT_IDX_KERNEL_CODE  GDT_IDX(GDT_SEL_KERNEL_CODE)
 %define GDT_IDX_KERNEL_DATA  GDT_IDX(GDT_SEL_KERNEL_DATA)
-%define GDT_IDX_RING1_CODE   GDT_IDX(GDT_SEL_RING1_CODE)
-%define GDT_IDX_RING1_DATA   GDT_IDX(GDT_SEL_RING1_DATA)
-%define GDT_IDX_RING2_CODE   GDT_IDX(GDT_SEL_RING2_CODE)
-%define GDT_IDX_RING2_DATA   GDT_IDX(GDT_SEL_RING2_DATA)
 %define GDT_IDX_USER_CODE    GDT_IDX(GDT_SEL_USER_CODE)
 %define GDT_IDX_USER_DATA    GDT_IDX(GDT_SEL_USER_DATA)
 %define GDT_IDX_TSS          GDT_IDX(GDT_SEL_TSS)

--- a/kernel/arch/IDT/isr.c
+++ b/kernel/arch/IDT/isr.c
@@ -132,9 +132,15 @@ void isr_gpf_handler(struct isr_context *ctx) {
     serial_printf("LDTR=%04x CS=%04x SS=%04x DS=%04x ES=%04x FS=%04x GS=%04x\n",
                   ldtr, cs, ss, ds, es, fs, gs);
 
-    uint64_t *sp = (uint64_t *)(uintptr_t)ctx->rsp;
-    serial_printf("Stack5: %016lx %016lx %016lx %016lx %016lx\n",
-                  sp[0], sp[1], sp[2], sp[3], sp[4]);
+    /* Instruction bytes at faulting RIP */
+    uint8_t *rip = (uint8_t *)(uintptr_t)ctx->rip;
+    serial_printf("Instr: %02x %02x %02x %02x %02x %02x\n",
+                  rip[0], rip[1], rip[2], rip[3], rip[4], rip[5]);
+
+    /* Dump the iret frame that was about to be popped */
+    uint64_t *frame = (uint64_t *)(uintptr_t)ctx->rsp;
+    serial_printf("IRET frame: SS=%04lx RSP=%016lx RFLAGS=%016lx CS=%04lx RIP=%016lx\n",
+                  frame[0], frame[1], frame[2], frame[3], frame[4]);
 
     backtrace_rbp(ctx->rbp, 16);
 

--- a/kernel/n2_entry.asm
+++ b/kernel/n2_entry.asm
@@ -6,6 +6,8 @@ extern n2_main
 
 _start:
     cld
+    xor eax, eax
+    lldt ax              ; disable any LDT
     ; Enable SSE/FXSR before any C code runs
     mov rax, cr0
     and eax, 0xFFFFFFFB  ; clear EM

--- a/tests/unit/test_gdt.c
+++ b/tests/unit/test_gdt.c
@@ -9,26 +9,16 @@ int main(void) {
     gdt_install();
     struct gdt_entry entry;
 
-    gdt_get_entry(GDT_SEL_RING1_CODE >> 3, &entry);
-    assert((entry.access & 0x60) == 0x20);
-
-    /* Ensure ring 1 selectors carry the correct RPL */
-    assert((GDT_SEL_RING1_CODE_R1 & 0x3) == 1);
-
-    gdt_get_entry(GDT_SEL_RING2_CODE >> 3, &entry);
-    assert((entry.access & 0x60) == 0x40);
-
-    /* Ensure ring 2 selectors carry the correct RPL */
-    assert((GDT_SEL_RING2_CODE_R2 & 0x3) == 2);
-
-    /* Data segments must not set the 64-bit flag */
+    /* Kernel data segment must not set the 64-bit flag */
     gdt_get_entry(GDT_SEL_KERNEL_DATA >> 3, &entry);
     assert((entry.granularity & 0x20) == 0);
-    gdt_get_entry(GDT_SEL_RING1_DATA >> 3, &entry);
-    assert((entry.granularity & 0x20) == 0);
-    gdt_get_entry(GDT_SEL_RING2_DATA >> 3, &entry);
-    assert((entry.granularity & 0x20) == 0);
+
+    /* User code/data should have DPL=3 and data segment L flag clear */
+    gdt_get_entry(GDT_SEL_USER_CODE >> 3, &entry);
+    assert((entry.access & 0x60) == 0x60);
+
     gdt_get_entry(GDT_SEL_USER_DATA >> 3, &entry);
+    assert((entry.access & 0x60) == 0x60);
     assert((entry.granularity & 0x20) == 0);
 
     return 0;


### PR DESCRIPTION
## Summary
- clear LDTR on entry to disable LDT use
- remove Ring1/2 selectors and restrict GDT to kernel/user entries
- scrub segment registers and add detailed #GP diagnostics

## Testing
- `make -C tests test_gdt`
- `./tests/test_gdt && echo test_gdt_passed`


------
https://chatgpt.com/codex/tasks/task_b_689c150df37c8333b9c450bc3fee7149