### PR TITLE
Load init/login from NitrFS disk image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 - O2 Boot Agent UEFI bootloader (loads kernel and `.nosm` modules; no GRUB or other loaders)
 - N2 agent-based kernel running in true x86_64 long mode
 - Signed, manifest-driven **NOSM** modules with hot reload
-- Transactional **NOSFS** filesystem
+ - Transactional **NOSFS** (NitrFS) filesystem
+ - Init and login agents served from the on-disk NitrFS filesystem
 - Four-ring GDT layout (rings 0–3; user/kernel split)
 - Full paging and memory protection (NX, SMEP, SMAP)
 - Modular, timer-driven preemptive multitasking
@@ -57,7 +58,7 @@
 - Create a FAT-formatted image and copy `BOOTX64.EFI` (nboot) along with the `O2.bin` stage0 loader and `n2.bin` kernel:
 
   ```sh
-  mkfs.vfat -C disk.img 4096
+  mkfs.vfat -C disk.img 262144  # 128MB image
   mmd -i disk.img ::/EFI
   mmd -i disk.img ::/EFI/BOOT
   mcopy -i disk.img bootx64.efi ::/EFI/BOOT/BOOTX64.EFI

--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -1,5 +1,16 @@
 #include "login.h"
 
+/* Minimal manifest so the loader can discover the entry point when the
+ * agent is packaged as a Mach-O2 binary. */
+__attribute__((used, section("\"__O2INFO,__manifest\"")))
+static const char manifest[] =
+"{\n"
+"  \"name\": \"login\",\n"
+"  \"type\": 4,\n"
+"  \"version\": \"1.0.0\",\n"
+"  \"entry\": \"login_server\"\n"
+"}\n";
+
 /* Provide weak stubs for the minimal services the login agent relies on.
  * In standalone unit tests these will be overridden by test-specific
  * implementations. */


### PR DESCRIPTION
## Summary
- Build login as a standalone agent with its own manifest so it can be loaded from NitrFS.
- Revamp agent build rules and include the login agent in the image; enlarge the boot disk to 128 MB for on-disk execution.
- Document NitrFS-based init/login loading and updated image creation instructions.

## Testing
- `make image`

------
https://chatgpt.com/codex/tasks/task_b_689cd7d25bf08333ba2810fc52a52f41