### PR TITLE
Display login prompt via TTY

### DIFF
--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include "drivers/IO/serial.h"
+#include "drivers/IO/tty.h"
 #include "klib/stdio.h"
 #include "panic.h"
 
@@ -10,7 +11,7 @@
  * and avoids duplicate symbol definitions when linking.
  */
 void kcons_putc(int c) {
-    serial_write((char)c);
+    tty_putc((char)c);
 }
 
 int kprintf(const char *fmt, ...) {

--- a/tests/unit/test_login.c
+++ b/tests/unit/test_login.c
@@ -3,6 +3,10 @@
 #include "../../user/agents/login/login.h"
 #include "../../kernel/IPC/ipc.h"
 #include "../../user/libc/libc.h"
+#include "../../user/rt/agent_abi.h"
+
+const AgentAPI *NOS = NULL;
+uint32_t NOS_TID = 0;
 
 static const char *input = "admin\nadmin\n";
 static size_t pos = 0;

--- a/tests/unit/test_login_keyboard.c
+++ b/tests/unit/test_login_keyboard.c
@@ -3,6 +3,10 @@
 #include "../../kernel/IPC/ipc.h"
 #include "../../user/libc/libc.h"
 #include "../../user/agents/login/login.h"
+#include "../../user/rt/agent_abi.h"
+
+const AgentAPI *NOS = NULL;
+uint32_t NOS_TID = 0;
 
 static const char *input = "admin\nadmin\n";
 static size_t pos = 0;

--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -1,4 +1,5 @@
 #include "login.h"
+#include "../../rt/agent_abi.h"
 #ifndef LOGIN_UNIT_TEST
 #include "../../../nosm/drivers/IO/serial.c"
 #else
@@ -9,8 +10,10 @@
 
 volatile login_session_t current_session = {0};
 
-/* Simple output helper (no stdio). */
-static void put_str(const char *s) { serial_puts(s); }
+/* Simple output helper that routes through the Agent API when available. */
+static void put_str(const char *s) {
+    if (NOS && NOS->puts) NOS->puts(s);
+}
 
 /* Block until a character is available from the serial port. */
 static char getchar_block(void) {


### PR DESCRIPTION
## Summary
- Route kernel console output through the TTY driver so messages reach both serial and framebuffer
- Update login agent to emit prompts using the Agent API for on-screen display
- Adjust unit tests to stub Agent API globals

## Testing
- `make -C tests`
- `make image` *(fails: clang: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689e8b408ce08333877c0a42233daab6