### PR TITLE
Add NOSFormatU disk partition utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ libc.o
 disk.img
 bootloader/*.efi
 bootloader/src/*.obj
+boot/*.obj
+boot/*.efi
+boot/*.bin
 Kernel/*.bin
 Kernel/*.o
 qemu.log

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 - O2 Boot Agent UEFI bootloader (loads kernel and `.nosm` modules; no GRUB or other loaders)
 - Configurable boot menu for live boot, installation, disk utilities, and kernel/module selection
+- NOSFormatU disk partitioning utility accessible from the boot menu
 - N2 agent-based kernel running in true x86_64 long mode
 - Signed, manifest-driven **NOSM** modules with hot reload
  - Transactional **NOSFS** (NitrFS) filesystem

--- a/boot/Makefile
+++ b/boot/Makefile
@@ -1,3 +1,4 @@
+.RECIPEPREFIX = >
 CC=clang
 LD=lld-link
 
@@ -11,25 +12,20 @@ LDFLAGS=/entry:efi_main \
         /subsystem:efi_application \
         /nodefaultlib \
         /base:0 \
-        /filealign:32 \
-        /out:nboot.efi
+        /filealign:32
 
-# Build all C sources in this directory. The original build assumed sources
-# lived under a `src/` subdirectory, but `nboot.c` now resides at the top level
-# of `boot/`. Use a wildcard that matches files in the current directory so the
-# boot agent links correctly.
-SRC := $(wildcard *.c)
-OBJ := $(SRC:.c=.obj)
+all: nboot.efi nosformatu.bin
 
-all: nboot.efi
+nboot.efi: nboot.obj
+>$(LD) $(LDFLAGS) /out:nboot.efi nboot.obj
 
-nboot.efi: $(OBJ)
-	$(LD) $(LDFLAGS) $(OBJ)
+nosformatu.bin: nosformatu.obj
+>$(LD) $(LDFLAGS) /out:nosformatu.bin nosformatu.obj
 
 %.obj: %.c
-	$(CC) $(CFLAGS) -c -o $@ $<
+>$(CC) $(CFLAGS) -c -o $@ $<
 
 clean:
-	rm -f *.obj *.efi
+>rm -f *.obj *.efi *.bin
 
 .PHONY: all clean

--- a/boot/include/efi.h
+++ b/boot/include/efi.h
@@ -464,6 +464,43 @@ struct EFI_MEMORY_DESCRIPTOR {
 typedef struct EFI_MEMORY_DESCRIPTOR EFI_MEMORY_DESCRIPTOR;
 
 // ====================
+// Block I/O Protocol
+// ====================
+typedef UINT64 EFI_LBA;
+
+typedef struct {
+    UINT32  MediaId;
+    BOOLEAN RemovableMedia;
+    BOOLEAN MediaPresent;
+    BOOLEAN LogicalPartition;
+    BOOLEAN ReadOnly;
+    BOOLEAN WriteCaching;
+    UINT32  BlockSize;
+    UINT32  IoAlign;
+    EFI_LBA LastBlock;
+    EFI_LBA LowestAlignedLba;
+    EFI_LBA LogicalBlocksPerPhysicalBlock;
+    EFI_LBA OptimalTransferLengthGranularity;
+} EFI_BLOCK_IO_MEDIA;
+
+typedef struct EFI_BLOCK_IO_PROTOCOL EFI_BLOCK_IO_PROTOCOL;
+struct EFI_BLOCK_IO_PROTOCOL {
+    UINT64                        Revision;
+    EFI_BLOCK_IO_MEDIA           *Media;
+    EFI_STATUS (EFIAPI *Reset)(EFI_BLOCK_IO_PROTOCOL*, BOOLEAN);
+    EFI_STATUS (EFIAPI *ReadBlocks)(EFI_BLOCK_IO_PROTOCOL*, UINT32, EFI_LBA, UINTN, VOID*);
+    EFI_STATUS (EFIAPI *WriteBlocks)(EFI_BLOCK_IO_PROTOCOL*, UINT32, EFI_LBA, UINTN, const VOID*);
+    EFI_STATUS (EFIAPI *FlushBlocks)(EFI_BLOCK_IO_PROTOCOL*);
+};
+
+static const EFI_GUID gEfiBlockIoProtocolGuid =
+    { 0x964e5b21, 0x6459, 0x11d2, { 0x8e, 0x39, 0x0, 0xa0, 0xc9, 0x69, 0x72, 0x3b } };
+
+#define EFI_LOCATE_SEARCH_ALL_HANDLES       0
+#define EFI_LOCATE_SEARCH_BY_REGISTER_NOTIFY 1
+#define EFI_LOCATE_SEARCH_BY_PROTOCOL       2
+
+// ====================
 // NULL Definition (if not included from stddef.h)
 // ====================
 #ifndef NULL

--- a/boot/menu.cfg
+++ b/boot/menu.cfg
@@ -2,4 +2,4 @@
 # Format: Title|KernelPath|Module1,Module2,...
 Live Boot NitrOS|n2.bin|agents/init.mo2,agents/login.mo2
 Install NitrOS|installer.bin|
-NOSferatu Disk Utility|nosferatu.bin|
+NOSFormatU Disk Utility|nosformatu.bin|

--- a/boot/nosformatu.c
+++ b/boot/nosformatu.c
@@ -1,0 +1,118 @@
+#include "efi.h"
+#include <stdint.h>
+#include <stddef.h>
+
+void __chkstk(void) {}
+
+static void print_ascii(EFI_SYSTEM_TABLE *st, const char *s) {
+    CHAR16 buf[128];
+    size_t i = 0;
+    while (s[i] && i < 127) {
+        buf[i] = (CHAR16)s[i];
+        i++;
+    }
+    buf[i] = 0;
+    st->ConOut->OutputString(st->ConOut, buf);
+}
+
+static void print_dec(EFI_SYSTEM_TABLE *st, uint64_t v) {
+    char buf[32];
+    char *p = buf + sizeof(buf) - 1;
+    *p = 0;
+    if (v == 0) *--p = '0';
+    while (v) {
+        *--p = '0' + (v % 10);
+        v /= 10;
+    }
+    print_ascii(st, p);
+}
+
+static char read_char(EFI_SYSTEM_TABLE *st) {
+    EFI_INPUT_KEY key;
+    EFI_STATUS status;
+    for (;;) {
+        status = st->ConIn->ReadKeyStroke(st->ConIn, &key);
+        if (!EFI_ERROR(status)) {
+            if (key.UnicodeChar) {
+                CHAR16 out[2] = { key.UnicodeChar, 0 };
+                st->ConOut->OutputString(st->ConOut, out);
+                return (char)key.UnicodeChar;
+            }
+        }
+    }
+}
+
+// MBR partition entry
+typedef struct {
+    UINT8  boot_indicator;
+    UINT8  start_head;
+    UINT8  start_sector;
+    UINT8  start_cylinder;
+    UINT8  partition_type;
+    UINT8  end_head;
+    UINT8  end_sector;
+    UINT8  end_cylinder;
+    UINT32 start_lba;
+    UINT32 sectors;
+} __attribute__((packed)) mbr_part_t;
+
+typedef EFI_STATUS (EFIAPI *EFI_LOCATE_HANDLE_BUFFER)(UINTN, EFI_GUID*, VOID*, UINTN*, EFI_HANDLE**);
+
+EFI_STATUS EFIAPI efi_main(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable) {
+    print_ascii(SystemTable, "NOSFormatU - NitrOS Disk Format Utility\r\n");
+
+    EFI_LOCATE_HANDLE_BUFFER LocateHandleBuffer = (EFI_LOCATE_HANDLE_BUFFER)SystemTable->BootServices->LocateHandleBuffer;
+    EFI_HANDLE *handles = NULL;
+    UINTN handle_count = 0;
+    EFI_STATUS status = LocateHandleBuffer(EFI_LOCATE_SEARCH_BY_PROTOCOL, (EFI_GUID*)&gEfiBlockIoProtocolGuid, NULL, &handle_count, &handles);
+    if (EFI_ERROR(status) || handle_count == 0) {
+        print_ascii(SystemTable, "No block devices found\r\n");
+        return status;
+    }
+
+    for (UINTN i = 0; i < handle_count; ++i) {
+        EFI_BLOCK_IO_PROTOCOL *bio;
+        if (EFI_ERROR(SystemTable->BootServices->HandleProtocol(handles[i], (EFI_GUID*)&gEfiBlockIoProtocolGuid, (void**)&bio)))
+            continue;
+        uint64_t size = (bio->Media->LastBlock + 1) * bio->Media->BlockSize;
+        print_ascii(SystemTable, "Disk ");
+        print_dec(SystemTable, i);
+        print_ascii(SystemTable, ": ");
+        print_dec(SystemTable, size / 1024);
+        print_ascii(SystemTable, " KB\r\n");
+    }
+
+    print_ascii(SystemTable, "Select disk number to format or 'q' to quit: ");
+    char c = read_char(SystemTable);
+    print_ascii(SystemTable, "\r\n");
+    if (c == 'q' || c == 'Q')
+        return EFI_SUCCESS;
+    UINTN index = (UINTN)(c - '0');
+    if (index >= handle_count) {
+        print_ascii(SystemTable, "Invalid selection\r\n");
+        return EFI_SUCCESS;
+    }
+
+    EFI_BLOCK_IO_PROTOCOL *bio;
+    status = SystemTable->BootServices->HandleProtocol(handles[index], (EFI_GUID*)&gEfiBlockIoProtocolGuid, (void**)&bio);
+    if (EFI_ERROR(status))
+        return status;
+
+    UINT8 sector[512];
+    for (UINTN i = 0; i < 512; ++i) sector[i] = 0;
+    mbr_part_t *part = (mbr_part_t*)(sector + 446);
+    part[0].boot_indicator = 0;
+    part[0].partition_type = 0x07;
+    part[0].start_lba = 1;
+    part[0].sectors = (UINT32)(bio->Media->LastBlock);
+    sector[510] = 0x55;
+    sector[511] = 0xAA;
+
+    status = bio->WriteBlocks(bio, bio->Media->MediaId, 0, 512, sector);
+    if (EFI_ERROR(status))
+        print_ascii(SystemTable, "Write failed\r\n");
+    else
+        print_ascii(SystemTable, "Disk formatted with single partition\r\n");
+
+    return EFI_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- implement NOSFormatU UEFI disk partition tool
- extend EFI headers with Block I/O support
- update boot menu and documentation for new utility

## Testing
- `make -C boot nosformatu.bin`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689d05a0abb883338f4bccb05be595c0