### PR TITLE
Fix deprecated stack pointer clobber and unused parameter

### DIFF
--- a/kernel/agent_loader.c
+++ b/kernel/agent_loader.c
@@ -94,6 +94,7 @@ static void* kalloc_aligned_or_arena(size_t bytes, size_t align) {
 static size_t apply_relocations_rela(uint8_t* load_base, uint64_t lo_for_exec,
                                      const Elf64_Ehdr* eh, const void* img, size_t sz)
 {
+    (void)sz;
     const Elf64_Phdr *ph = (const Elf64_Phdr *)((const uint8_t*)img + eh->e_phoff);
     uint64_t base_adj = (eh->e_type == ET_EXEC) ? lo_for_exec : 0;
     size_t applied = 0;

--- a/user/rt/rt0_agent.c
+++ b/user/rt/rt0_agent.c
@@ -8,7 +8,7 @@ __attribute__((noreturn)) void agent_main(void);
 
 __attribute__((noreturn))
 void _start(const AgentAPI *api, uint32_t self_tid) {
-    __asm__ __volatile__("andq $-16, %%rsp" ::: "rsp");
+    __asm__ __volatile__("andq $-16, %%rsp" ::: "memory");
     NOS = api;
     NOS_TID = self_tid;
     agent_main();


### PR DESCRIPTION
## Summary
- Avoid deprecated `rsp` clobber in agent runtime start routine
- Silence unused parameter warning in agent loader

## Testing
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_689c7596409c8333b91d4a9c326981d6