### PR TITLE
Add MAC query to net stack and pwd command to NitroShell

### DIFF
--- a/nosm/drivers/Net/netstack.c
+++ b/nosm/drivers/Net/netstack.c
@@ -189,6 +189,12 @@ void net_set_ip(uint32_t ip) {
     ip_addr = ip;
 }
 
+void net_get_mac(uint8_t out[6]) {
+    if (!out) return;
+    for (int i = 0; i < 6; ++i)
+        out[i] = our_mac[i];
+}
+
 // ---- Socket style API ---------------------------------------------------
 
 int net_socket_open(uint16_t port, net_socket_type_t type) {

--- a/nosm/drivers/Net/netstack.h
+++ b/nosm/drivers/Net/netstack.h
@@ -34,6 +34,9 @@ void net_poll(void);
 uint32_t net_get_ip(void);
 void net_set_ip(uint32_t ip);
 
+// Retrieve the MAC address currently configured for the stack.
+void net_get_mac(uint8_t out[6]);
+
 // Convenience helpers for transmitting IPv4 packets.
 int net_send_ipv4_udp(uint32_t dst_ip, uint16_t src_port, uint16_t dst_port,
                       const void *data, size_t len);

--- a/tests/unit/test_net.c
+++ b/tests/unit/test_net.c
@@ -89,6 +89,11 @@ static uint16_t htons(uint16_t x) { return (x >> 8) | (x << 8); }
 
 int main(void) {
     net_set_ip(0x0A00020F);
+    assert(net_get_ip() == 0x0A00020F);
+    uint8_t mac[6];
+    net_get_mac(mac);
+    for (int i = 0; i < 6; ++i)
+        assert(mac[i] == 0);
     uint8_t payload[3] = {1,2,3};
 
     /* Basic socket open/close and loopback send/recv */

--- a/user/agents/nsh/nsh.c
+++ b/user/agents/nsh/nsh.c
@@ -437,6 +437,7 @@ static void cmd_help(void) {
     puts_out("  update TARGET - update kernel or userland\n");
     puts_out("  cd DIR    - change directory\n");
     puts_out("  mkdir DIR - make directory\n");
+    puts_out("  pwd       - print working directory\n");
     puts_out("  help      - show this message\n");
 }
 
@@ -479,6 +480,9 @@ void nsh_main(ipc_queue_t *fs_q, ipc_queue_t *pkg_q, ipc_queue_t *upd_q, uint32_
             cmd_cd(fs_q, self_id, argv[1]);
         } else if (!strcmp(argv[0], "mkdir") && argc > 1) {
             cmd_mkdir(fs_q, self_id, argv[1]);
+        } else if (!strcmp(argv[0], "pwd")) {
+            puts_out(cwd);
+            putc_out('\n');
         } else if (!strcmp(argv[0], "install") && argc > 1) {
             cmd_install_pkg(pkg_q, self_id, argv[1]);
         } else if (!strcmp(argv[0], "uninstall") && argc > 1) {


### PR DESCRIPTION
## Summary
- expose a new `net_get_mac` helper for retrieving the current MAC address
- exercise MAC/IP querying in `test_net`
- extend NitroShell with a `pwd` command and help entry

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_b_689cbeb80c808333a3e50a52a813851a