### PR TITLE
Refactor HAL for modular async operations

### DIFF
--- a/include/hal.h
+++ b/include/hal.h
@@ -10,6 +10,9 @@ typedef struct {
     const char *capabilities; // optional capabilities list
 } hal_descriptor_t;
 
+// Asynchronous callback signature.
+typedef void (*hal_async_cb_t)(uint64_t id, int status, void *ctx);
+
 void hal_init(void);
 void hal_shutdown(void);
 
@@ -17,3 +20,8 @@ uint64_t hal_register(const hal_descriptor_t *desc, uint64_t parent_id);
 int      hal_unregister(uint64_t id);
 const regx_entry_t *hal_query(uint64_t id);
 size_t   hal_enumerate(const regx_selector_t *sel, regx_entry_t *out, size_t max);
+
+// Asynchronous variants
+void hal_register_async(const hal_descriptor_t *desc, uint64_t parent_id,
+                        hal_async_cb_t cb, void *ctx);
+void hal_unregister_async(uint64_t id, hal_async_cb_t cb, void *ctx);

--- a/kernel/hal_async.c
+++ b/kernel/hal_async.c
@@ -1,0 +1,89 @@
+#include <stdlib.h>
+#include <hal.h>
+#include "Task/thread.h"
+
+typedef enum {
+    HAL_TASK_REG,
+    HAL_TASK_UNREG
+} hal_task_type_t;
+
+typedef struct hal_async_task {
+    hal_task_type_t op;
+    hal_descriptor_t desc;
+    uint64_t parent_id;
+    uint64_t id;
+    hal_async_cb_t cb;
+    void *ctx;
+} hal_async_task_t;
+
+static hal_async_task_t *current_task;
+
+static void hal_async_worker(void) {
+    hal_async_task_t *t = current_task;
+    uint64_t id = 0;
+    int status = 0;
+
+    if (t->op == HAL_TASK_REG) {
+        id = hal_register(&t->desc, t->parent_id);
+        status = id ? 0 : -1;
+    } else {
+        status = hal_unregister(t->id);
+        id = t->id;
+    }
+
+    if (t->cb) {
+        t->cb(id, status, t->ctx);
+    }
+
+    free(t);
+}
+
+static int start_async(hal_async_task_t *task) {
+    current_task = task;
+    thread_t *thr = thread_create(hal_async_worker);
+    return thr ? 0 : -1;
+}
+
+void hal_register_async(const hal_descriptor_t *desc, uint64_t parent_id,
+                        hal_async_cb_t cb, void *ctx) {
+    if (!desc) {
+        if (cb) cb(0, -1, ctx);
+        return;
+    }
+
+    hal_async_task_t *t = malloc(sizeof(*t));
+    if (!t) {
+        if (cb) cb(0, -1, ctx);
+        return;
+    }
+
+    t->op = HAL_TASK_REG;
+    t->desc = *desc;
+    t->parent_id = parent_id;
+    t->cb = cb;
+    t->ctx = ctx;
+
+    if (start_async(t) != 0) {
+        if (cb) cb(0, -1, ctx);
+        free(t);
+    }
+}
+
+void hal_unregister_async(uint64_t id, hal_async_cb_t cb, void *ctx) {
+    hal_async_task_t *t = malloc(sizeof(*t));
+    if (!t) {
+        if (cb) cb(id, -1, ctx);
+        return;
+    }
+
+    t->op = HAL_TASK_UNREG;
+    t->id = id;
+    t->cb = cb;
+    t->ctx = ctx;
+
+    if (start_async(t) != 0) {
+        if (cb) cb(id, -1, ctx);
+        free(t);
+    }
+}
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -51,7 +51,7 @@ test_nitroheap: unit/test_nitroheap.c ../kernel/VM/nitroheap/nitroheap.c \
 ../kernel/VM/nitroheap/classes.c buddy_stub.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
-test_hal: unit/test_hal.c ../kernel/hal.c ../kernel/regx.c $(LIBC_SRC)
+test_hal: unit/test_hal.c ../kernel/hal.c ../kernel/hal_async.c ../kernel/regx.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
 clean:

--- a/tests/thread_stub.c
+++ b/tests/thread_stub.c
@@ -21,6 +21,18 @@ thread_t *thread_current(void) { return &dummy_thread; }
 void thread_block(thread_t *t) { (void)t; }
 void thread_unblock(thread_t *t) { (void)t; }
 
+thread_t *thread_create(void (*func)(void)) {
+    if (func) func();
+    return &dummy_thread;
+}
+
+thread_t *thread_create_with_priority(void (*func)(void), int priority) {
+    (void)priority;
+    return thread_create(func);
+}
+
+void thread_join(thread_t *t) { (void)t; }
+
 /* New scheduler entry points */
 void scheduler_enqueue(thread_t *t) { (void)t; }
 void scheduler_pick_and_run(void) {}

--- a/tests/unit/test_hal.c
+++ b/tests/unit/test_hal.c
@@ -2,6 +2,21 @@
 #include <stdio.h>
 #include <hal.h>
 
+static uint64_t last_id;
+static int last_status;
+
+static void reg_cb(uint64_t id, int status, void *ctx) {
+    (void)ctx;
+    last_id = id;
+    last_status = status;
+}
+
+static void unreg_cb(uint64_t id, int status, void *ctx) {
+    (void)ctx;
+    last_id = id;
+    last_status = status;
+}
+
 int main(void) {
     hal_init();
 
@@ -13,7 +28,9 @@ int main(void) {
         .capabilities = "serial"
     };
 
-    uint64_t id = hal_register(&dev, 0);
+    hal_register_async(&dev, 0, reg_cb, NULL);
+    assert(last_status == 0);
+    uint64_t id = last_id;
     assert(id != 0);
 
     const regx_entry_t *e = hal_query(id);
@@ -28,7 +45,9 @@ int main(void) {
     assert(n == 1);
     assert(out[0].id == id);
 
-    assert(hal_unregister(id) == 0);
+    hal_unregister_async(id, unreg_cb, NULL);
+    assert(last_status == 0);
+
     hal_shutdown();
     return 0;
 }


### PR DESCRIPTION
## Summary
- extend HAL interface with asynchronous registration and unregistration callbacks
- add new `hal_async` module using lightweight worker threads
- adjust unit tests and stubs for async HAL behavior

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689d3ee448c483338655036597b17b5f