### PR TITLE
Disable runaway watchdog and guard module loading

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -285,9 +285,13 @@ __attribute__((noreturn,used)) static void thread_start(void (*f)(void)){
     }
 
     kprintf("[thread] id=%u about to jump to entry @ %p\n", tid, (void*)entry);
-    arm_init_watchdog(1000); /* ~N ms depending on timer freq */
+    /* The previous implementation armed a watchdog for every thread
+     * and only disarmed it after the entry function returned.  Long-lived
+     * agents like the registry or filesystem never return, causing the
+     * watchdog to fire and reboot the system before userland (e.g. the
+     * login agent) could start.  Drop the watchdog so threads that run
+     * indefinitely no longer trigger spurious resets. */
     entry(&k_agent_api, tid);
-    arm_init_watchdog(0);
     kprintf("[thread] id=%u returned from entry\n", tid);
     thread_exit();
 }

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -303,7 +303,12 @@ void n2_main(bootinfo_t *bootinfo) {
                   (rflags >> 9) & 1, cr0, cr3, cr4);
     serial_printf("[N2] runqueue len cpu0=%d\n", thread_runqueue_length(0));
 
-    for (uint32_t i = 0; i < bootinfo->module_count; ++i)
+    uint32_t module_count = bootinfo->module_count;
+    if (module_count > 16) {
+        kprintf("[N2] module_count %u exceeds max 16; clamping\n", module_count);
+        module_count = 16;
+    }
+    for (uint32_t i = 0; i < module_count; ++i)
         load_module(&bootinfo->modules[i]);
 
     if (nosfs_is_ready())


### PR DESCRIPTION
## Summary
- Prevent uninitialized boot info from overrunning module loading by clamping module count
- Remove global thread watchdog arming that caused early guest reboots

## Testing
- `make`
- `cd tests && make clean && make`
- `qemu-system-x86_64 -cpu max -bios OVMF.fd -drive file=disk.img,format=raw -drive file=fs.img,format=raw -m 512M -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -device qemu-xhci -device usb-kbd -serial stdio -display none -no-reboot` *(fails: still exits before login)*

------
https://chatgpt.com/codex/tasks/task_b_689e2e4f03608333a324c7adda0c2e45