### PR TITLE
Declare strlcpy and remove duplicate kernel string helpers

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -1,0 +1,4 @@
+#pragma once
+#include_next <string.h>
+
+size_t strlcpy(char *dst, const char *src, size_t size);

--- a/kernel/klib/string.c
+++ b/kernel/klib/string.c
@@ -1,4 +1,13 @@
 // Minimal freestanding string/memory for the kernel
+//
+// The full user-space libc (user/libc/libc.c) already provides robust
+// implementations of these routines along with additional helpers like
+// `strnlen`, `strlcpy`, and `snprintf`.  When linking the kernel we pull
+// in that libc, which results in multiple-definition errors if this file
+// also defines the same symbols.  Since the libc versions are more
+// complete, this legacy implementation is now disabled to avoid clashes
+// during linkage while keeping the source around for reference.
+#if 0
 #include <stddef.h>
 #include "string.h"
 
@@ -81,3 +90,4 @@ char *strrchr(const char *s, int c) {
     for (; *s; ++s) if (*s == ch) last = s;
     return (char*)( (ch == 0) ? s : last );
 }
+#endif


### PR DESCRIPTION
## Summary
- expose `strlcpy` through a new `string.h` overlay for kernel builds
- disable legacy `kernel/klib/string.c` implementations to avoid multiple-definition conflicts with user libc

## Testing
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_689cbff3e4908333a58c704e83cbc272