### PR TITLE
Launch login via dyld2 in init agent

### DIFF
--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -1,9 +1,6 @@
 #include "../../rt/agent_abi.h"
 #include "../../libc/libc.h"
 #include "dyld2.h"
-#include <stdint.h>
-
-static inline void dbg_char(char c){ __asm__ __volatile__("outb %0,$0xe9"::"a"(c)); }
 
 /* Minimal manifest so the loader can discover the entry point when the
  * agent is packaged as a Mach-O2 binary. */
@@ -18,26 +15,29 @@ static const char manifest[] =
 
 /* Entry point for the init agent.  It now acts as a userspace agent loader
  * using the dyld2 runtime to start other agents in a sandboxed manner. */
-static inline void dbg_ch(char c){ __asm__ __volatile__("outb %0,$0xe9"::"a"(c)); }
-static inline void dbg_str(const char*s){ while(*s) dbg_ch(*s++); }
-static inline void dbg_hex(uint64_t v){ for(int i=60;i>=0;i-=4){ int n=(v>>i)&0xF; dbg_ch(n<10?'0'+n:'A'+n-10); } }
+void init_main(const AgentAPI *api, uint32_t self_tid)
+{
+    (void)self_tid;
+    if (!api)
+        return;
 
-void init_main(const AgentAPI *api, uint32_t self_tid) {
-    dbg_str("[init] entered api="); dbg_hex((uint64_t)api);
-    dbg_str(" tid="); dbg_hex(self_tid); dbg_ch('\n');
+    if (api->puts)
+        api->puts("[init] starting with dyld2\n");
 
-    if (api && api->puts) api->puts("[init] starting\n");
-    else dbg_str("[init] puts=NULL\n");
+    dyld2_init(api);
 
-    int rc = -1;
-    if (api && api->regx_load) rc = api->regx_load("/agents/login.mo2", NULL, NULL);
-    else dbg_str("[init] regx_load=NULL\n");
+    const char *argvv[2] = { "login", 0 };
+    int rc = dyld2_run_exec("/agents/login.mo2", 1, argvv);
+    if (api->printf)
+        api->printf("[init] login exited rc=%d\n", rc);
 
-    if (api && api->printf) api->printf("[init] launch login rc=%d\n", rc);
-    else dbg_str("[init] printf=NULL\n");
+    if (api->puts)
+        api->puts("[init] idle loop\n");
 
-    if (api && api->puts) api->puts("[init] bootstrap complete\n");
-    else dbg_str("[init] done\n");
-
-    for(;;){ if (api && api->yield) api->yield(); __asm__ __volatile__("pause"); }
+    for (;;) {
+        if (api->yield)
+            api->yield();
+        for (volatile int i = 0; i < 200000; i++)
+            __asm__ __volatile__("pause");
+    }
 }


### PR DESCRIPTION
## Summary
- Use dyld2 runtime in init agent and execute login.mo2 to bring up TTY login

## Testing
- `make -C tests`
- `gcc -ffreestanding -O2 -Wall -Wextra -mno-red-zone -nostdlib -DKERNEL_BUILD -fno-builtin -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -I include -I boot/include -I nosm -I loader -I src/agents/regx -I kernel -fPIE -c user/agents/init/init.c -o /tmp/init.o`


------
https://chatgpt.com/codex/tasks/task_b_689cabee355483338b9c482be00dd3bb