### PR TITLE
Fix init login path

### DIFF
--- a/system/init.c
+++ b/system/init.c
@@ -20,7 +20,7 @@ void init_main(const AgentAPI *api, uint32_t self_tid)
     kprintf("[init] starting with dyld2\n");
     dyld2_init(api);
 
-    const char* login_path = "/agents/login.mo2";
+    const char* login_path = "agents/login.mo2";
     if(api->puts) api->puts("[init] launching login\n");
     kprintf("[init] launching login\n");
     int tid = -1;

--- a/user/agents/init/init.c
+++ b/user/agents/init/init.c
@@ -35,7 +35,7 @@ void init_main(const AgentAPI *api, uint32_t self_tid)
 
     dyld2_init(api);
 
-    const char *login_path = "/agents/login.mo2";
+    const char *login_path = "agents/login.mo2";
     if (api->puts)
         api->puts("[init] launching login\n");
     kprintf("[init] launching login\n");


### PR DESCRIPTION
## Summary
- fix login agent path in init to allow NitroShell to launch

## Testing
- `make -C tests`
- `python -m pytest tests/integration/test_qemu.py -q` *(fails: skipped: qemu-system-x86_64 not installed)*

------
https://chatgpt.com/codex/tasks/task_b_689e5d1bea008333aa94e7a079419047