### PR TITLE
Fix kernel entry boot loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ AGENT_CFLAGS := $(filter-out -no-pie,$(CFLAGS)) -fPIE
 # The kernel now links against the real driver and agent implementations instead
 # of stub placeholders.  Explicitly list the required sources so the linker sees
 # the concrete implementations.
-KERNEL_SRCS := $(shell find kernel loader src/agents/regx -name '*.c') \
+KERNEL_SRCS := $(filter-out kernel/O2.c,$(shell find kernel loader src/agents/regx -name '*.c')) \
                user/agents/nosfs/nosfs.c user/agents/nosfs/nosfs_server.c \
                user/agents/nosm/nosm.c \
                nosm/drivers/IO/serial.c nosm/drivers/IO/usb.c \
@@ -41,7 +41,7 @@ KERNEL_SRCS := $(shell find kernel loader src/agents/regx -name '*.c') \
                nosm/drivers/Net/netstack.c nosm/drivers/Net/e1000.c \
                user/libc/libc.c
 KERNEL_ASM_S   := $(shell find kernel -name '*.S')
-KERNEL_ASM_ASM := $(filter-out kernel/n2_entry.asm,$(shell find kernel -name '*.asm'))
+KERNEL_ASM_ASM := $(shell find kernel -name '*.asm')
 # Convert each source type to its object path without leaving the original
 # source names in the list, ensuring the linker only sees object files.  Use a
 # distinct suffix for `.asm` objects so files sharing the same stem as a C

--- a/kernel/n2_entry.asm
+++ b/kernel/n2_entry.asm
@@ -1,3 +1,12 @@
+%define BOOTSTRAP_STACK_SIZE (64 * 1024)
+
+section .bss
+align 16
+global _kernel_stack_top
+_kernel_stack_bottom:
+    resb BOOTSTRAP_STACK_SIZE
+_kernel_stack_top:
+
 section .text
 global _start
 
@@ -5,7 +14,11 @@ global _start
 extern n2_main
 
 _start:
+    cli
     cld
+    ; Set up a known-good stack before calling C code
+    mov rsp, _kernel_stack_top
+
     ; Enable SSE/FXSR before any C code runs
     mov rax, cr0
     and eax, 0xFFFFFFFB  ; clear EM

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -40,9 +40,8 @@ __attribute__((weak)) void idt_guard_init_once(void);
 
 static void kprint(const char *s) { serial_puts(s); }
 
-/* Default kernel stack for TSS RSP0 */
-static uint8_t kernel_stack[4096] __attribute__((aligned(16)));
-uint8_t *_kernel_stack_top = kernel_stack + sizeof(kernel_stack);
+/* Early bootstrap stack exported from n2_entry.asm */
+extern uint8_t _kernel_stack_top[];
 
 #if VERBOSE
 #define vprint(s) kprint(s)
@@ -117,10 +116,10 @@ void n2_main(bootinfo_t *bootinfo) {
     // Guard: probe/log IDT very early (no SSE, see idt_guard.c)
     if (idt_guard_init_once) idt_guard_init_once();
 
-    // Install our full ISR/IRQ table before enabling interrupts
+    // Install our full ISR/IRQ table and TSS before enabling interrupts
     idt_install();
-    start_timer_interrupts();
     gdt_tss_init(_kernel_stack_top);
+    start_timer_interrupts();
 
     print_acpi_info(bootinfo);
     print_cpu_topology(bootinfo);


### PR DESCRIPTION
## Summary
- define 64 KiB bootstrap stack directly in n2_entry.asm and expose `_kernel_stack_top`
- initialize RSP with `_kernel_stack_top` to avoid early stack faults

## Testing
- `make kernel`
- `make image`
- `timeout 5s qemu-system-x86_64 -cpu max -bios OVMF.fd -drive file=disk.img,format=raw -m 512M -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -serial stdio -display none`


------
https://chatgpt.com/codex/tasks/task_b_689cc6d719e08333a60b6317388ffa6b