### PR TITLE
Fix TTY init using framebuffer to avoid VGA segfault

### DIFF
--- a/nosm/drivers/IO/tty.c
+++ b/nosm/drivers/IO/tty.c
@@ -30,10 +30,15 @@ static void draw_char_fb(char c, int r, int cpos) {
 }
 
 void tty_init(void) {
-    use_fb = 0;
-    fb_info = NULL;
-    fb_cols = 0;
-    fb_rows = 0;
+    fb_info = video_get_info();
+    if (fb_info) {
+        use_fb = 1;
+        fb_cols = fb_info->width / 8;
+        fb_rows = fb_info->height / 16;
+    } else {
+        use_fb = 0;
+        fb_cols = fb_rows = 0;
+    }
     tty_clear();
 }
 


### PR DESCRIPTION
## Summary
- Initialize TTY with framebuffer when available to avoid accessing VGA memory

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689d6b2997ec8333a5277b6782643637