### PR TITLE
Relax regx gate and fix paging accessor

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -148,10 +148,9 @@ void threads_early_init(void){
     memset(&main_thread,0,sizeof(main_thread));
     main_thread.magic=THREAD_MAGIC; main_thread.id=0; main_thread.state=THREAD_RUNNING; main_thread.started=1;
     main_thread.priority=MIN_PRIORITY; main_thread.next=&main_thread;
-    main_thread.pml4 = paging_kernel_pml4;
     uint64_t rsp; __asm__ volatile("mov %%rsp,%0":"=r"(rsp));
     main_thread.rsp=rsp;
-    main_thread.pml4=paging_kernel_pml4();
+    main_thread.pml4 = paging_kernel_pml4();
     current_cpu[0]=tail_cpu[0]=&main_thread;
 }
 

--- a/kernel/VM/paging_adv.c
+++ b/kernel/VM/paging_adv.c
@@ -68,7 +68,7 @@ out:
     // failed allocation, nothing mapped
 done:
     
-  _UNLOCK();
+    PAGING_UNLOCK();
 }
 
 void paging_unmap_adv(uint64_t virt) {

--- a/kernel/VM/paging_adv.h
+++ b/kernel/VM/paging_adv.h
@@ -23,7 +23,6 @@ extern "C" {
 #define PAGE_HUGE_1GB 0x200ULL
 #define PAGE_SIZE_2MB  PAGE_HUGE_2MB
 
-extern uint64_t paging_kernel_pml4[512];
 
 // Map a virtual address to a physical one on a preferred NUMA node.
 void paging_map_adv(uint64_t virt, uint64_t phys, uint64_t flags, uint32_t order, int numa_node);

--- a/kernel/VM/vmm.c
+++ b/kernel/VM/vmm.c
@@ -54,8 +54,9 @@ uint64_t *vmm_create_pml4(void) {
     int node = current_cpu_node();
     uint64_t *new_pml4 = alloc_table(node);
     if (!new_pml4) return NULL;
+    uint64_t *kernel_pml4 = paging_kernel_pml4();
     for (int i = 256; i < 512; ++i)
-        new_pml4[i] = paging_kernel_pml4[i];
+        new_pml4[i] = kernel_pml4[i];
     return new_pml4;
 }
 


### PR DESCRIPTION
## Summary
- Simplify regx policy gate to log requests and always allow agent loads while launch key check remains intact.
- Convert paging_kernel_pml4 to an accessor function and update VMM, thread setup, and paging code accordingly.

## Testing
- `make -C tests` *(fails: undefined reference to `vmm_switch` and `regx_verify_launch_key`)*
- `tests/test_regx`
- `make run` *(fails: XDG_RUNTIME_DIR is invalid or not set)*

------
https://chatgpt.com/codex/tasks/task_b_689d7eb205d48333bbcc37f1e3af367a