### PR TITLE
Handle missing AgentAPI in init agent

### DIFF
--- a/tests/thread_test_stubs.c
+++ b/tests/thread_test_stubs.c
@@ -12,3 +12,4 @@ void ipc_init(void *q) { (void)q; }
 void ipc_grant(void *q, uint32_t id, uint32_t caps) { (void)q; (void)id; (void)caps; }
 int agent_loader_run_from_path(const char *path, int prio) { (void)path; (void)prio; return -1; }
 void serial_puts(const char *s) { (void)s; }
+void arm_init_watchdog(void) {}

--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -20,7 +20,15 @@ void agent_main(void) {
     const AgentAPI *api = NOS;
     uint32_t self_tid = NOS_TID;
     (void)self_tid;
-    if (!api) return;
+    /*
+     * _start (from rt0_agent.c) declares agent_main() as noreturn.  If the
+     * kernel failed to supply the AgentAPI pointer, returning here would jump
+     * into random memory and wedge the boot sequence.  Instead, halt forever so
+     * the behaviour is defined and we can still diagnose the issue.
+     */
+    if (!api) {
+        for (;;) __asm__ __volatile__("hlt");
+    }
 
     if (api->puts) api->puts("[init] starting with dyld2\n");
     dyld2_init(api);


### PR DESCRIPTION
## Summary
- prevent `agent_main` from returning when the kernel doesn't provide an AgentAPI pointer
- add missing `arm_init_watchdog` stub for thread unit tests

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689c760c204883338c7675e1e7677ac4