### PR TITLE
Display login prompt via TTY

### DIFF
--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include "drivers/IO/serial.h"
+#include "drivers/IO/tty.h"
 #include "klib/stdio.h"
 #include "panic.h"
 
@@ -10,7 +11,7 @@
  * and avoids duplicate symbol definitions when linking.
  */
 void kcons_putc(int c) {
-    serial_write((char)c);
+    tty_putc((char)c);
 }
 
 int kprintf(const char *fmt, ...) {

--- a/nosm/drivers/IO/serial.c
+++ b/nosm/drivers/IO/serial.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include "io.h"
 #include "serial.h"
+#include "tty.h"
 #include <stdarg.h>
 
 #define COM1 0x3F8
@@ -38,6 +39,7 @@ void serial_write(char c) {
         ;
     }
     outb(COM1, c);
+    tty_putc_noserial(c);
 }
 
 void serial_puts(const char *s) {

--- a/nosm/drivers/IO/tty.h
+++ b/nosm/drivers/IO/tty.h
@@ -8,6 +8,8 @@ void tty_enable_framebuffer(int enable);
 void tty_clear(void);
 void tty_use_vga(int enable);
 void tty_putc(char c);
+/* Output to the display without serial logging. */
+void tty_putc_noserial(char c);
 void tty_write(const char *s);
 int tty_getchar(void);
 

--- a/tests/unit/test_login.c
+++ b/tests/unit/test_login.c
@@ -3,6 +3,10 @@
 #include "../../user/agents/login/login.h"
 #include "../../kernel/IPC/ipc.h"
 #include "../../user/libc/libc.h"
+#include "../../user/rt/agent_abi.h"
+
+const AgentAPI *NOS = NULL;
+uint32_t NOS_TID = 0;
 
 static const char *input = "admin\nadmin\n";
 static size_t pos = 0;
@@ -24,6 +28,10 @@ int serial_read(void) {
     if (pos >= strlen(input)) return -1;
     return (unsigned char)input[pos++];
 }
+
+/* Stubs for TTY output used by the login server */
+void tty_clear(void) {}
+void tty_write(const char *s) { (void)s; }
 
 int main(void) {
     ipc_queue_t q; (void)q;

--- a/tests/unit/test_login_keyboard.c
+++ b/tests/unit/test_login_keyboard.c
@@ -3,6 +3,10 @@
 #include "../../kernel/IPC/ipc.h"
 #include "../../user/libc/libc.h"
 #include "../../user/agents/login/login.h"
+#include "../../user/rt/agent_abi.h"
+
+const AgentAPI *NOS = NULL;
+uint32_t NOS_TID = 0;
 
 static const char *input = "admin\nadmin\n";
 static size_t pos = 0;
@@ -24,6 +28,10 @@ int serial_read(void) {
     if (pos >= strlen(input)) return -1;
     return (unsigned char)input[pos++];
 }
+
+/* Stubs for TTY output used by the login server */
+void tty_clear(void) {}
+void tty_write(const char *s) { (void)s; }
 
 int main(void) {
     ipc_queue_t q; (void)q;

--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -1,16 +1,25 @@
 #include "login.h"
+#include "../../rt/agent_abi.h"
 #ifndef LOGIN_UNIT_TEST
 #include "../../../nosm/drivers/IO/serial.c"
 #else
 #include "../../../nosm/drivers/IO/serial.h"
 #endif
+#include "../../../nosm/drivers/IO/tty.h"
 
 #include <stdint.h>
 
 volatile login_session_t current_session = {0};
 
-/* Simple output helper (no stdio). */
-static void put_str(const char *s) { serial_puts(s); }
+/* Simple output helper that uses the Agent API when available, otherwise
+ * falls back to the TTY driver directly. */
+static void put_str(const char *s) {
+    if (NOS && NOS->puts) {
+        NOS->puts(s);
+    } else {
+        tty_write(s);
+    }
+}
 
 /* Block until a character is available from the serial port. */
 static char getchar_block(void) {
@@ -52,6 +61,7 @@ void login_server(void *fs_q, uint32_t self_id) {
     (void)fs_q; (void)self_id;
 
     serial_init();
+    tty_clear();
     put_str("[login] server starting\n");
 
     char user[32];


### PR DESCRIPTION
## Summary
- Mirror serial writes to the TTY driver so kernel and agent logs also reach the framebuffer
- Add a display-only TTY helper and simplify tty_putc to rely on the serial layer

## Testing
- `make -C tests`
- `make image`


------
https://chatgpt.com/codex/tasks/task_b_689e8b408ce08333877c0a42233daab6