### PR TITLE
Fix login agent path to prevent boot hang

### DIFF
--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -25,7 +25,7 @@ void agent_main(void) {
     if (api->puts) api->puts("[init] starting with dyld2\n");
     dyld2_init(api);
 
-    const char *login_path = "/agents/login.mo2";
+    const char *login_path = "agents/login.mo2";
     const char *argvv[2] = { "login", 0 };
     int rc = dyld2_run_exec(login_path, 1, argvv);
     if (api->printf) api->printf("[init] login exited rc=%d\n", rc);


### PR DESCRIPTION
## Summary
- Ensure init agent uses relative path when launching login module so it can be found at boot

## Testing
- `make agents`


------
https://chatgpt.com/codex/tasks/task_b_689c760c204883338c7675e1e7677ac4