### PR TITLE
Resolve printf symbol collision by using klib implementation

### DIFF
--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -1,24 +1,22 @@
 #include <stdarg.h>
 #include "drivers/IO/serial.h"
+#include "klib/stdio.h"
 #include "panic.h"
 
-static int kvprintf(const char *fmt, va_list ap) {
-    serial_vprintf(fmt, ap);
-    return 0;
-}
-
-int printf(const char *fmt, ...) {
-    va_list ap;
-    va_start(ap, fmt);
-    int ret = kvprintf(fmt, ap);
-    va_end(ap);
-    return ret;
+/*
+ * Provide a low-level console character output so the minimal stdio
+ * implementation in klib can route all formatted printing through the
+ * serial driver.  This replaces the old standalone printf implementation
+ * and avoids duplicate symbol definitions when linking.
+ */
+void kcons_putc(int c) {
+    serial_write((char)c);
 }
 
 int kprintf(const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
-    int ret = kvprintf(fmt, ap);
+    int ret = vprintf(fmt, ap);
     va_end(ap);
     return ret;
 }
@@ -27,7 +25,7 @@ void panic(const char *fmt, ...) {
     va_list ap;
     serial_puts("[panic] ");
     va_start(ap, fmt);
-    kvprintf(fmt, ap);
+    vprintf(fmt, ap);
     va_end(ap);
     serial_puts("\n");
     for (;;) {


### PR DESCRIPTION
## Summary
- Hook kernel console output through `kcons_putc` so the shared stdio implementation drives the serial port
- Replace bespoke `printf` implementation with wrappers around `vprintf` and preserve `kprintf`/`panic`

## Testing
- `make kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689cc3a538dc8333b991389e5e1df2d1