### PR TITLE
Add HAL layer integrated with RegX

### DIFF
--- a/docs/HAL.md
+++ b/docs/HAL.md
@@ -1,0 +1,23 @@
+# Hardware Abstraction Layer (HAL)
+
+The HAL provides a thin wrapper around the RegX registry so hardware devices,
+drivers and buses can be described and discovered in a uniform way.
+
+## API
+
+```
+void hal_init(void);
+void hal_shutdown(void);
+
+uint64_t hal_register(const hal_descriptor_t *desc, uint64_t parent_id);
+int      hal_unregister(uint64_t id);
+const regx_entry_t *hal_query(uint64_t id);
+size_t   hal_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max);
+```
+
+Each registration maps directly to a RegX entry. `hal_init()` creates a
+root bus under which all HAL-managed devices are attached. Calls to
+`hal_register()` default to this root when no parent is supplied.
+
+The HAL does not perform device I/O; it purely manages discovery and
+lifecycle in cooperation with RegX.

--- a/include/hal.h
+++ b/include/hal.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <stdint.h>
+#include <regx.h>
+
+typedef struct {
+    regx_type_t type;         // REGX_TYPE_DEVICE, DRIVER, BUS, etc.
+    const char *name;         // identifier for the entry
+    const char *version;      // optional version string
+    const char *abi;          // ABI or interface identifier
+    const char *capabilities; // optional capabilities list
+} hal_descriptor_t;
+
+void hal_init(void);
+void hal_shutdown(void);
+
+uint64_t hal_register(const hal_descriptor_t *desc, uint64_t parent_id);
+int      hal_unregister(uint64_t id);
+const regx_entry_t *hal_query(uint64_t id);
+size_t   hal_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max);

--- a/kernel/hal.c
+++ b/kernel/hal.c
@@ -1,0 +1,55 @@
+#include <string.h>
+#include <hal.h>
+
+static uint64_t hal_root_id = 0;
+
+void hal_init(void) {
+    if (hal_root_id) return;
+    regx_manifest_t m = {0};
+    strlcpy(m.name, "hal-root", sizeof(m.name));
+    m.type = REGX_TYPE_BUS;
+    strlcpy(m.version, "1.0", sizeof(m.version));
+    strlcpy(m.abi, "N2-1.0", sizeof(m.abi));
+    hal_root_id = regx_register(&m, 0);
+}
+
+void hal_shutdown(void) {
+    if (hal_root_id) {
+        regx_unregister(hal_root_id);
+        hal_root_id = 0;
+    }
+}
+
+static uint64_t default_parent(uint64_t parent_id) {
+    if (parent_id) return parent_id;
+    if (!hal_root_id) hal_init();
+    return hal_root_id;
+}
+
+uint64_t hal_register(const hal_descriptor_t *desc, uint64_t parent_id) {
+    if (!desc || !desc->name) return 0;
+
+    regx_manifest_t m = {0};
+    m.type = desc->type;
+    strlcpy(m.name, desc->name, sizeof(m.name));
+    if (desc->version)
+        strlcpy(m.version, desc->version, sizeof(m.version));
+    if (desc->abi)
+        strlcpy(m.abi, desc->abi, sizeof(m.abi));
+    if (desc->capabilities)
+        strlcpy(m.capabilities, desc->capabilities, sizeof(m.capabilities));
+
+    return regx_register(&m, default_parent(parent_id));
+}
+
+int hal_unregister(uint64_t id) {
+    return regx_unregister(id);
+}
+
+const regx_entry_t *hal_query(uint64_t id) {
+    return regx_query(id);
+}
+
+size_t hal_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max) {
+    return regx_enumerate(sel, out, max);
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
 
 LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c ../kernel/uaccess.c
 
-UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap
+UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal
 
 all: $(UNIT_TESTS)
 	for t in $(UNIT_TESTS); do ./$$t; done
@@ -49,6 +49,9 @@ test_thread: unit/test_thread.c ../kernel/Task/thread.c thread_test_stubs.c $(fi
 
 test_nitroheap: unit/test_nitroheap.c ../kernel/VM/nitroheap/nitroheap.c \
 ../kernel/VM/nitroheap/classes.c buddy_stub.c $(LIBC_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_hal: unit/test_hal.c ../kernel/hal.c ../kernel/regx.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
 clean:

--- a/tests/unit/test_hal.c
+++ b/tests/unit/test_hal.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <stdio.h>
+#include <hal.h>
+
+int main(void) {
+    hal_init();
+
+    hal_descriptor_t dev = {
+        .type = REGX_TYPE_DEVICE,
+        .name = "uart0",
+        .version = "1.0",
+        .abi = "hw",
+        .capabilities = "serial"
+    };
+
+    uint64_t id = hal_register(&dev, 0);
+    assert(id != 0);
+
+    const regx_entry_t *e = hal_query(id);
+    assert(e && e->id == id);
+
+    regx_selector_t sel = {
+        .type = REGX_TYPE_DEVICE,
+        .parent_id = e->parent_id,
+    };
+    regx_entry_t out[2];
+    size_t n = hal_enumerate(&sel, out, 2);
+    assert(n == 1);
+    assert(out[0].id == id);
+
+    assert(hal_unregister(id) == 0);
+    hal_shutdown();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement a simple hardware abstraction layer (HAL) built on top of the RegX registry
- document HAL API and behavior
- add unit test and Makefile hooks to exercise HAL registration

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689d02493f4083338d18b696037b1581