### PR TITLE
Defer NOSFS readiness until filesystem is populated

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -107,12 +107,6 @@ static void load_module(const void *m)
     if (!mod || !mod->base || !mod->name)
         return;
 
-    /* Wait a bit for NOSFS to come up; skip if it never does. */
-    for (int i = 0; i < 1000 && !nosfs_is_ready(); ++i)
-        thread_yield();
-    if (!nosfs_is_ready())
-        return;
-
     const char *name = mod->name;
     if (name[0] == '/')
         name++;

--- a/user/agents/nosfs/nosfs.c
+++ b/user/agents/nosfs/nosfs.c
@@ -128,7 +128,6 @@ void nosfs_init(nosfs_fs_t *fs) {
     pthread_mutex_init(&fs->mutex, NULL);
     nosfs_journal_init();
     undo_log.type = NOSFS_UNDO_NONE;
-    atomic_store(&nosfs_ready, 1);
 }
 
 void nosfs_destroy(nosfs_fs_t *fs) {

--- a/user/agents/nosfs/nosfs_server.c
+++ b/user/agents/nosfs/nosfs_server.c
@@ -36,10 +36,8 @@ void nosfs_server(ipc_queue_t *q, uint32_t self_id) {
     // boot can continue even if device loading is slow.  If the kernel already
     // staged modules into an existing instance (e.g. before this server
     // thread started) avoid re-initialising to preserve those files.
-    if (!nosfs_is_ready()) {
+    if (!nosfs_is_ready())
         nosfs_init(&nosfs_root);
-        atomic_store(&nosfs_ready, 1);
-    }
     kprintf("[nosfs] server ready\n");
 
     /* If the kernel staged boot modules into the filesystem before this server
@@ -52,6 +50,8 @@ void nosfs_server(ipc_queue_t *q, uint32_t self_id) {
     } else {
         kprintf("[nosfs] formatting new filesystem\n");
     }
+
+    atomic_store(&nosfs_ready, 1);
 
     // Optional one-time debug listing (uncomment if needed)
     nosfs_debug_list_all();


### PR DESCRIPTION
## Summary
- avoid advertising NOSFS ready before the server has loaded the filesystem
- drop premature ready flag in `nosfs_init`
- stage boot modules without waiting inside the loader

## Testing
- `make`
- `timeout 60s qemu-system-x86_64 -cpu max -bios OVMF.fd -drive file=disk.img,format=raw -drive file=fs.img,format=raw -m 512M -netdev user,id=n0 -device e1000,netdev=n0 -device i8042 -device qemu-xhci -device usb-kbd -nographic -serial mon:stdio >/tmp/qemu.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_b_689e4fb3aeac833382320848f2e32aa1