### PR TITLE
Add NitroHeap syscall wrappers and tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
 
 LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c vmm_stub.c ../kernel/uaccess.c
 
-UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2 test_regx_load test_nh_classes
+UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2 test_regx_load test_nh_classes test_nh_sys
 
 all: $(UNIT_TESTS)
 	for t in $(UNIT_TESTS); do ./$$t; done
@@ -51,10 +51,15 @@ test_thread: unit/test_thread.c ../kernel/Task/thread.c thread_test_stubs.c $(fi
 	$(CC) $(CFLAGS) -DUNIT_TEST $^ -Wl,--gc-sections -o $@
 
 test_nitroheap: unit/test_nitroheap.c ../kernel/VM/nitroheap/nitroheap.c \
-	../kernel/VM/nitroheap/classes.c buddy_stub.c $(LIBC_SRC)
+        ../kernel/VM/nitroheap/classes.c buddy_stub.c $(LIBC_SRC)
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_nh_classes: unit/test_nh_classes.c ../kernel/VM/nitroheap/classes.c $(LIBC_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_nh_sys: unit/test_nh_sys.c ../kernel/VM/nitroheap/nitroheap.c \
+        ../kernel/VM/nitroheap/classes.c nh_sys_shim.c \
+        buddy_stub.c $(filter-out ../user/libc/libc.c,$(LIBC_SRC))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_hal: unit/test_hal.c ../kernel/hal.c ../kernel/hal_async.c ../kernel/regx.c $(LIBC_SRC)

--- a/tests/buddy_stub.c
+++ b/tests/buddy_stub.c
@@ -7,7 +7,9 @@ void* buddy_alloc(uint32_t order, int preferred_node, int strict) {
     (void)preferred_node;
     (void)strict;
     size_t bytes = ((size_t)1 << order) * 4096;
-    void* p = malloc(bytes);
+    void* p = NULL;
+    if (posix_memalign(&p, 4096, bytes) != 0)
+        p = NULL;
     if (p) buddy_allocs++;
     return p;
 }

--- a/tests/nh_sys_shim.c
+++ b/tests/nh_sys_shim.c
@@ -1,0 +1,21 @@
+#include "../include/nitroheap_sys.h"
+#include <stddef.h>
+
+void* mallocx(size_t size, nh_flags_t flags) {
+    nh_alloc_req req = { .size = size, .flags = flags, .partition_hint = 0 };
+    nh_alloc_resp resp;
+    if (sys_nh_alloc(&req, &resp) != 0) return NULL;
+    return resp.ptr;
+}
+
+int dallocx(void* p, nh_flags_t flags) {
+    nh_free_req req = { .ptr = p, .flags = flags };
+    return sys_nh_free(&req);
+}
+
+void* rallocx(void* p, size_t size, nh_flags_t flags) {
+    nh_realloc_req req = { .ptr = p, .new_size = size, .flags = flags };
+    nh_alloc_resp resp;
+    if (sys_nh_realloc(&req, &resp) != 0) return NULL;
+    return resp.ptr;
+}

--- a/tests/unit/test_nh_sys.c
+++ b/tests/unit/test_nh_sys.c
@@ -1,0 +1,29 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "../../include/nitroheap_shim.h"
+#include "../../kernel/VM/nitroheap/nitroheap.h"
+
+extern int buddy_allocs;
+void smp_stub_set_cpu_index(uint32_t idx);
+
+int main(void) {
+    smp_stub_set_cpu_index(0);
+    nitroheap_init();
+
+    void* p = mallocx(64, NH_PRESET_BALANCED);
+    assert(p);
+    memset(p, 0x5A, 64);
+    dallocx(p, 0);
+
+    void* q = mallocx(32, NH_PRESET_BALANCED);
+    assert(q);
+    memset(q, 0x5A, 32);
+    q = rallocx(q, 64, NH_PRESET_BALANCED);
+    assert(q);
+    dallocx(q, 0);
+
+    printf("nh syscall tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expose sys_nh_alloc/free/realloc in NitroHeap and decode alignment hints
- stub out handle-based syscalls for future movable allocations
- add unit test exercising mallocx/dallocx/rallocx via the syscall path

## Testing
- `make test_nh_classes`
- `./test_nh_classes`
- `make test_nitroheap`
- `./test_nitroheap`
- `make test_nh_sys`
- `./test_nh_sys`


------
https://chatgpt.com/codex/tasks/task_b_689e95a9b8688333b0d6324e9816d2cc