### PR TITLE
Add debug launch key for core agents

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -12,6 +12,7 @@
 #include <kernel/api.h>
 #include "VM/vmm.h"
 #include "../VM/paging_adv.h"
+#include "regx_key.h"
 
 extern int kprintf(const char *fmt, ...);
 
@@ -455,6 +456,11 @@ void threads_init(void){
 
     agent_loader_set_read(agentfs_read_all, agentfs_free);
     __agent_loader_spawn_fn = loader_spawn_bridge;
+
+    if (regx_verify_launch_key(REGX_LAUNCH_KEY) != 0) {
+        kprintf("[boot] regx launch key check failed\n");
+        return;
+    }
 
     // Bring up NOSFS before other core agents so init.mo2 can be served.
     thread_t *t_nosfs = thread_create_with_priority(nosfs_thread_wrapper, MAX_PRIORITY);

--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -7,6 +7,8 @@
 #include "../../../kernel/agent_loader.h"
 #include "../../../user/agents/nosfs/nosfs_server.h"
 #include "../../../user/libc/string_guard.h"
+#include "regx_key.h"
+#include <string.h>
 
 // Kernel console
 extern int kprintf(const char *fmt, ...);
@@ -38,6 +40,10 @@ static int _regx_load_agent(const char *path, const char *arg, uint32_t *out) {
 
 int regx_load(const char *name, const char *arg, uint32_t *out) {
     return _regx_load_agent(name, arg, out);
+}
+
+int regx_verify_launch_key(const char *key) {
+    return (key && strcmp(key, REGX_LAUNCH_KEY) == 0) ? 0 : -1;
 }
 
 // --- utils ---

--- a/src/agents/regx/regx_key.h
+++ b/src/agents/regx/regx_key.h
@@ -1,0 +1,8 @@
+#ifndef REGX_KEY_H
+#define REGX_KEY_H
+
+#define REGX_LAUNCH_KEY "NOS_DEBUG_KEY"
+
+int regx_verify_launch_key(const char *key);
+
+#endif /* REGX_KEY_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
     -I../include -I../kernel -I../kernel/VM -I../boot/include \
     -I../user/agents/nosfs -I../user/agents/login -I../user/agents/ftp \
     -I../user/libc -I../nosm/drivers/IO -I../nosm/drivers/Audio \
-    -I../nosm/drivers/Net -I../kernel/arch/GDT
+    -I../nosm/drivers/Net -I../kernel/arch/GDT -I../src/agents/regx
 
 LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c vmm_stub.c ../kernel/uaccess.c
 

--- a/user/agents/nosfs/nosfs_server.c
+++ b/user/agents/nosfs/nosfs_server.c
@@ -2,6 +2,7 @@
 #include "nosfs.h"
 #include <string.h>
 #include <stdatomic.h>
+#include "regx_key.h"
 
 // Optional boot logging from kernel
 extern int kprintf(const char *fmt, ...);
@@ -25,6 +26,11 @@ static void nosfs_debug_list_all(void) {
 // sequentially and the response is sent back on the same queue.
 void nosfs_server(ipc_queue_t *q, uint32_t self_id) {
     (void)self_id;
+
+    if (regx_verify_launch_key(REGX_LAUNCH_KEY) != 0) {
+        kprintf("[nosfs] invalid launch key\n");
+        return;
+    }
 
     // Initialise filesystem; attempt to load existing NOSFS from block device.
     nosfs_init(&nosfs_root);

--- a/user/agents/nosm/nosm.c
+++ b/user/agents/nosm/nosm.c
@@ -1,4 +1,5 @@
 #include "drivers/IO/serial.h"
+#include "regx_key.h"
 
 extern int kprintf(const char *fmt, ...);
 
@@ -6,6 +7,10 @@ extern int kprintf(const char *fmt, ...);
 // For now it simply announces itself so the kernel can
 // verify that the thread was launched.
 void nosm_entry(void) {
+    if (regx_verify_launch_key(REGX_LAUNCH_KEY) != 0) {
+        kprintf("[nosm] invalid launch key\n");
+        return;
+    }
     kprintf("[nosm] module manager initialized\n");
     serial_puts("[nosm] module manager initialized\n");
 }


### PR DESCRIPTION
## Summary
- Introduce shared debug launch key and verification helper in RegX
- Require key check before starting nosfs and nosm threads
- Validate key inside nosfs and nosm agents; expose regx headers to tests

## Testing
- `make -C tests` *(fails: ‘paging_kernel_pml4’ redeclared as different kind of symbol)*

------
https://chatgpt.com/codex/tasks/task_b_689d7c9305b483339f89fb409ebd6349