### PR TITLE
Handle PML4 allocation failure in thread creation

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -351,9 +351,11 @@ thread_t *thread_create_with_priority(void(*func)(void), int priority){
     t->started=0;
     t->priority=priority;
     t->next=NULL;
-    t->pml4=vmm_create_pml4();
-    if(!t->pml4){
-        t->magic=0;
+    uint64_t *new_pml4 = vmm_create_pml4();
+    if (new_pml4)
+        t->pml4 = new_pml4;
+    if (!t->pml4) {
+        t->magic = 0;
         return NULL;
     }
 


### PR DESCRIPTION
## Summary
- Avoid thread creation failure when a per-thread PML4 can't be allocated

## Testing
- `make disk.img`
- `timeout 20 qemu-system-x86_64 -drive format=raw,file=disk.img -bios OVMF.fd -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -device qemu-xhci -device usb-kbd -serial stdio -display none -no-reboot -d guest_errors` *(no serial output)*

------
https://chatgpt.com/codex/tasks/task_b_689d8a400d60833392f2f5c9c3d9229f