### PR TITLE
Add user mode context and switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,8 @@ kernel: libc agents bins
 	$(NASM) -f elf64 kernel/n2_entry.asm -o kernel/n2_entry.o
 	$(NASM) -f elf64 kernel/Task/context_switch.asm -o kernel/Task/context_switch_asm.o
 	$(CC) $(CFLAGS) -c kernel/Task/context_switch.c -o kernel/Task/context_switch.o
+	$(NASM) -f elf64 kernel/Task/switch_to_user.asm -o kernel/Task/switch_to_user.o
+	$(CC) $(CFLAGS) -c kernel/Task/user_thread.c -o kernel/Task/user_thread.o
 	$(CC) $(O2_CFLAGS) -c kernel/O2.c -o kernel/O2.o
 	$(CC) $(CFLAGS) -c kernel/n2_main.c -o kernel/n2_main.o
 	$(CC) $(CFLAGS) -c kernel/builtin_nosfs.c -o kernel/builtin_nosfs.o
@@ -169,7 +171,7 @@ endif
 	$(CC) $(CFLAGS) -c regx/regx_launch_adapters.c -o regx/regx_launch_adapters.o
 
 	$(LD) -T kernel/n2.ld -Map kernel.map kernel/n2_entry.o kernel/n2_main.o kernel/builtin_nosfs.o \
-	    kernel/agent.o kernel/agent_loader.o kernel/agent_loader_pub.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/Task/context_switch.o kernel/Task/context_switch_asm.o \
+            kernel/agent.o kernel/agent_loader.o kernel/agent_loader_pub.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/Task/context_switch.o kernel/Task/context_switch_asm.o kernel/Task/user_thread.o kernel/Task/switch_to_user.o \
 	    kernel/arch/CPU/smp.o kernel/arch/CPU/lapic.o kernel/arch/GDT/gdt.o kernel/arch/GDT/tss.o kernel/arch/GDT/gdt_flush.o kernel/macho2.o kernel/printf.o kernel/nosm.o \
 	    kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o \
 	    kernel/VM/heap_select.o kernel/VM/legacy_heap.o \
@@ -219,8 +221,8 @@ disk.img: boot kernel agents bins modules
 
 # ===== utility =====
 clean:
-	rm -f kernel/n2_entry.o kernel/Task/context_switch.o kernel/Task/context_switch_asm.o kernel/n2_main.o kernel/builtin_nosfs.o kernel/agent.o \
-	            kernel/nosm.o kernel/agent_loader.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/stubs.o kernel/arch/CPU/smp.o kernel/arch/CPU/lapic.o kernel/arch/GDT/gdt.o kernel/arch/GDT/tss.o kernel/arch/GDT/gdt_flush.o \
+	rm -f kernel/n2_entry.o kernel/Task/context_switch.o kernel/Task/context_switch_asm.o kernel/Task/user_thread.o kernel/Task/switch_to_user.o kernel/n2_main.o kernel/builtin_nosfs.o kernel/agent.o \
+                    kernel/nosm.o kernel/agent_loader.o kernel/regx.o kernel/IPC/ipc.o kernel/Task/thread.o kernel/stubs.o kernel/arch/CPU/smp.o kernel/arch/CPU/lapic.o kernel/arch/GDT/gdt.o kernel/arch/GDT/tss.o kernel/arch/GDT/gdt_flush.o \
 	            kernel/macho2.o kernel/printf.o kernel.bin n2.bin O2.elf O2.bin user/libc/libc.o disk.img \
 	            kernel/VM/pmm_buddy.o kernel/VM/paging_adv.o kernel/VM/cow.o kernel/VM/numa.o \
 	            kernel/VM/heap_select.o kernel/VM/legacy_heap.o kernel/VM/nitroheap/nitroheap.o kernel/VM/nitroheap/classes.o \

--- a/kernel/Task/switch_to_user.asm
+++ b/kernel/Task/switch_to_user.asm
@@ -1,0 +1,45 @@
+%include "kernel/arch/GDT/segments.inc"
+
+extern assert_selector_gdt
+
+global switch_to_user
+
+section .text
+switch_to_user:
+    ; Save user RIP/RSP across calls
+    mov rbx, rdi        ; user RIP
+    mov r12, rsi        ; user RSP
+
+    ; Load user data selector into data segments
+    mov ax, GDT_SEL_USER_DATA_R3
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+
+    ; Verify selectors use GDT
+    mov di, GDT_SEL_USER_DATA_R3
+    lea rsi, [rel .str_ss]
+    call assert_selector_gdt
+    mov di, GDT_SEL_USER_CODE_R3
+    lea rsi, [rel .str_cs]
+    call assert_selector_gdt
+
+    ; Build iretq frame and enter user mode
+    push GDT_SEL_USER_DATA_R3   ; SS
+    push r12                    ; RSP
+    pushfq                      ; RFLAGS
+    or   qword [rsp], (1<<9)    ; ensure IF=1
+    push GDT_SEL_USER_CODE_R3   ; CS
+    push rbx                    ; RIP
+    iretq                       ; never returns
+
+.hang:
+    hlt
+    jmp .hang
+
+section .rodata
+.str_ss: db "switch_to_user SS",0
+.str_cs: db "switch_to_user CS",0
+
+section .note.GNU-stack noalloc nobits align=1

--- a/kernel/Task/user_thread.c
+++ b/kernel/Task/user_thread.c
@@ -1,0 +1,15 @@
+#include <string.h>
+#include "user_thread.h"
+#include "../arch/GDT/segments.h"
+
+void init_user_thread(cpu_context *ctx, uint64_t entry, uint64_t user_stack) {
+    if (!ctx) {
+        return;
+    }
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->rip    = entry;
+    ctx->cs     = GDT_SEL_USER_CODE_R3;
+    ctx->rflags = 0x202;            /* IF=1 */
+    ctx->rsp    = user_stack;
+    ctx->ss     = GDT_SEL_USER_DATA_R3;
+}

--- a/kernel/Task/user_thread.h
+++ b/kernel/Task/user_thread.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Saved CPU context for a thread. Matches iretq-compatible layout. */
+typedef struct cpu_context {
+    uint64_t r15, r14, r13, r12;
+    uint64_t r11, r10, r9, r8;
+    uint64_t rsi, rdi, rdx, rcx;
+    uint64_t rbx, rbp, rax;
+    uint64_t rip, cs, rflags;
+    uint64_t rsp, ss;
+} cpu_context;
+
+/* Prepare a context so a later iretq enters user mode. */
+void init_user_thread(cpu_context *ctx, uint64_t entry, uint64_t user_stack);
+
+/* Drop to user mode at provided RIP/RSP via iretq. Never returns. */
+void switch_to_user(uint64_t rip, uint64_t rsp) __attribute__((noreturn));
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- define `cpu_context` for saving registers and user-mode transition
- add `init_user_thread` to prep context for `iretq`
- implement `switch_to_user` NASM routine to drop to ring3
- wire new sources into build system

## Testing
- `make kernel`

------
https://chatgpt.com/codex/tasks/task_b_689c1e4b8df08333aa0a28149687deb5