### PR TITLE
Add Mach-O symbol lookup for NOSM modules

### DIFF
--- a/kernel/macho2.c
+++ b/kernel/macho2.c
@@ -1,15 +1,78 @@
-#include "macho2.h"
+#include <macho2.h>
+#include <stdint.h>
+#include <string.h>
+
+#define LC_SYMTAB   0x2
+
+struct symtab_command {
+    uint32_t cmd;
+    uint32_t cmdsize;
+    uint32_t symoff;
+    uint32_t nsyms;
+    uint32_t stroff;
+    uint32_t strsize;
+};
+
+struct nlist_64 {
+    uint32_t n_strx;
+    uint8_t  n_type;
+    uint8_t  n_sect;
+    uint16_t n_desc;
+    uint64_t n_value;
+};
 
 int macho2_load(const void *image, size_t size) {
-    (void)image;
-    (void)size;
-    return 1; /* Stub: pretend success */
+    if (!image || size < sizeof(struct mach_header_64))
+        return -1;
+    const struct mach_header_64 *mh = (const struct mach_header_64 *)image;
+    if (mh->magic != MH_MAGIC_64)
+        return -1;
+    return 0;
 }
 
 void *macho2_find_symbol(const void *image, size_t size, const char *name) {
-    (void)image;
-    (void)size;
-    (void)name;
+    if (!image || !name || size < sizeof(struct mach_header_64))
+        return NULL;
+
+    const uint8_t *base = (const uint8_t *)image;
+    const struct mach_header_64 *mh = (const struct mach_header_64 *)base;
+    if (mh->magic != MH_MAGIC_64)
+        return NULL;
+
+    const uint8_t *p = base + sizeof(struct mach_header_64);
+    const struct symtab_command *sc = NULL;
+
+    for (uint32_t i = 0; i < mh->ncmds; i++) {
+        if (p + sizeof(struct load_command) > base + size)
+            return NULL;
+        const struct load_command *lc = (const struct load_command *)p;
+        if (lc->cmd == LC_SYMTAB && lc->cmdsize >= sizeof(struct symtab_command))
+            sc = (const struct symtab_command *)lc;
+        p += lc->cmdsize;
+    }
+
+    if (!sc)
+        return NULL;
+    if ((size_t)sc->symoff + sc->nsyms * sizeof(struct nlist_64) > size)
+        return NULL;
+    if ((size_t)sc->stroff + sc->strsize > size)
+        return NULL;
+
+    const struct nlist_64 *syms = (const struct nlist_64 *)(base + sc->symoff);
+    const char *strtab = (const char *)(base + sc->stroff);
+
+    for (uint32_t i = 0; i < sc->nsyms; i++) {
+        if (syms[i].n_strx >= sc->strsize)
+            continue;
+        const char *sname = strtab + syms[i].n_strx;
+        if (strcmp(sname, name) == 0) {
+            uint64_t off = syms[i].n_value;
+            if (off < size)
+                return (void *)(base + off);
+            return NULL;
+        }
+    }
+
     return NULL;
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
 
 LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c vmm_stub.c ../kernel/uaccess.c
 
-UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal
+UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2
 
 all: $(UNIT_TESTS)
 	for t in $(UNIT_TESTS); do ./$$t; done
@@ -39,7 +39,7 @@ test_nosfs: unit/test_nosfs.c ../user/agents/nosfs/nosfs.c \
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_nosm: unit/test_nosm.c ../kernel/IPC/ipc.c $(LIBC_SRC)
-	        $(CC) $(CFLAGS) $^ -o $@
+	$(CC) $(CFLAGS) $^ -o $@
 
 test_regx: unit/test_regx.c ../kernel/regx.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
@@ -52,6 +52,9 @@ test_nitroheap: unit/test_nitroheap.c ../kernel/VM/nitroheap/nitroheap.c \
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_hal: unit/test_hal.c ../kernel/hal.c ../kernel/hal_async.c ../kernel/regx.c $(LIBC_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_macho2: unit/test_macho2.c ../kernel/macho2.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
 clean:

--- a/tests/unit/test_macho2.c
+++ b/tests/unit/test_macho2.c
@@ -1,0 +1,54 @@
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include "macho2.h"
+
+void *macho2_find_symbol(const void *, size_t, const char *);
+
+#define LC_SYMTAB 0x2
+struct symtab_command {
+    uint32_t cmd;
+    uint32_t cmdsize;
+    uint32_t symoff;
+    uint32_t nsyms;
+    uint32_t stroff;
+    uint32_t strsize;
+};
+struct nlist_64 {
+    uint32_t n_strx;
+    uint8_t n_type;
+    uint8_t n_sect;
+    uint16_t n_desc;
+    uint64_t n_value;
+};
+
+int main(void) {
+    uint8_t image[256] = {0};
+    struct mach_header_64 *mh = (struct mach_header_64 *)image;
+    mh->magic = MH_MAGIC_64;
+    mh->ncmds = 1;
+    mh->sizeofcmds = sizeof(struct symtab_command);
+
+    struct symtab_command *sc = (struct symtab_command *)(image + sizeof(struct mach_header_64));
+    sc->cmd = LC_SYMTAB;
+    sc->cmdsize = sizeof(struct symtab_command);
+    sc->symoff = sizeof(struct mach_header_64) + sizeof(struct symtab_command);
+    sc->nsyms = 1;
+    sc->stroff = sc->symoff + sizeof(struct nlist_64);
+    sc->strsize = 16;
+
+    struct nlist_64 *nl = (struct nlist_64 *)(image + sc->symoff);
+    nl->n_strx = 1; /* index into string table */
+    nl->n_value = sc->stroff + sc->strsize; /* symbol points past string table */
+
+    char *strtab = (char *)(image + sc->stroff);
+    strtab[0] = '\0';
+    strcpy(strtab + 1, "target");
+
+    uint8_t *target = image + nl->n_value;
+    *target = 0xAA;
+
+    void *res = macho2_find_symbol(image, sizeof(image), "target");
+    assert(res == target);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Implement Mach-O parser to resolve module symbols during NOSM loading
- Add unit test verifying Mach-O symbol lookup and hook it into test suite

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689d4df891388333aa1095bec0818901