### PR TITLE
Avoid NOSFS reinit wiping preloaded modules

### DIFF
--- a/user/agents/nosfs/nosfs_server.c
+++ b/user/agents/nosfs/nosfs_server.c
@@ -32,11 +32,14 @@ void nosfs_server(ipc_queue_t *q, uint32_t self_id) {
         return;
     }
 
-    // Initialise filesystem and mark it ready immediately so boot can
-    // continue even if device loading is slow. Then attempt to load from
-    // disk in the background.
-    nosfs_init(&nosfs_root);
-    atomic_store(&nosfs_ready, 1);
+    // Initialise filesystem on first launch and mark it ready immediately so
+    // boot can continue even if device loading is slow.  If the kernel already
+    // staged modules into an existing instance (e.g. before this server
+    // thread started) avoid re-initialising to preserve those files.
+    if (!nosfs_is_ready()) {
+        nosfs_init(&nosfs_root);
+        atomic_store(&nosfs_ready, 1);
+    }
     kprintf("[nosfs] server ready\n");
     if (nosfs_load_device(&nosfs_root, 0) == 0)
         kprintf("[nosfs] loaded filesystem from disk\n");


### PR DESCRIPTION
## Summary
- prevent nosfs server from reinitializing filesystem if already staged
- preserves init/login agents so login prompt can appear

## Testing
- `cd tests && make clean && make`


------
https://chatgpt.com/codex/tasks/task_b_689e28068eb08333b13ca7af3ef252ac