### PR TITLE
kernel: don't block on async init threads

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -259,11 +259,11 @@ void n2_main(bootinfo_t *bootinfo) {
         hal_register(&d, 0);
     }
 
-    /* Launch storage and network init in parallel to shorten boot time */
-    thread_t *t_storage = thread_create(storage_init_thread);
-    thread_t *t_net     = thread_create(net_init_thread);
-    thread_join(t_storage);
-    thread_join(t_net);
+    /* Launch storage and network init in parallel but don't block on them.
+       Some environments lack the hardware these threads probe and they may
+       never return, stalling boot.  Let them run asynchronously instead. */
+    thread_create(storage_init_thread);
+    thread_create(net_init_thread);
 
     vprint("[N2] Starting Agent Registry\r\n");
 


### PR DESCRIPTION
## Summary
- avoid blocking on storage and network init threads during boot to prevent deadlocks when hardware is absent

## Testing
- `make -C tests`
- `qemu-system-x86_64 -cpu max -bios OVMF.fd -drive file=disk.img,format=raw -drive file=fs.img,format=raw -m 512M -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -device qemu-xhci -device usb-kbd -serial stdio -display none`

------
https://chatgpt.com/codex/tasks/task_b_689d924c95048333a9859df720b7493f