### PR TITLE
docs: outline nosfs architecture

### DIFF
--- a/docs/NOSFS.md
+++ b/docs/NOSFS.md
@@ -29,3 +29,51 @@ agent platform.
     filesystem internals.
   - Tools discover agents at runtime and can trigger snapshot or rollback
     operations safely.
+
+## Architecture
+
+NOSFS is designed around a set of modular subsystems that balance performance,
+security and scalability.  The following sections sketch the core components
+that will be fleshed out during implementation.
+
+### Storage Engine
+- Copy‑on‑write update path for all data and metadata.
+- Dynamic block allocation (4 KB–1 MB) with space maps and free‑space
+  coalescing.
+- Pluggable compression and encryption at the file or directory level.
+
+### Metadata Layer
+- Hybrid B⁺‑tree/LSM indexing for fast lookups and append‑heavy workloads.
+- Versioned entries to support snapshots and clones with minimal overhead.
+- Shardable namespace to distribute directory subtrees across nodes.
+
+### Journaling & Consistency
+- Two‑tier journal: an in‑memory log for low‑latency commits and a persistent
+  log for crash recovery.
+- Journal records include Merkle hashes to enable integrity verification and
+  atomic group commits.
+
+### Security Subsystem
+- Transparent AES‑256‑GCM encryption with per‑object keys and rotation.
+- Pluggable authentication and authorization modules (ACLs, roles,
+  capabilities).
+- Cryptographically signed journals and metadata blocks.
+
+### Caching & Prefetching
+- Multi‑level adaptive caches separating hot and cold data.
+- Asynchronous read‑ahead and write coalescing to maximise throughput.
+
+### Distributed Operation
+- Namespace sharding across storage nodes with replication and failover.
+- Lightweight RPC layer with TLS and optional RDMA data paths.
+
+### Observability & Management
+- Unified metrics and tracing (OpenTelemetry compatible).
+- CLI/REST management interfaces for snapshot, clone and recovery orchestration.
+
+### Implementation Roadmap
+1. Foundation: block allocator, basic metadata store and journal.
+2. Reliability: full CoW path, crash recovery and background scrubbing.
+3. Security: encryption, ACL framework and signed metadata.
+4. Scalability: namespace sharding and replication.
+5. Advanced features: snapshots, compression and extended attributes.

--- a/tests/thread_test_stubs.c
+++ b/tests/thread_test_stubs.c
@@ -17,3 +17,7 @@ int api_puts(const char *s) { (void)s; return 0; }
 int api_fs_read_all(const char *path, void *buf, size_t len, size_t *outlen) { (void)path; (void)buf; (void)len; if (outlen) *outlen = 0; return -1; }
 int api_regx_load(const char *name, const char *arg, uint32_t *out) { (void)name; (void)arg; if (out) *out = 0; return -1; }
 void api_yield(void) {}
+
+uint64_t *paging_kernel_pml4(void) { return NULL; }
+void paging_switch(uint64_t *new_pml4) { (void)new_pml4; }
+uint64_t *paging_new_context(void) { return NULL; }


### PR DESCRIPTION
## Summary
- document NOSFS architecture covering storage engine, metadata layer, journaling, security, caching, distribution, and roadmap
- stub paging functions in thread_test_stubs to link thread unit tests

## Testing
- `make clean && make` (from `tests/`)

------
https://chatgpt.com/codex/tasks/task_b_689d4c2741f4833380fd09882ae9f0cd