### PR TITLE
Ensure agents have runtime entry points

### DIFF
--- a/user/agents/init/agent_entry.c
+++ b/user/agents/init/agent_entry.c
@@ -1,0 +1,9 @@
+#include "../../rt/agent_abi.h"
+
+// Forward declaration of the real init entry point
+void init_main(const AgentAPI *api, uint32_t self_tid);
+
+// Runtime entry expected by rt0_user.S
+void _agent_main(const AgentAPI *api, uint32_t self_tid) {
+    init_main(api, self_tid);
+}

--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -13,7 +13,7 @@ static const char manifest[] =
 "  \"name\": \"init\",\n"
 "  \"type\": 4,\n"
 "  \"version\": \"1.0.0\",\n"
-"  \"entry\": \"init_main\"\n"
+"  \"entry\": \"_start\"\n"
 "}\n";
 
 /* Entry point for the init agent.  It now acts as a userspace agent loader

--- a/user/agents/login/agent_entry.c
+++ b/user/agents/login/agent_entry.c
@@ -1,4 +1,5 @@
 #include "../../libc/libc.h"
+#include "../../rt/agent_abi.h"
 #include "login.h"
 
 // Real entry implemented in login.c
@@ -15,9 +16,10 @@ static const char mo2_manifest[] =
 "  \"entry\": \"_start\"\n"
 "}\n";
 
-// Single entry point expected by the loader
-void agent_main(void) {
-    login_server(NULL, 0);
+// Runtime entry expected by rt0_user.S
+void _agent_main(const AgentAPI *api, uint32_t self_id) {
+    (void)api; // API currently unused by the login server
+    login_server(NULL, self_id);
     for (;;) thread_yield();
 }
 


### PR DESCRIPTION
## Summary
- Provide `_agent_main` wrapper for init agent so loader invokes `init_main`
- Wire login agent through `_agent_main` and expose AgentAPI
- Point init manifest entry to `_start`

## Testing
- `make agents`
- `make -C tests`


------
https://chatgpt.com/codex/tasks/task_b_689e5d1bea008333aa94e7a079419047