### PR TITLE
Refactor regx IPC handler to remove duplication

### DIFF
--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -7,7 +7,6 @@
 #include "../../../nosm/drivers/IO/serial.h"
 #include "../../../kernel/agent_loader.h"
 #include "../../../kernel/init_bin.h"
-#include "../../../kernel/login_bin.h"
 #include "../../../user/agents/nosfs/nosfs_server.h"
 #include "../../../user/libc/string_guard.h"
 

--- a/src/agents/regx/regx_ipc.c
+++ b/src/agents/regx/regx_ipc.c
@@ -38,33 +38,3 @@ void regx_ipc_handle(const regx_ipc_req_t *req, regx_ipc_resp_t *resp) {
         break;
     }
 }
-#include "regx_ipc.h"
-
-void regx_ipc_handle(const regx_ipc_req_t *req, regx_ipc_resp_t *resp) {
-    memset(resp, 0, sizeof(*resp));
-    switch (req->op) {
-    case REGX_IPC_ENUM:
-        resp->count = regx_enumerate(&req->sel, resp->entries, REGX_MAX_ENTRIES);
-        resp->status = 0;
-        break;
-    case REGX_IPC_QUERY: {
-        const regx_entry_t *e = regx_query(req->id);
-        if (e) { resp->entry = *e; resp->status = 0; }
-        else   { resp->status = -1; }
-        break;
-    }
-    case REGX_IPC_REGISTER:
-        resp->entry.id = regx_register(&req->manifest, req->id);
-        resp->status = (resp->entry.id ? 0 : -1);
-        break;
-    case REGX_IPC_UNREGISTER:
-        resp->status = regx_unregister(req->id);
-        break;
-    case REGX_IPC_TREE: // Full dump
-        resp->count = regx_enumerate(NULL, resp->entries, REGX_MAX_ENTRIES);
-        resp->status = 0;
-        break;
-    default:
-        resp->status = -99;
-    }
-}


### PR DESCRIPTION
## Summary
- collapse duplicate regx_ipc_handle implementation into a single defensively checked version
- drop stale login_bin include from regx agent

## Testing
- `make CC=clang CFLAGS='-O2 -Wall -fno-builtin -nostdlib -fPIC -I ../../../include -I ../../../user/libc'` *(fails: undefined references)*
- `clang -c regx_ipc.c -O2 -Wall -fno-builtin -nostdlib -fPIC -I ../../../include -I ../../../user/libc -o /tmp/regx_ipc.o`

------
https://chatgpt.com/codex/tasks/task_b_689c5eaf17348333a6287569f7024f70