### PR TITLE
Fix login keyboard test segmentation fault

### DIFF
--- a/tests/unit/test_login_keyboard.c
+++ b/tests/unit/test_login_keyboard.c
@@ -55,7 +55,6 @@ void nsh_main(ipc_queue_t *fs_q, ipc_queue_t *pkg_q, ipc_queue_t *upd_q, uint32_
 }
 
 int main(void) {
-    tty_init();
     tty_enable_framebuffer(1);
     ipc_queue_t q; (void)q;
     login_server(&q, 0);

--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -75,8 +75,8 @@ static void read_line(char *buf, size_t sz, int echo_asterisk) {
 void login_server(void *fs_q, uint32_t self_id) {
     (void)fs_q;
     (void)self_id;
-
-    tty_init();
+    /* TTY initialization is expected to be done by the caller.
+     * Clear any existing output before starting. */
     tty_clear();
     kprintf("[login] server starting\n");
     put_str("[login] server starting\n");


### PR DESCRIPTION
## Summary
- avoid reinitializing TTY in login server to prevent VGA memory access
- start login keyboard unit test without calling tty_init to use framebuffer-only path

## Testing
- `cd tests && make`


------
https://chatgpt.com/codex/tasks/task_b_689d6ad94e1c83339116fba9a2da213d