### PR TITLE
Verify launch key before starting core agents

### DIFF
--- a/system/init.c
+++ b/system/init.c
@@ -4,6 +4,7 @@
 #include "../rt/agent_abi.h"
 #include "../libc/libc.h"
 #include "../loader/dyld2.h"
+#include "regx_key.h"
 
 extern int kprintf(const char *fmt, ...);
 
@@ -11,6 +12,10 @@ void init_main(const AgentAPI *api, uint32_t self_tid)
 {
     (void)self_tid;
     if(!api) return;
+    if (regx_verify_launch_key(REGX_LAUNCH_KEY) != 0) {
+        kprintf("[init] invalid launch key\n");
+        return;
+    }
     if(api->puts) api->puts("[init] starting with dyld2\n");
     kprintf("[init] starting with dyld2\n");
     dyld2_init(api);

--- a/tests/thread_test_stubs.c
+++ b/tests/thread_test_stubs.c
@@ -17,6 +17,7 @@ int api_puts(const char *s) { (void)s; return 0; }
 int api_fs_read_all(const char *path, void *buf, size_t len, size_t *outlen) { (void)path; (void)buf; (void)len; if (outlen) *outlen = 0; return -1; }
 int api_regx_load(const char *name, const char *arg, uint32_t *out) { (void)name; (void)arg; if (out) *out = 0; return -1; }
 void api_yield(void) {}
+int regx_verify_launch_key(const char *key) { (void)key; return 0; }
 
 uint64_t *paging_kernel_pml4(void) { return NULL; }
 void paging_switch(uint64_t *new_pml4) { (void)new_pml4; }

--- a/tests/vmm_stub.c
+++ b/tests/vmm_stub.c
@@ -1,4 +1,8 @@
 #include <stddef.h>
+#include <stdint.h>
 void vmm_prot(void* va, size_t size, int prot) {
     (void)va; (void)size; (void)prot;
 }
+void vmm_switch(uint64_t *new_pml4) { (void)new_pml4; }
+static uint64_t dummy_pml4;
+uint64_t *vmm_create_pml4(void) { return &dummy_pml4; }

--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -1,6 +1,7 @@
 #include "../../rt/agent_abi.h"
 #include "../../libc/libc.h"
 #include "dyld2.h"
+#include "regx_key.h"
 
 extern int kprintf(const char *fmt, ...);
 
@@ -22,6 +23,11 @@ void init_main(const AgentAPI *api, uint32_t self_tid)
     (void)self_tid;
     if (!api)
         return;
+
+    if (regx_verify_launch_key(REGX_LAUNCH_KEY) != 0) {
+        kprintf("[init] invalid launch key\n");
+        return;
+    }
 
     if (api->puts)
         api->puts("[init] starting with dyld2\n");

--- a/user/agents/nosm/nosm_agent.c
+++ b/user/agents/nosm/nosm_agent.c
@@ -3,6 +3,7 @@
 #include "../../../include/nosm_ipc.h"
 #include "../../../nosm/drivers/IO/serial.h"
 #include <stdint.h>
+#include "regx_key.h"
 
 /* --- Minimal SHA-256 + HMAC implementation (public domain) ---------------- */
 
@@ -229,6 +230,10 @@ static int extract_manifest(const void *blob, uint32_t len, char *out, uint32_t 
 
 void nosm_server(ipc_queue_t *q, uint32_t self_id) {
     (void)self_id;
+    if (regx_verify_launch_key(REGX_LAUNCH_KEY) != 0) {
+        serial_puts("[nosm] invalid launch key\n");
+        return;
+    }
     serial_puts("[nosm] security agent online\n");
     for (;;) {
         ipc_message_t m = {0};


### PR DESCRIPTION
## Summary
- ensure init agent validates REGX launch key before booting login
- add launch key check for system init and nosm security server
- expand test stubs for launch key and virtual memory helpers

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689d83f26e74833397d0106c32a95439