### PR TITLE
Ensure init agent validates launch key

### DIFF
--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -1,6 +1,7 @@
 #include "../../rt/agent_abi.h"
 #include "../../libc/libc.h"
 #include "dyld2.h"
+#include "regx_key.h"
 
 extern int kprintf(const char *fmt, ...);
 
@@ -22,6 +23,13 @@ void init_main(const AgentAPI *api, uint32_t self_tid)
     (void)self_tid;
     if (!api)
         return;
+
+    if (regx_verify_launch_key(REGX_LAUNCH_KEY) != 0) {
+        if (api->puts)
+            api->puts("[init] invalid launch key\n");
+        kprintf("[init] invalid launch key\n");
+        return;
+    }
 
     if (api->puts)
         api->puts("[init] starting with dyld2\n");


### PR DESCRIPTION
## Summary
- Require valid launch key before init agent starts.

## Testing
- `make out/agents/init.mo2`
- `make -C tests test_nosm test_nosfs`
- `./tests/test_nosm`
- `./tests/test_nosfs`


------
https://chatgpt.com/codex/tasks/task_b_689d83f26e74833397d0106c32a95439