### PR TITLE
Add per-task virtual memory manager with NX/SMEP/SMAP

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -10,6 +10,7 @@
 #include "arch_x86_64/gdt_tss.h"
 #include "../arch/CPU/smp.h"
 #include <kernel/api.h>
+#include "VM/vmm.h"
 
 extern int kprintf(const char *fmt, ...);
 
@@ -145,6 +146,7 @@ void threads_early_init(void){
     memset(&main_thread,0,sizeof(main_thread));
     main_thread.magic=THREAD_MAGIC; main_thread.id=0; main_thread.state=THREAD_RUNNING; main_thread.started=1;
     main_thread.priority=MIN_PRIORITY; main_thread.next=&main_thread;
+    main_thread.pml4 = paging_kernel_pml4;
     uint64_t rsp; __asm__ volatile("mov %%rsp,%0":"=r"(rsp));
     main_thread.rsp=rsp;
     current_cpu[0]=tail_cpu[0]=&main_thread;
@@ -226,6 +228,7 @@ void schedule(void){
     }
 
     next->state=THREAD_RUNNING; next->started=1; current_cpu[cpu]=next;
+    vmm_switch(next->pml4);
     context_switch(&prev->rsp,next->rsp);
     if(prev->state==THREAD_EXITED) add_to_zombie_list(prev);
     thread_reap();
@@ -237,6 +240,7 @@ uint64_t schedule_from_isr(uint64_t *old_rsp){
     thread_t *next=pick_next(cpu);
     if(!next){ current_cpu[cpu]=prev; prev->state=THREAD_RUNNING; return (uint64_t)old_rsp; }
     next->state=THREAD_RUNNING; next->started=1; current_cpu[cpu]=next;
+    vmm_switch(next->pml4);
     kprintf("[sched_isr] switch to tid=%d func=%p rsp=%p\n", next->id, (void*)next->func, (void*)next->rsp);
     return next->rsp;
 }
@@ -322,6 +326,11 @@ thread_t *thread_create_with_priority(void(*func)(void), int priority){
     t->started=0;
     t->priority=priority;
     t->next=NULL;
+    t->pml4=vmm_create_pml4();
+    if(!t->pml4){
+        t->magic=0;
+        return NULL;
+    }
 
     kprintf("[thread] spawn id=%d entry=%p stack=%p-%p prio=%d\n",
             t->id, func, t->stack, t->stack+STACK_SIZE, priority);

--- a/kernel/Task/thread.h
+++ b/kernel/Task/thread.h
@@ -37,6 +37,7 @@ typedef struct THREAD_ALIGNED(64) thread {
     uint64_t       rsp;       // Stack pointer for context switching
     void         (*func)(void); // Entry function
     char          *stack;     // Kernel stack base (from static pool)
+    uint64_t      *pml4;      // Page table root for this thread
     int            id;        // Thread ID (unique)
     thread_state_t state;     // Current state
     int            started;   // Has thread begun execution

--- a/kernel/VM/paging_adv.h
+++ b/kernel/VM/paging_adv.h
@@ -23,6 +23,8 @@ extern "C" {
 #define PAGE_HUGE_1GB 0x200ULL
 #define PAGE_SIZE_2MB  PAGE_HUGE_2MB
 
+extern uint64_t paging_kernel_pml4[512];
+
 // Map a virtual address to a physical one on a preferred NUMA node.
 void paging_map_adv(uint64_t virt, uint64_t phys, uint64_t flags, uint32_t order, int numa_node);
 void paging_unmap_adv(uint64_t virt);

--- a/kernel/VM/vmm.c
+++ b/kernel/VM/vmm.c
@@ -1,0 +1,87 @@
+#include "vmm.h"
+#include "pmm_buddy.h"
+#include "numa.h"
+#include "../../include/cpuid.h"
+#include <string.h>
+
+static inline uint64_t rdmsr(uint32_t msr) {
+    uint32_t lo, hi;
+    __asm__ volatile("rdmsr" : "=a"(lo), "=d"(hi) : "c"(msr));
+    return ((uint64_t)hi << 32) | lo;
+}
+
+static inline void wrmsr(uint32_t msr, uint64_t val) {
+    uint32_t lo = (uint32_t)val;
+    uint32_t hi = (uint32_t)(val >> 32);
+    __asm__ volatile("wrmsr" :: "c"(msr), "a"(lo), "d"(hi));
+}
+
+void vmm_init(void) {
+    uint32_t eax, ebx, ecx, edx;
+    cpuid(0x80000001u, 0, &eax, &ebx, &ecx, &edx);
+    if (edx & (1u << 20)) {
+        uint64_t efer = rdmsr(0xC0000080);
+        efer |= (1ULL << 11); // NXE
+        wrmsr(0xC0000080, efer);
+    }
+    cpuid(7u, 0, &eax, &ebx, &ecx, &edx);
+    uint64_t cr4;
+    __asm__ volatile("mov %%cr4,%0" : "=r"(cr4));
+    if (ebx & (1u << 7))
+        cr4 |= (1ULL << 20); // SMEP
+    if (ebx & (1u << 20))
+        cr4 |= (1ULL << 21); // SMAP
+    __asm__ volatile("mov %0,%%cr4" :: "r"(cr4));
+}
+
+static uint64_t *alloc_table(int node) {
+    void *p = buddy_alloc(0, node, 0);
+    if (!p) return NULL;
+    memset(p, 0, PAGE_SIZE);
+    return (uint64_t *)p;
+}
+
+static uint64_t *get_or_create(uint64_t *table, uint64_t index, uint64_t flags, int node) {
+    if (!(table[index] & PAGE_PRESENT)) {
+        uint64_t *new = alloc_table(node);
+        if (!new) return NULL;
+        table[index] = ((uint64_t)new) | flags | PAGE_PRESENT | PAGE_WRITABLE;
+    }
+    return (uint64_t *)(table[index] & ~0xFFFULL);
+}
+
+uint64_t *vmm_create_pml4(void) {
+    int node = current_cpu_node();
+    uint64_t *new_pml4 = alloc_table(node);
+    if (!new_pml4) return NULL;
+    for (int i = 256; i < 512; ++i)
+        new_pml4[i] = paging_kernel_pml4[i];
+    return new_pml4;
+}
+
+void vmm_map_page(uint64_t *pml4, uint64_t virt, uint64_t phys, uint64_t flags, uint32_t order, int node) {
+    uint64_t pml4_i = (virt >> 39) & 0x1FF;
+    uint64_t pdpt_i = (virt >> 30) & 0x1FF;
+    uint64_t pd_i   = (virt >> 21) & 0x1FF;
+    uint64_t pt_i   = (virt >> 12) & 0x1FF;
+
+    uint64_t *pdpt_t = get_or_create(pml4, pml4_i, PAGE_USER, node);
+    if (!pdpt_t) return;
+    uint64_t *pd_t = get_or_create(pdpt_t, pdpt_i, PAGE_USER, node);
+    if (!pd_t) return;
+
+    if (order >= 9 || (flags & PAGE_SIZE_2MB)) {
+        pd_t[pd_i] = (phys & ~0x1FFFFFULL) | (flags & ~PAGE_SIZE_2MB) |
+                     PAGE_PRESENT | PAGE_WRITABLE | PAGE_SIZE_2MB;
+        return;
+    }
+
+    uint64_t *pt_t = get_or_create(pd_t, pd_i, PAGE_USER, node);
+    if (!pt_t) return;
+    pt_t[pt_i] = (phys & ~0xFFFULL) | flags | PAGE_PRESENT;
+}
+
+void vmm_switch(uint64_t *pml4) {
+    if (!pml4) return;
+    __asm__ volatile("mov %0,%%cr3" :: "r"((uint64_t)pml4) : "memory");
+}

--- a/kernel/VM/vmm.h
+++ b/kernel/VM/vmm.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <stdint.h>
+#include "paging_adv.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void vmm_init(void);
+uint64_t *vmm_create_pml4(void);
+void vmm_map_page(uint64_t *pml4, uint64_t virt, uint64_t phys, uint64_t flags, uint32_t order, int numa_node);
+void vmm_switch(uint64_t *pml4);
+
+#ifdef __cplusplus
+}
+#endif

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -19,6 +19,7 @@
 #include "arch_x86_64/gdt_tss.h"
 #include "VM/numa.h"
 #include "VM/pmm_buddy.h"
+#include "VM/vmm.h"
 #include "VM/heap.h"
 #include "arch/APIC/lapic.h"
 #include "arch/CPU/irq.h"
@@ -131,6 +132,7 @@ void n2_main(bootinfo_t *bootinfo) {
 
     numa_init(bootinfo);
     buddy_init(bootinfo);
+    vmm_init();
     kheap_parse_bootarg(bootinfo->cmdline);
     kheap_init();
 


### PR DESCRIPTION
## Summary
- add VMM module that detects CPU features and enables NX, SMEP and SMAP
- create per-task page tables and switch CR3 on context switch
- expose kernel PML4 for sharing high-memory mappings

## Testing
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_689d4598fe70833388fafb38425a0512