### PR TITLE
Add NitroHeap size class unit tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
 
 LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c vmm_stub.c ../kernel/uaccess.c
 
-UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2 test_regx_load
+UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2 test_regx_load test_nh_classes
 
 all: $(UNIT_TESTS)
 	for t in $(UNIT_TESTS); do ./$$t; done
@@ -51,7 +51,10 @@ test_thread: unit/test_thread.c ../kernel/Task/thread.c thread_test_stubs.c $(fi
 	$(CC) $(CFLAGS) -DUNIT_TEST $^ -Wl,--gc-sections -o $@
 
 test_nitroheap: unit/test_nitroheap.c ../kernel/VM/nitroheap/nitroheap.c \
-../kernel/VM/nitroheap/classes.c buddy_stub.c $(LIBC_SRC)
+	../kernel/VM/nitroheap/classes.c buddy_stub.c $(LIBC_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_nh_classes: unit/test_nh_classes.c ../kernel/VM/nitroheap/classes.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_hal: unit/test_hal.c ../kernel/hal.c ../kernel/hal_async.c ../kernel/regx.c $(LIBC_SRC)

--- a/tests/unit/test_nh_classes.c
+++ b/tests/unit/test_nh_classes.c
@@ -1,0 +1,35 @@
+#include <assert.h>
+#include <stdio.h>
+#include "../../kernel/VM/nitroheap/classes.h"
+
+int main(void) {
+    // Small size with minimal alignment
+    int cls = size_class_for(1, 1);
+    assert(cls >= 0);
+    assert(nh_size_classes[cls].size == 8);
+    assert(nh_size_classes[cls].align == 8);
+
+    // Alignment larger than size class alignment should move to next class
+    int cls_aligned = size_class_for(30, 64);
+    assert(cls_aligned >= 0);
+    assert(nh_size_classes[cls_aligned].size == 64);
+    assert(nh_size_classes[cls_aligned].align == 64);
+
+    // Larger request near upper bound
+    int cls_large = size_class_for(5000, 16);
+    assert(cls_large >= 0);
+    assert(nh_size_classes[cls_large].size == 5120);
+    assert(nh_size_classes[cls_large].align == 4096);
+
+    // Request exceeding all classes should return -1
+    assert(size_class_for(20000, 8) == -1);
+
+    // class_align utility
+    assert(class_align(cls) == nh_size_classes[cls].align);
+    assert(class_align(-1) == 0);
+    assert(class_align(nh_size_class_count) == 0);
+
+    printf("nh_size_class tests passed\n");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for NitroHeap size class selection and alignment helpers
- integrate new test into tests/Makefile

## Testing
- `make test_nh_classes`
- `make test_nitroheap`


------
https://chatgpt.com/codex/tasks/task_b_689e718cfae48333b39c9318163b5fd2