### PR TITLE
Remove stdio dependency from agent loader

### DIFF
--- a/kernel/agent_loader.c
+++ b/kernel/agent_loader.c
@@ -2,7 +2,6 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
-#include <stdio.h>
 
 #include "elf.h"
 #include "agent_loader.h"


### PR DESCRIPTION
## Summary
- Drop `stdio.h` from `kernel/agent_loader.c` to keep kernel build freestanding

## Testing
- `make kernel`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689d2698c9bc833399652db0e244999d