### PR TITLE
Avoid stdlib dependency in hal_async

### DIFF
--- a/kernel/hal_async.c
+++ b/kernel/hal_async.c
@@ -1,6 +1,9 @@
-#include <stdlib.h>
+#include <stddef.h>
 #include <hal.h>
 #include "Task/thread.h"
+
+void *malloc(size_t size);
+void free(void *ptr);
 
 typedef enum {
     HAL_TASK_REG,


### PR DESCRIPTION
## Summary
- drop stdlib include from `hal_async.c`
- forward declare `malloc`/`free` to support freestanding build

## Testing
- `make -C tests test_hal`
- `./tests/test_hal`
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_689d733c4af48333a13219b1b9624602