### PR TITLE
Define timespec and include NUMA header

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -21,6 +21,7 @@
 #include "VM/pmm.h"
 #include "VM/heap.h"
 #include "VM/paging_adv.h"
+#include "VM/numa.h"
 #include "arch/APIC/lapic.h"
 #include "arch/CPU/irq.h"
 #include "uaccess.h"

--- a/user/libc/time.h
+++ b/user/libc/time.h
@@ -17,6 +17,11 @@ struct tm {
     int tm_isdst; /* daylight savings flag */
 };
 
+struct timespec {
+    time_t tv_sec;  /* seconds */
+    long   tv_nsec; /* nanoseconds */
+};
+
 time_t time(time_t *t);
 
 #endif


### PR DESCRIPTION
## Summary
- add `struct timespec` to custom `time.h`
- include NUMA header in kernel to expose `current_cpu_node`

## Testing
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_689d5d4ad5948333859e9dc6ef509354