### PR TITLE
Consolidate regx launch helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ kernel: libc agents bins
 	$(CC) $(CFLAGS) -c kernel/trap.c -o kernel/trap.o
 	# New: page-mapped ELF loader + regx glue
 	$(CC) $(CFLAGS) -c loader/elf_paged_loader.c -o loader/elf_paged_loader.o
-	$(CC) $(CFLAGS) -c regx/regx_launch_elf_paged.c -o regx/regx_launch_elf_paged.o
+	$(CC) $(CFLAGS) -c src/agents/regx/regx_launch_elf_paged.c -o src/agents/regx/regx_launch_elf_paged.o
 	# Optional (diagnostics) if present:
 ifneq ($(wildcard kernel/arch/ud_handler_patch.c),)
 	$(CC) $(CFLAGS) -c kernel/arch/ud_handler_patch.c -o kernel/arch/ud_handler_patch.o
@@ -168,7 +168,7 @@ endif
 	$(CC) $(CFLAGS) -c kernel/nosfs_pub.c -o kernel/nosfs_pub.o
 	$(CC) $(CFLAGS) -c kernel/agent_loader_pub.c -o kernel/agent_loader_pub.o
 	$(CC) $(CFLAGS) -c kernel/loader_vm_pmm_shims.c -o kernel/loader_vm_pmm_shims.o
-	$(CC) $(CFLAGS) -c regx/regx_launch_adapters.c -o regx/regx_launch_adapters.o
+	$(CC) $(CFLAGS) -c src/agents/regx/regx_launch_adapters.c -o src/agents/regx/regx_launch_adapters.o
 
 	$(LD) -T kernel/n2.ld -Map kernel.map kernel/n2_entry.o kernel/n2_main.o kernel/builtin_nosfs.o \
 	    kernel/agent.o kernel/agent_loader.o kernel/agent_loader_pub.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/Task/context_switch.o kernel/Task/context_switch_asm.o \
@@ -179,7 +179,7 @@ endif
 	    kernel/proc_launch.o kernel/trap.o kernel/symbols.o \
 	    kernel/arch/idt_guard.o kernel/arch/IDT/idt.o kernel/arch/IDT/isr.o kernel/arch/IDT/isr_stub.o \
 	    loader/elf_paged_loader.o \
-	    regx/regx_launch_elf_paged.o \
+        src/agents/regx/regx_launch_elf_paged.o \
 	    kernel/nosfs_pub.o \
 	    nosm/drivers/IO/serial.o nosm/drivers/IO/usb.o nosm/drivers/IO/usbkbd.o nosm/drivers/IO/video.o nosm/drivers/IO/tty.o \
 	    nosm/drivers/IO/ps2.o nosm/drivers/IO/keyboard.o nosm/drivers/IO/mouse.o nosm/drivers/IO/pci.o nosm/drivers/IO/pic.o \
@@ -189,7 +189,7 @@ endif
 	    user/libc/libc.o \
 	    $(if $(wildcard kernel/arch/ud_handler_patch.o),kernel/arch/ud_handler_patch.o,) \
 	    kernel/loader_vm_pmm_shims.o \
-	    regx/regx_launch_adapters.o \
+        src/agents/regx/regx_launch_adapters.o \
 	    kernel/arch/APIC/lapic.o \
 		-o kernel.bin
 
@@ -238,7 +238,7 @@ clean:
 	    nosm/drivers/IO/pit.o nosm/drivers/IO/block.o nosm/drivers/IO/sata.o nosm/drivers/Net/e1000.o nosm/drivers/Net/netstack.o \
 	    nosm/drivers/example/hello/hello_nmod.o out/modules/hello.elf out/modules/hello.mo2 \
 	    kernel/login_bin.h \
-	    loader/elf_paged_loader.o regx/regx_launch_elf_paged.o \
+        loader/elf_paged_loader.o src/agents/regx/regx_launch_elf_paged.o \
 	    kernel/arch/ud_handler_patch.o
 	rm -rf out
 	make -C boot clean

--- a/src/agents/regx/regx_launch_adapters.c
+++ b/src/agents/regx/regx_launch_adapters.c
@@ -1,4 +1,4 @@
-// regx/regx_launch_adapters.c
+// src/agents/regx/regx_launch_adapters.c
 // Adapts to your thread/stack APIs so regx_launch_elf_paged links cleanly.
 
 #include <stddef.h>
@@ -6,8 +6,8 @@
 #include <stdarg.h>
 
 #include "drivers/IO/serial.h"
-#include "../kernel/VM/legacy_heap.h"
-#include "../kernel/Task/thread.h"
+#include "../../../kernel/VM/legacy_heap.h"
+#include "../../../kernel/Task/thread.h"
 
 // Allocate a simple stack for user threads
 void* create_user_stack(size_t size) {

--- a/src/agents/regx/regx_launch_elf_paged.c
+++ b/src/agents/regx/regx_launch_elf_paged.c
@@ -1,9 +1,9 @@
 // ============================================================================
-// File: regx/regx_launch_elf_paged.c  (optional glue)
+// File: src/agents/regx/regx_launch_elf_paged.c  (optional glue)
 // Purpose: Helper to launch an ELF agent using the page-mapped loader
 // ============================================================================
 #include <stdint.h>
-#include "../loader/elf_paged_loader.h"
+#include "../../../loader/elf_paged_loader.h"
 
 // Kernel/threading hooks (provided by your kernel)
 extern int   thread_spawn(uintptr_t rip, void* user_stack_top, uint32_t prio, uint32_t* out_tid);


### PR DESCRIPTION
## Summary
- Move `regx_launch_*` helpers into `src/agents/regx` to keep regx components together
- Update include paths and Makefile entries for the new location

## Testing
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_689c518bff608333832e81067162999f