### PR TITLE
Allow absolute paths in regx_load

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
 
 LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c vmm_stub.c ../kernel/uaccess.c
 
-UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2
+UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2 test_regx_load
 
 all: $(UNIT_TESTS)
 	for t in $(UNIT_TESTS); do ./$$t; done
@@ -42,6 +42,9 @@ test_nosm: unit/test_nosm.c ../kernel/IPC/ipc.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_regx: unit/test_regx.c ../kernel/regx.c $(LIBC_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_regx_load: unit/test_regx_load.c
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_thread: unit/test_thread.c ../kernel/Task/thread.c thread_test_stubs.c $(filter-out thread_stub.c,$(LIBC_SRC))

--- a/tests/unit/test_regx_load.c
+++ b/tests/unit/test_regx_load.c
@@ -1,0 +1,33 @@
+#include <assert.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Stubs for external dependencies of regx.c
+int kprintf(const char *fmt, ...) { (void)fmt; return 0; }
+void thread_yield(void) {}
+int nosfs_is_ready(void) { return 1; }
+void serial_puts(const char *s) { (void)s; }
+void serial_putsn(const char *s, size_t n) { (void)s; (void)n; }
+void agent_loader_set_gate(int (*gate)(const char*, const char*, const char*, const char*, const char*)) { (void)gate; }
+
+static const char *last_path;
+int agent_loader_run_from_path(const char *path, int prio) {
+    (void)prio;
+    last_path = path;
+    return 1; // fake thread id
+}
+
+// Include the implementation under test
+#include "../../src/agents/regx/regx.c"
+
+int main(void) {
+    // Absolute path should be normalized
+    regx_load("/agents/login.mo2", NULL, NULL);
+    assert(strcmp(last_path, "agents/login.mo2") == 0);
+
+    // Relative path should remain unchanged
+    regx_load("agents/login.mo2", NULL, NULL);
+    assert(strcmp(last_path, "agents/login.mo2") == 0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- normalize agent paths in `regx_load` to accept leading slashes
- add regression test for absolute vs relative agent paths

## Testing
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689e5d1bea008333aa94e7a079419047