### PR TITLE
Use full QEMU config in integration test

### DIFF
--- a/tests/integration/test_qemu.py
+++ b/tests/integration/test_qemu.py
@@ -10,10 +10,14 @@ def run_qemu():
         result = subprocess.run(
             [
                 "qemu-system-x86_64",
+                "-cpu",
+                "max",
                 "-bios",
                 "/usr/share/ovmf/OVMF.fd",
                 "-drive",
                 "file=disk.img,format=raw",
+                "-drive",
+                "file=fs.img,format=raw",
                 "-m",
                 "512M",
                 "-netdev",


### PR DESCRIPTION
## Summary
- run integration QEMU tests with a CPU model and filesystem drive to match project expectations

## Testing
- `pytest tests/integration/test_qemu.py::test_boot_sequence -q` *(fails: [init] missing or out of order)*

------
https://chatgpt.com/codex/tasks/task_b_689d6e06e1f88333ac44ed19d789c333