### PR TITLE
nosfs: preserve boot-staged modules

### DIFF
--- a/user/agents/nosfs/nosfs_server.c
+++ b/user/agents/nosfs/nosfs_server.c
@@ -41,10 +41,17 @@ void nosfs_server(ipc_queue_t *q, uint32_t self_id) {
         atomic_store(&nosfs_ready, 1);
     }
     kprintf("[nosfs] server ready\n");
-    if (nosfs_load_device(&nosfs_root, 0) == 0)
+
+    /* If the kernel staged boot modules into the filesystem before this server
+       started, preserve them instead of overwriting with whatever is on disk. */
+    if (nosfs_root.file_count > 0) {
+        kprintf("[nosfs] using preloaded filesystem (%u files)\n",
+                nosfs_root.file_count);
+    } else if (nosfs_load_device(&nosfs_root, 0) == 0) {
         kprintf("[nosfs] loaded filesystem from disk\n");
-    else
+    } else {
         kprintf("[nosfs] formatting new filesystem\n");
+    }
 
     // Optional one-time debug listing (uncomment if needed)
     nosfs_debug_list_all();


### PR DESCRIPTION
## Summary
- prevent nosfs server from overwriting modules staged by the kernel during boot
- keep preloaded files like init.mo2 available so login shell launches

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689e3cc4dd5c8333a8568a4639fe5b0f