### PR TITLE
Add headers for kernel library

### DIFF
--- a/kernel/klib/stdio.c
+++ b/kernel/klib/stdio.c
@@ -1,6 +1,7 @@
 // Minimal freestanding stdio for the kernel
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include "stdio.h"
 
 // If your kernel already has a low-level console putc, declare it here.

--- a/kernel/klib/stdio.h
+++ b/kernel/klib/stdio.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <stdarg.h>
+
+// Low-level console output provided by the kernel
+void kcons_putc(int c);
+
+int putchar(int c);
+int puts(const char *s);
+int vprintf(const char *fmt, va_list ap);
+int printf(const char *fmt, ...);

--- a/kernel/klib/stdlib.h
+++ b/kernel/klib/stdlib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+// Placeholder for future kernel stdlib implementations

--- a/kernel/klib/string.h
+++ b/kernel/klib/string.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <stddef.h>
+
+void *memcpy(void *dest, const void *src, size_t n);
+void *memmove(void *dest, const void *src, size_t n);
+void *memset(void *s, int c, size_t n);
+int memcmp(const void *s1, const void *s2, size_t n);
+size_t strlen(const char *s);
+char *strcpy(char *dest, const char *src);
+char *strncpy(char *dest, const char *src, size_t n);
+int strcmp(const char *s1, const char *s2);
+int strncmp(const char *s1, const char *s2, size_t n);
+char *strchr(const char *s, int c);
+char *strrchr(const char *s, int c);


### PR DESCRIPTION
## Summary
- add stdio.h with prototypes for kernel console output and printf helpers
- add string.h with basic memory and string operations
- add placeholder stdlib.h
- include <stdint.h> in stdio.c

## Testing
- `make kernel` *(fails: multiple definition of printf/memcpy/memmove...)*

------
https://chatgpt.com/codex/tasks/task_b_689cc0d3d8308333be064eabb5e3225d