### PR TITLE
Fix TTY initialization to avoid VGA access

### DIFF
--- a/nosm/drivers/IO/tty.c
+++ b/nosm/drivers/IO/tty.c
@@ -34,6 +34,14 @@ void tty_init(void) {
     fb_info = NULL;
     fb_cols = 0;
     fb_rows = 0;
+    /* Prefer framebuffer output when available before clearing the screen. */
+    const bootinfo_framebuffer_t *info = video_get_info();
+    if (info) {
+        fb_info = info;
+        fb_cols = fb_info->width / 8;
+        fb_rows = fb_info->height / 16;
+        use_fb = 1;
+    }
     tty_clear();
 }
 

--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -20,6 +20,7 @@ __attribute__((weak)) void tty_init(void) {}
 __attribute__((weak)) void tty_clear(void) {}
 __attribute__((weak)) void tty_write(const char *s) { (void)s; }
 __attribute__((weak)) int  tty_getchar(void) { return -1; }
+__attribute__((weak)) void tty_enable_framebuffer(int enable) { (void)enable; }
 __attribute__((weak)) void thread_yield(void) {}
 
 /* NitroShell entry point.  In tests a custom implementation is linked in. */
@@ -76,7 +77,9 @@ void login_server(void *fs_q, uint32_t self_id) {
     (void)fs_q;
     (void)self_id;
 
-    tty_init();
+    /* Console is expected to be initialized by the system before starting the login server. */
+    /* Ensure framebuffer output is used when available to avoid touching VGA memory. */
+    tty_enable_framebuffer(1);
     tty_clear();
     kprintf("[login] server starting\n");
     put_str("[login] server starting\n");


### PR DESCRIPTION
## Summary
- avoid reinitializing the console in the login agent and enable framebuffer output if available
- have `tty_init` select the framebuffer before clearing to prevent writes to unmapped VGA memory

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689d6b0e7e088333bc1d22b9963ecc94