### PR TITLE
Fix init module launch path

### DIFF
--- a/kernel/Task/thread.c
+++ b/kernel/Task/thread.c
@@ -458,7 +458,7 @@ void threads_init(void){
         return;
     }
 
-    // Bring up NOSFS before other core agents so init.mo2 can be served.
+    // Bring up NOSFS before other core agents so agents/init.mo2 can be served.
     thread_t *t_nosfs = thread_create_with_priority(nosfs_thread_wrapper, MAX_PRIORITY);
 
     // Then bring up other helpers (security gate started later once FS populated)
@@ -493,5 +493,5 @@ void regx_start(void){
     thread_t *t_regx = thread_create_with_priority(regx_thread_wrapper, 220);
     if(!t_regx){ kprintf("[boot] failed to spawn regx\n"); for(;;)__asm__ volatile("hlt"); }
     ipc_grant(&regx_queue, t_regx->id, IPC_CAP_SEND | IPC_CAP_RECV);
-    ipc_grant(&fs_queue,   t_regx->id, IPC_CAP_SEND | IPC_CAP_RECV);   // regx needs FS to load /agents/init.mo2
+    ipc_grant(&fs_queue,   t_regx->id, IPC_CAP_SEND | IPC_CAP_RECV);   // regx needs FS to load agents/init.mo2
 }

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -328,7 +328,9 @@ void n2_main(bootinfo_t *bootinfo) {
     for (int i = 0; i < 1000 && !n2_agent_get("login"); ++i)
         thread_yield();
     if (!n2_agent_get("login")) {
-        int tid = agent_loader_run_from_path("init.mo2", MAX_PRIORITY);
+        int tid = agent_loader_run_from_path("agents/init.mo2", MAX_PRIORITY);
+        if (tid < 0)
+            tid = agent_loader_run_from_path("init.mo2", MAX_PRIORITY);
         serial_printf("[N2] fallback init launch tid=%d\n", tid);
     }
 

--- a/src/agents/regx/regx.c
+++ b/src/agents/regx/regx.c
@@ -82,8 +82,10 @@ static void spawn_init_once(void) {
 
     for (;;) {
         kprintf("[regx] launching init (boot:init:regx)\n");
-        /* Boot modules are saved without directory prefixes. */
-        int rc = agent_loader_run_from_path("init.mo2", MAX_PRIORITY);
+        /* Boot modules retain their full paths (e.g. "agents/init.mo2"). */
+        int rc = agent_loader_run_from_path("agents/init.mo2", MAX_PRIORITY);
+        if (rc < 0)
+            rc = agent_loader_run_from_path("init.mo2", MAX_PRIORITY);
         if (rc >= 0) {
             kprintf("[regx] init agent launched rc=%d\n", rc);
             break;


### PR DESCRIPTION
## Summary
- Ensure registry and kernel launch init from `agents/init.mo2`
- Update comments to reflect correct boot module path

## Testing
- `make kernel agents`


------
https://chatgpt.com/codex/tasks/task_b_689e3cc4dd5c8333a8568a4639fe5b0f