### PR TITLE
feat: run init as userspace agent loader

### DIFF
--- a/loader/dyld2.c
+++ b/loader/dyld2.c
@@ -3,7 +3,7 @@
 // ============================================================================
 #include "dyld2.h"
 #include "mo2_format.h"
-#include "../libc/libc.h"
+#include "../user/libc/libc.h"
 #include <stdint.h>
 
 typedef struct ExportKV { const char* name; void* addr; struct ExportKV* next; } ExportKV;
@@ -200,7 +200,7 @@ static Module* load_one(const char* path){
 int dyld2_init(const AgentAPI* api){ G=api; LOG("[dyld2] init\n"); return 0; }
 
 mo2_handle_t dyld2_dlopen(const char* path, int flags){ (void)flags; return (mo2_handle_t)load_one(path); }
-mo2_sym_t    dyld2_dlsym(mo2_handle_t h, const char* name){ Module* m=(Module*)h; return exports_find(m,name); }
+mo2_sym_handle_t dyld2_dlsym(mo2_handle_t h, const char* name){ Module* m=(Module*)h; return exports_find(m,name); }
 int          dyld2_dlclose(mo2_handle_t h){ Module* m=(Module*)h; unregister_module(m); return 0; }
 
 int dyld2_run_exec(const char* path, int argc, const char** argv){

--- a/loader/dyld2.h
+++ b/loader/dyld2.h
@@ -3,15 +3,15 @@
 // ============================================================================
 #ifndef DYLD2_H
 #define DYLD2_H
-#include "../rt/agent_abi.h"
+#include "../user/rt/agent_abi.h"
 #include <stddef.h>
 
 typedef void* mo2_handle_t;
-typedef void* mo2_sym_t;
+typedef void* mo2_sym_handle_t;
 
 int          dyld2_init(const AgentAPI* api);
 mo2_handle_t dyld2_dlopen(const char* path, int flags); // flags: 1=EAGER, 2=NODELETE
-mo2_sym_t    dyld2_dlsym(mo2_handle_t h, const char* name);
+mo2_sym_handle_t dyld2_dlsym(mo2_handle_t h, const char* name);
 int          dyld2_dlclose(mo2_handle_t h);
 
 /* optional: start an executable image (transfer control) */

--- a/user/agents/init/dyld2_loader.c
+++ b/user/agents/init/dyld2_loader.c
@@ -1,0 +1,1 @@
+#include "../../../loader/dyld2.c"

--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -1,5 +1,6 @@
 #include "../../rt/agent_abi.h"
 #include "../../libc/libc.h"
+#include "dyld2.h"
 #include <stdint.h>
 
 /* Minimal manifest so the loader can discover the entry point when the
@@ -13,24 +14,23 @@ static const char manifest[] =
 "  \"entry\": \"_start\"\n"
 "}\n";
 
-/* Entry point for the init agent.  It simply launches the login agent and
- * then yields forever. */
+/* Entry point for the init agent.  It now acts as a userspace agent loader
+ * using the dyld2 runtime to start other agents in a sandboxed manner. */
 void agent_main(void) {
     const AgentAPI *api = NOS;
     uint32_t self_tid = NOS_TID;
     (void)self_tid;
     if (!api) return;
 
-    if (api->puts) api->puts("[init] starting\n");
+    if (api->puts) api->puts("[init] starting with dyld2\n");
+    dyld2_init(api);
 
-    if (api->regx_load) {
-        int rc = api->regx_load("/agents/login.mo2", NULL, NULL);
-        if (api->printf)
-            api->printf("[init] launch login rc=%d\n", rc);
-    }
+    const char *login_path = "/agents/login.mo2";
+    const char *argvv[2] = { "login", 0 };
+    int rc = dyld2_run_exec(login_path, 1, argvv);
+    if (api->printf) api->printf("[init] login exited rc=%d\n", rc);
 
-    if (api->puts) api->puts("[init] bootstrap complete\n");
-
+    if (api->puts) api->puts("[init] idle loop\n");
     for (;;) {
         if (api->yield) api->yield();
     }


### PR DESCRIPTION
## Summary
- boot init via dyld2 so it can load other agents from userspace
- embed dyld2 into init build and fix headers for user paths

## Testing
- `make agents`


------
https://chatgpt.com/codex/tasks/task_b_689c71e64c5c8333aa04c9c2676cb209