### PR TITLE
Add physical page manager with alloc/free primitives

### DIFF
--- a/kernel/VM/pmm.c
+++ b/kernel/VM/pmm.c
@@ -1,0 +1,43 @@
+#include <stddef.h>
+#include <stdint.h>
+#include "pmm.h"
+#include "pmm_buddy.h"
+#include "numa.h"
+
+#define PROT_EXEC  0x1
+#define PROT_WRITE 0x2
+#define PROT_READ  0x4
+
+extern void vmm_prot(void *va, size_t size, int prot);
+
+extern char __text_start[] __attribute__((weak));
+extern char __text_end[] __attribute__((weak));
+extern char __rodata_start[] __attribute__((weak));
+extern char __rodata_end[] __attribute__((weak));
+
+static void protect_kernel(void) {
+    uintptr_t text_lo = (uintptr_t)__text_start;
+    uintptr_t text_hi = (uintptr_t)__text_end;
+    if (text_hi > text_lo)
+        vmm_prot((void *)text_lo, text_hi - text_lo, PROT_READ | PROT_EXEC);
+
+    uintptr_t ro_lo = (uintptr_t)__rodata_start;
+    uintptr_t ro_hi = (uintptr_t)__rodata_end;
+    if (ro_hi > ro_lo)
+        vmm_prot((void *)ro_lo, ro_hi - ro_lo, PROT_READ);
+}
+
+void pmm_init(const bootinfo_t *bootinfo) {
+    numa_init(bootinfo);
+    buddy_init(bootinfo);
+    protect_kernel();
+}
+
+void *alloc_page(void) {
+    return buddy_alloc(0, current_cpu_node(), 0);
+}
+
+void free_page(void *page) {
+    if (page)
+        buddy_free(page, 0, current_cpu_node());
+}

--- a/kernel/VM/pmm.h
+++ b/kernel/VM/pmm.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <stdint.h>
+#include "../../boot/include/bootinfo.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void pmm_init(const bootinfo_t *bootinfo);
+void *alloc_page(void);
+void free_page(void *page);
+
+#ifdef __cplusplus
+}
+#endif

--- a/kernel/loader_vm_pmm_shims.c
+++ b/kernel/loader_vm_pmm_shims.c
@@ -4,7 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "VM/paging_adv.h"
-#include "VM/pmm_buddy.h"
+#include "VM/pmm.h"
 #include "VM/numa.h"
 #include "VM/legacy_heap.h"
 
@@ -57,6 +57,6 @@ int vmm_is_mapped_x(void* va) {
 
 // Physical page allocator (4K pages)
 uintptr_t pmm_alloc_page(void) {
-    void* p = buddy_alloc(0, current_cpu_node(), 0);
+    void* p = alloc_page();
     return (uintptr_t)p;
 }

--- a/kernel/n2.ld
+++ b/kernel/n2.ld
@@ -6,14 +6,18 @@ SECTIONS
     . = 0x100000;  /* Start at 1MB */
 
     /* Text section */
+    __text_start = .;
     .text ALIGN(4K) : AT(ADDR(.text)) {
         *(.text*)
     }
+    __text_end = .;
 
     /* Read-only data */
+    __rodata_start = .;
     .rodata ALIGN(4K) : AT(ADDR(.rodata)) {
         *(.rodata*)
     }
+    __rodata_end = .;
 
     /* Data section */
     .data ALIGN(4K) : AT(ADDR(.data)) {

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -17,8 +17,7 @@
 #include "arch/GDT/gdt_selectors.h"
 #include "arch/IDT/idt.h"
 #include "arch_x86_64/gdt_tss.h"
-#include "VM/numa.h"
-#include "VM/pmm_buddy.h"
+#include "VM/pmm.h"
 #include "VM/heap.h"
 #include "arch/APIC/lapic.h"
 #include "arch/CPU/irq.h"
@@ -129,8 +128,7 @@ void n2_main(bootinfo_t *bootinfo) {
     print_framebuffer(bootinfo);
     print_mmap(bootinfo);
 
-    numa_init(bootinfo);
-    buddy_init(bootinfo);
+    pmm_init(bootinfo);
     kheap_parse_bootarg(bootinfo->cmdline);
     kheap_init();
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
     -I../user/libc -I../nosm/drivers/IO -I../nosm/drivers/Audio \
     -I../nosm/drivers/Net -I../kernel/arch/GDT
 
-LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c ../kernel/uaccess.c
+LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c vmm_stub.c ../kernel/uaccess.c
 
 UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal
 
@@ -15,7 +15,7 @@ all: $(UNIT_TESTS)
 test_ipc: unit/test_ipc.c ../kernel/IPC/ipc.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
-test_pmm: unit/test_pmm.c ../kernel/VM/pmm_buddy.c ../kernel/VM/numa.c $(LIBC_SRC)
+test_pmm: unit/test_pmm.c ../kernel/VM/pmm.c ../kernel/VM/pmm_buddy.c ../kernel/VM/numa.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_login: unit/test_login.c ../user/agents/login/login.c $(LIBC_SRC) ../kernel/IPC/ipc.c ../kernel/agent.c

--- a/tests/unit/test_pmm.c
+++ b/tests/unit/test_pmm.c
@@ -1,6 +1,6 @@
 #include <assert.h>
+#include "../../kernel/VM/pmm.h"
 #include "../../kernel/VM/pmm_buddy.h"
-#include "../../kernel/VM/numa.h"
 #include "../../boot/include/bootinfo.h"
 #include "../../user/libc/libc.h"
 #ifndef PAGE_SIZE
@@ -15,21 +15,20 @@ int main(void) {
     bootinfo_t bi = {0};
     bi.mmap = mmap;
     bi.mmap_entries = 1;
-    numa_init(&bi);
-    buddy_init(&bi);
+    pmm_init(&bi);
     assert(buddy_free_frames_total() == 128);
 
-    void *p1 = buddy_alloc(6, 0, 0); // 64-page block
+    void *p1 = alloc_page();
     assert(p1);
-    assert(buddy_free_frames_total() == 64);
+    assert(buddy_free_frames_total() == 127);
 
-    void *p2 = buddy_alloc(5, 0, 0); // 32-page block
+    void *p2 = alloc_page();
     assert(p2);
-    assert(buddy_free_frames_total() == 32);
+    assert(buddy_free_frames_total() == 126);
 
-    buddy_free(p1, 6, 0);
-    assert(buddy_free_frames_total() == 96);
-    buddy_free(p2, 5, 0);
+    free_page(p1);
+    assert(buddy_free_frames_total() == 127);
+    free_page(p2);
     assert(buddy_free_frames_total() == 128);
 
     return 0;

--- a/tests/vmm_stub.c
+++ b/tests/vmm_stub.c
@@ -1,0 +1,4 @@
+#include <stddef.h>
+void vmm_prot(void* va, size_t size, int prot) {
+    (void)va; (void)size; (void)prot;
+}


### PR DESCRIPTION
## Summary
- introduce pmm_init wrapper that builds the buddy allocator from boot info and exposes alloc_page/free_page
- harden kernel by marking text and rodata read-only after PMM initialization
- update loader shims and tests for new physical page manager API

## Testing
- `make kernel`
- `make -C tests test_pmm`
- `tests/test_pmm && echo test_pmm_passed`


------
https://chatgpt.com/codex/tasks/task_b_689d456f305483338cf68fae0bebae27