### PR TITLE
Rewrite init and login agents

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -31,7 +31,7 @@ test_ftp: unit/test_ftp.c ../user/agents/ftp/ftp.c ../kernel/IPC/ipc.c $(LIBC_SR
 test_net: unit/test_net.c ../nosm/drivers/Net/netstack.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
-test_gdt: unit/test_gdt.c ../kernel/arch/GDT/gdt.c $(LIBC_SRC)
+test_gdt: unit/test_gdt.c ../kernel/arch/GDT/gdt.c $(filter-out gdt_stub.c,$(LIBC_SRC))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_nosfs: unit/test_nosfs.c ../user/agents/nosfs/nosfs.c \

--- a/tests/kprintf_stub.c
+++ b/tests/kprintf_stub.c
@@ -4,6 +4,6 @@ int kprintf(const char *fmt, ...) {
     return 0;
 }
 
-void panic(const char *fmt, ...) {
+__attribute__((weak)) void panic(const char *fmt, ...) {
     (void)fmt;
 }

--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -1,18 +1,11 @@
-/*
- * init agent (standalone, gated by regx)
- * - NO kernel headers
- * - NO stdio / thread_* / serial_* deps
- * - Uses AgentAPI passed by regx via agent_entry.c (api + self_tid)
- */
-
 #include "../../rt/agent_abi.h"
-#include "../../libc/libc.h"   /* memset, memcpy, strcmp, snprintf, malloc/free */
+#include "../../libc/libc.h"
 #include <stdint.h>
-#include <stddef.h>
 
-/* Optional embedded manifest for Mach-O2 discovery (won’t be referenced in code) */
+/* Minimal manifest so the loader can discover the entry point when the
+ * agent is packaged as a Mach-O2 binary. */
 __attribute__((used, section("\"__O2INFO,__manifest\"")))
-static const char mo2_manifest[] =
+static const char manifest[] =
 "{\n"
 "  \"name\": \"init\",\n"
 "  \"type\": 4,\n"
@@ -20,165 +13,24 @@ static const char mo2_manifest[] =
 "  \"entry\": \"_start\"\n"
 "}\n";
 
-/* ---------- minimal JSON helpers (string-only) ---------- */
-typedef struct {
-    char path[160];
-    char args[160];
-} svc_spec_t;
-
-#define MAX_SERVICES 16
-
-static int json_skip_ws(const char *s, int i) {
-    while (s[i]==' '||s[i]=='\t'||s[i]=='\r'||s[i]=='\n') i++;
-    return i;
-}
-static int json_match(const char *s, int i, const char *kw) {
-    int j=0; while (kw[j] && s[i+j]==kw[j]) j++; return kw[j]?0:1;
-}
-static int json_copy_quoted(const char *s, int i, char *out, size_t out_sz) {
-    i = json_skip_ws(s,i);
-    if (s[i]!='"') return -1;
-    i++;
-    size_t w=0;
-    while (s[i] && s[i]!='"' && w+1<out_sz) out[w++]=s[i++];
-    if (s[i]!='"') return -1;
-    out[w]=0;
-    return i+1;
-}
-static int parse_manifest_services(const char *buf, size_t len,
-                                   svc_spec_t *list, int max_list) {
-    (void)len;
-    int n=0, i=0;
-    while (buf[i]) {
-        i = json_skip_ws(buf,i);
-        if (json_match(buf,i,"\"services\"")) {
-            i+=10;
-            i = json_skip_ws(buf,i);
-            if (buf[i++]!=':') break;
-            i = json_skip_ws(buf,i);
-            if (buf[i++]!='[') break;
-
-            while (buf[i]) {
-                i = json_skip_ws(buf,i);
-                if (buf[i]==']') return n;
-                if (buf[i++]!='{') break;
-
-                char path[160]={0}, args[160]={0};
-                int have_path=0, have_args=0;
-
-                for (;;) {
-                    i = json_skip_ws(buf,i);
-                    if (buf[i]=='}') { i++; break; }
-
-                    char key[16]={0}, val[160]={0};
-                    int ni = json_copy_quoted(buf,i,key,sizeof(key));
-                    if (ni<0) return n;
-                    i = json_skip_ws(buf,ni);
-                    if (buf[i++]!=':') return n;
-                    i = json_skip_ws(buf,i);
-                    ni = json_copy_quoted(buf,i,val,sizeof(val));
-                    if (ni<0) return n;
-                    i = ni;
-
-                    if (!have_path && !strcmp(key,"path")) {
-                        snprintf(path,sizeof(path),"%s",val); have_path=1;
-                    } else if (!have_args && !strcmp(key,"args")) {
-                        snprintf(args,sizeof(args),"%s",val); have_args=1;
-                    }
-
-                    i = json_skip_ws(buf,i);
-                    if (buf[i]==',') { i++; continue; }
-                    if (buf[i]=='}') { i++; break; }
-                }
-
-                if (have_path && n<max_list) {
-                    snprintf(list[n].path,sizeof(list[n].path),"%s",path);
-                    snprintf(list[n].args,sizeof(list[n].args),"%s",args);
-                    n++;
-                }
-
-                i = json_skip_ws(buf,i);
-                if (buf[i]==',') { i++; continue; }
-                if (buf[i]==']') return n;
-            }
-        }
-        if (buf[i]) i++;
-    }
-    return n;
-}
-
-/* ---------- manifest loading via AgentAPI ---------- */
-static int load_manifest_from_disk(const AgentAPI *api,
-                                   svc_spec_t *out, int max_out) {
-    if (!api || !api->fs_read_all) return 0;
-
-    /* Read file into a temporary buffer */
-    size_t got = 0;
-    /* read up to 64 KiB */
-    size_t cap = 64*1024;
-    char *buf = (char*)malloc(cap+1);
-    if (!buf) return 0;
-
-    int rc = api->fs_read_all("/agents/init.json", buf, cap, &got);
-    if (rc!=0 || got==0) { free(buf); return 0; }
-    buf[got]=0;
-
-    int n = parse_manifest_services(buf, got, out, max_out);
-    free(buf);
-    return n;
-}
-
-/* ---------- fallback defaults ---------- */
-static int default_manifest(svc_spec_t *out, int max_out) {
-    /* Only include agents that ship on the current disk image.
-       Loading non-existent services (e.g., pkg or update) caused
-       init to stall before reaching the login agent. */
-    static const char *paths[] = {
-        "/agents/login.mo2",
-    };
-    int n = 0;
-    for (size_t i = 0; i < sizeof(paths)/sizeof(paths[0]) && n < max_out; ++i) {
-        snprintf(out[n].path, sizeof(out[n].path), "%s", paths[i]);
-        out[n].args[0] = 0;
-        n++;
-    }
-    return n;
-}
-
-/* ---------- public entry for agent (called by agent_entry.c) ---------- */
-void init_main(const AgentAPI *api, uint32_t self_tid)
-{
+/* Entry point for the init agent.  It simply launches the login agent and
+ * then yields forever. */
+void init_main(const AgentAPI *api, uint32_t self_tid) {
     (void)self_tid;
     if (!api) return;
 
-    if (api->puts)   api->puts("[init] starting\n");
-    if (api->regx_ping && !api->regx_ping())
-        if (api->puts) api->puts("[init] WARNING: regx did not answer ping\n");
+    if (api->puts) api->puts("[init] starting\n");
 
-    svc_spec_t svcs[MAX_SERVICES];
-    int count = load_manifest_from_disk(api, svcs, MAX_SERVICES);
-    if (count<=0) {
-        if (api->puts) api->puts("[init] /agents/init.json missing; using defaults\n");
-        count = default_manifest(svcs, MAX_SERVICES);
-    }
-
-    for (int i=0; i<count; ++i) {
-        uint32_t tid = 0;
-        int rc = api->regx_load ? api->regx_load(svcs[i].path,
-                        svcs[i].args[0]?svcs[i].args:NULL, &tid) : -1;
-        if (rc==0) {
-            if (api->printf) api->printf("[init] launched %s tid=%u\n", svcs[i].path, tid);
-        } else {
-            if (api->printf) api->printf("[init] FAILED %s rc=%d\n", svcs[i].path, rc);
-        }
-        if (api->yield) api->yield();
+    if (api->regx_load) {
+        int rc = api->regx_load("/agents/login.mo2", NULL, NULL);
+        if (api->printf)
+            api->printf("[init] launch login rc=%d\n", rc);
     }
 
     if (api->puts) api->puts("[init] bootstrap complete\n");
 
-    /* Light monitor loop */
     for (;;) {
         if (api->yield) api->yield();
-        for (volatile int i=0;i<200000;i++) __asm__ __volatile__("pause");
     }
 }
+

--- a/user/agents/login/agent_entry.c
+++ b/user/agents/login/agent_entry.c
@@ -2,7 +2,7 @@
 #include "login.h"
 
 // Real entry implemented in login.c
-void login_server(ipc_queue_t *fs_q, uint32_t self_id);
+void login_server(void *fs_q, uint32_t self_id);
 void thread_yield(void);
 
 // Manifest describing this agent

--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -1,176 +1,106 @@
 #include "login.h"
-#include "../../libc/libc.h"
 
-/*
- * We avoid pulling kernel-private headers. Declare just what we need.
- * In kernel-linked builds, these resolve to real implementations.
- * In standalone tests, the weak stubs below will be used.
- */
+/* Provide weak stubs for the minimal services the login agent relies on.
+ * In standalone unit tests these will be overridden by test-specific
+ * implementations. */
 __attribute__((weak)) void tty_init(void) {}
 __attribute__((weak)) void tty_clear(void) {}
 __attribute__((weak)) void tty_write(const char *s) { (void)s; }
 __attribute__((weak)) int  tty_getchar(void) { return -1; }
-
 __attribute__((weak)) void thread_yield(void) {}
 
-/* Optional serial helpers (used only for diagnostics). */
-__attribute__((weak)) void serial_puts(const char *s) { (void)s; }
-
-/* Basic network helper to print IP at login screen. */
-__attribute__((weak)) uint32_t net_get_ip(void) { return 0x0A00020F; } /* 10.0.2.15 default qemu user-net */
-
-/* Weak IPC stubs for standalone builds */
-__attribute__((weak)) int ipc_receive(ipc_queue_t *q, uint32_t tid, ipc_message_t *m) {
-    (void)q; (void)tid; (void)m; return -1;
-}
-__attribute__((weak)) int ipc_send(ipc_queue_t *q, uint32_t tid, ipc_message_t *m) {
-    (void)q; (void)tid; (void)m; return -1;
-}
-
-/* NitroShell entry — weak so the agent can run even without NSH linked. */
-__attribute__((weak)) void nsh_main(ipc_queue_t *fs_q, ipc_queue_t *pkg_q,
-                                    ipc_queue_t *upd_q, uint32_t self_id)
-{
+/* NitroShell entry point.  In tests a custom implementation is linked in. */
+__attribute__((weak)) void nsh_main(void *fs_q, void *pkg_q, void *upd_q,
+                                    uint32_t self_id) {
     (void)fs_q; (void)pkg_q; (void)upd_q; (void)self_id;
-    tty_write("[nsh] stub not implemented\n");
     for (;;) thread_yield();
 }
 
-/* Health ping/pong message types must match your ipc.h values. */
-#ifndef IPC_HEALTH_PING
-#define IPC_HEALTH_PING  0xF1
-#endif
-#ifndef IPC_HEALTH_PONG
-#define IPC_HEALTH_PONG  0xF2
-#endif
-
 volatile login_session_t current_session = {0};
 
-static ipc_queue_t *health_q = NULL;
-static uint32_t     login_tid = 0;
+/* Simple output helper (no stdio). */
+static void put_str(const char *s) { tty_write(s); }
 
-/* Small helpers (no stdio). */
-static void puts_out(const char *s) { tty_write(s); }
-
-static char *u8_to_str(unsigned v, char *buf)
-{
-    if (v >= 100) { *buf++ = '0' + v/100; v %= 100; }
-    if (v >= 10)  { *buf++ = '0' + v/10;  v %= 10;  }
-    *buf++ = '0' + v;
-    return buf;
-}
-
-static void ip_to_str(uint32_t ip, char *buf)
-{
-    for (int i = 3; i >= 0; --i) {
-        unsigned o = (ip >> (i*8)) & 0xFF;
-        buf = u8_to_str(o, buf);
-        if (i) *buf++ = '.';
-    }
-    *buf = '\0';
-}
-
-static char getchar_block(void)
-{
+/* Block until a character is available from the TTY.  While waiting we
+ * yield so the scheduler can run other work. */
+static char getchar_block(void) {
     int ch;
     for (;;) {
         ch = tty_getchar();
         if (ch >= 0) return (char)ch;
-
-        /* Answer health pings while idle */
-        if (health_q) {
-            ipc_message_t m = {0}, r = {0};
-            if (ipc_receive(health_q, login_tid, &m) == 0 && m.type == IPC_HEALTH_PING) {
-                r.type = IPC_HEALTH_PONG;
-                ipc_send(health_q, login_tid, &r);
-            }
-        }
         thread_yield();
     }
 }
 
-static void read_line(char *buf, size_t sz, int echo_asterisk)
-{
+/* Read a line of text from the TTY.  The caller decides whether characters
+ * are echoed back or replaced with asterisks (for passwords). */
+static void read_line(char *buf, size_t sz, int echo_asterisk) {
     size_t n = 0;
     for (;;) {
         char c = getchar_block();
-        if (c == '\r' || c == '\n') { puts_out("\n"); break; }
-        if ((c == '\b' || c == 127) && n) { puts_out("\b \b"); --n; continue; }
+        if (c == '\n' || c == '\r') { put_str("\n"); break; }
+        if ((c == '\b' || c == 127) && n) {
+            put_str("\b \b");
+            --n;
+            continue;
+        }
         if (n + 1 < sz) {
             buf[n++] = c;
-            if (echo_asterisk) puts_out("*");
-            else { char t[2] = {c, 0}; puts_out(t); }
+            if (echo_asterisk) {
+                put_str("*");
+            } else {
+                char t[2] = {c, 0};
+                put_str(t);
+            }
         }
     }
     buf[n] = 0;
 }
 
-/*
- * Manifest for Mach-O2 container (your loader is already looking for this).
- * Change "entry" if you rename the function below.
- */
-void login_server(ipc_queue_t *fs_q, uint32_t self_id)
-{
+/* Public entry point for the login server.  fs_q is currently unused but
+ * kept for ABI compatibility with the real system. */
+void login_server(void *fs_q, uint32_t self_id) {
     (void)fs_q;
-    health_q = fs_q;
-    login_tid = self_id;
+    (void)self_id;
 
     tty_init();
     tty_clear();
+    put_str("[login] server starting\n");
 
-    puts_out("[login] server starting\n");
-
-    /* Show IP to help users know where to SSH/VNC. */
-    char ipbuf[16];
-    ip_to_str(net_get_ip(), ipbuf);
-    puts_out("IP ");
-    puts_out(ipbuf);
-    puts_out(" (SSH/VNC)\n\n");
-
-    char user[32], pass[32];
-
-    /* trivial built-in auth db */
-    typedef struct { const char *u, *p; uint32_t uid; } cred_t;
-    static const cred_t creds[] = {
-        {"admin","admin",0},
-        {"guest","guest",1},
-    };
+    char user[32];
+    char pass[32];
 
     for (;;) {
-        const cred_t *hit = NULL;
-
-        puts_out("Username: ");
+        put_str("Username: ");
         read_line(user, sizeof(user), 0);
 
-        puts_out("Password: ");
+        put_str("Password: ");
         read_line(pass, sizeof(pass), 1);
 
-        for (size_t i = 0; i < sizeof(creds)/sizeof(creds[0]); ++i) {
-            if (!strcmp(user, creds[i].u) && !strcmp(pass, creds[i].p)) {
-                hit = &creds[i];
-                break;
-            }
+        if (!strcmp(user, "admin") && !strcmp(pass, "admin")) {
+            current_session.uid = 0;
+            strlcpy((char*)current_session.username, "admin",
+                    sizeof(current_session.username));
+        } else if (!strcmp(user, "guest") && !strcmp(pass, "guest")) {
+            current_session.uid = 1;
+            strlcpy((char*)current_session.username, "guest",
+                    sizeof(current_session.username));
+        } else {
+            put_str("Login failed\n\n");
+            continue;
         }
 
-        if (hit) {
-            puts_out("Login successful\n\n");
-            current_session.uid = hit->uid;
-            current_session.session_id++;
-            current_session.active = 1;
-            /* write username safely */
-            strlcpy((char*)current_session.username, hit->u, sizeof(current_session.username));
-            break;
-        } else {
-            puts_out("Login failed\n\n");
-        }
+        current_session.session_id++;
+        current_session.active = 1;
+        put_str("Login successful\n\n");
+        break;
     }
 
-    puts_out("[login] launching nsh...\n");
-    /* Launch NitroShell; pass NULL queues for now (keep ABI stable). */
+    /* Start NitroShell; queues are not yet wired up so NULLs are passed. */
     nsh_main(NULL, NULL, NULL, self_id);
 
-    /* nsh_main should not return; in unit tests allow graceful exit */
 #ifndef LOGIN_UNIT_TEST
     for (;;) thread_yield();
 #endif
 }
+

--- a/user/agents/login/login.h
+++ b/user/agents/login/login.h
@@ -4,43 +4,21 @@
 #include <stdint.h>
 #include "../../libc/libc.h"
 
-// Minimal IPC types so this header can be used without kernel internals
-#ifndef IPC_MSG_DATA_MAX
-#define IPC_MSG_DATA_MAX 64
-#endif
-
+/* Represents the state of the current authenticated session. */
 typedef struct {
-    uint32_t type;
-    uint32_t sender;
-    uint32_t arg1;
-    uint32_t arg2;
-    uint32_t len;
-    uint8_t  data[IPC_MSG_DATA_MAX];
-} ipc_message_t;
-
-typedef struct ipc_queue ipc_queue_t; // Opaque to the agent
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-typedef struct {
-    uint32_t uid;
-    uint32_t session_id;
-    uint8_t  active;
-    char     username[32];
+    uint32_t uid;            /* User identifier */
+    uint32_t session_id;     /* Monotonic session counter */
+    uint8_t  active;         /* Non-zero when a user is logged in */
+    char     username[32];   /* Null-terminated username */
 } login_session_t;
 
-/**
- * Entry point for the login server/agent.
- * In agent mode, regx will gate & launch this from the manifest "entry".
- */
-void login_server(ipc_queue_t *fs_q, uint32_t self_id);
+/* Entry point for the login agent.  The fs_q parameter is unused in this
+ * lightweight implementation and is typed as void* to avoid pulling in
+ * kernel IPC headers. */
+void login_server(void *fs_q, uint32_t self_id);
 
+/* Global session state exposed for tests and other agents. */
 extern volatile login_session_t current_session;
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
-
 #endif /* LOGIN_H */
+


### PR DESCRIPTION
## Summary
- Reimplement login agent with minimal TTY-driven credential handling and NitroShell launch
- Simplify init agent to start login and yield
- Fix unit test build by excluding gdt stubs and making panic stub weak
- Align login agent entry with simplified server prototype to drop ipc_queue_t dependency

## Testing
- `make agents`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689c322619e08333ac06e0b141c1f354