### PR TITLE
Ensure login agent initializes TTY

### DIFF
--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -51,8 +51,12 @@ static void read_line(char *buf, size_t sz, int echo_asterisk) {
 void login_server(void *fs_q, uint32_t self_id) {
     (void)fs_q;
     (void)self_id;
-    /* TTY initialization is expected to be done by the caller.
-     * Clear any existing output before starting. */
+    /* Ensure the TTY is ready even if the caller skipped initialization.
+     * Login previously assumed another agent would prepare the TTY which
+     * meant early boot sequences that launched login directly produced no
+     * visible output.  Initialising it here makes the server self‑contained
+     * and guarantees the prompt appears. */
+    tty_init();
     tty_clear();
     kprintf("[login] server starting\n");
     put_str("[login] server starting\n");


### PR DESCRIPTION
## Summary
- Initialize the TTY driver within the login agent so boot sequences that spawn login directly still display the prompt.

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make agents`


------
https://chatgpt.com/codex/tasks/task_b_689e4fb3aeac833382320848f2e32aa1