### PR TITLE
Initialize stack and disable interrupts before N2 launch

### DIFF
--- a/kernel/n2_entry.asm
+++ b/kernel/n2_entry.asm
@@ -3,9 +3,15 @@ global _start
 
 ; Kernel entry symbol implemented in C
 extern n2_main
+; Top of the bootstrap stack provided by n2_main.c
+extern _kernel_stack_top
 
 _start:
+    cli
     cld
+    ; Set up a known-good stack before calling C code
+    mov rsp, [_kernel_stack_top]
+
     ; Enable SSE/FXSR before any C code runs
     mov rax, cr0
     and eax, 0xFFFFFFFB  ; clear EM

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -41,8 +41,7 @@ __attribute__((weak)) void idt_guard_init_once(void);
 static void kprint(const char *s) { serial_puts(s); }
 
 /* Default kernel stack for TSS RSP0 */
-static uint8_t kernel_stack[4096] __attribute__((aligned(16)));
-uint8_t *_kernel_stack_top = kernel_stack + sizeof(kernel_stack);
+uint8_t *_kernel_stack_top = (uint8_t *)0x1FF000;
 
 #if VERBOSE
 #define vprint(s) kprint(s)


### PR DESCRIPTION
## Summary
- set up a fixed bootstrap stack pointer and expose it for TSS initialization
- disable interrupts and load stack before enabling SSE in N2 entry

## Testing
- `make kernel`
- `make image`


------
https://chatgpt.com/codex/tasks/task_b_689cc6d719e08333a60b6317388ffa6b