### PR TITLE
Fix cpuid helper warnings and define uintptr_t for printf

### DIFF
--- a/kernel/arch/CPU/cpu.c
+++ b/kernel/arch/CPU/cpu.c
@@ -9,7 +9,19 @@ static inline void cpuid2(uint32_t leaf, uint32_t subleaf,
     __asm__ volatile("cpuid"
                      : "=a"(ra), "=b"(rb), "=c"(rc), "=d"(rd)
                      : "a"(leaf), "c"(subleaf));
-    if (a) *a = ra; if (b) *b = rb; if (c) *c = rc; if (d) *d = rd;
+
+    if (a) {
+        *a = ra;
+    }
+    if (b) {
+        *b = rb;
+    }
+    if (c) {
+        *c = rc;
+    }
+    if (d) {
+        *d = rd;
+    }
 }
 
 static inline uint32_t cpuid_max_basic(void) {

--- a/kernel/klib/stdio.c
+++ b/kernel/klib/stdio.c
@@ -2,6 +2,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include "stdio.h"
+#include <stdint.h>
 
 // If your kernel already has a low-level console putc, declare it here.
 // Provide one of these somewhere in the kernel (serial, VGA, etc.):


### PR DESCRIPTION
## Summary
- Avoid misleading indentation in `cpuid2` by breaking out register assignments
- Include `<stdint.h>` so `uintptr_t` is available to `printf`

## Testing
- `make` *(fails: clang: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689cc2aa27d08333a5a81d50c837f385