### PR TITLE
Add NIC polling thread for hardware networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 - Mach-style IPC message passing (prototype queue implementation)
 - Simple secure heap allocator for user-space memory
 - Device drivers run in dedicated Ring 1/2 tasks; filesystems and networking remain user-mode agents
-- Minimal network stack with loopback support, IPv4 addressing and ARP replies
 - Credential-driven login agent that prints the current IP before launching NitroShell (nsh)
-- Stub VNC, SSH(SCP), and FTP agents that ride on the loopback stack and store files in NOSFS (no real networking yet)
+- Minimal network stack with loopback support, IPv4 addressing, ARP replies, and background polling for an e1000 NIC
+- Stub VNC, SSH(SCP), and FTP agents that ride on the loopback stack and store files in NOSFS; hardware packets now flow through the NIC but the services remain simplistic
 - Experimental copy-on-write paging and basic demand paging
 - Early NUMA node enumeration from bootloader memory map
 - IPC shared memory channels with rights masks

--- a/docs/NETWORK_SERVERS.md
+++ b/docs/NETWORK_SERVERS.md
@@ -12,9 +12,10 @@ brief overview of the stack and how current servers make use of it follows.
 - **Purpose**: Provide a minimal, message-oriented networking layer for
   user-space services.
 - **Status**: Supports a loopback device with port multiplexing, a fixed IPv4
-  address and rudimentary ARP replies.
-- **Future work**: Introduce UDP/TCP modules and hardware NIC drivers so that
-  the existing servers can communicate beyond the emulator.
+  address, rudimentary ARP replies, and background polling of an e1000 NIC for
+  real packets.
+- **Future work**: Expand UDP/TCP handling and higher-level protocols so the
+  existing servers can communicate beyond the emulator.
 
 ## VNC Server
 

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -139,6 +139,13 @@ static void storage_init_thread(void) {
     hal_register(&d_sata, 0);
 }
 
+static void net_poll_thread(void) {
+    for (;;) {
+        net_poll();
+        thread_yield();
+    }
+}
+
 static void net_init_thread(void) {
     net_init();
     hal_descriptor_t d_net = {
@@ -148,6 +155,7 @@ static void net_init_thread(void) {
         .abi = "hw",
     };
     hal_register(&d_net, 0);
+    thread_create(net_poll_thread);
 }
 
 static void start_timer_interrupts(void) {


### PR DESCRIPTION
## Summary
- Run a dedicated kernel thread that continually polls the NIC so hardware packets reach user-space services
- Update networking docs and README to reflect basic e1000 support

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689d6b3e9bfc8333a3d5170f40c3842a