### PR TITLE
Add basic heap stats and sys_heapctl support

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
 
 LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c vmm_stub.c ../kernel/uaccess.c
 
-UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2 test_regx_load test_nh_classes test_nh_sys
+UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2 test_regx_load test_nh_classes test_nh_sys test_nh_stats
 
 all: $(UNIT_TESTS)
 	for t in $(UNIT_TESTS); do ./$$t; done
@@ -58,8 +58,13 @@ test_nh_classes: unit/test_nh_classes.c ../kernel/VM/nitroheap/classes.c $(LIBC_
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_nh_sys: unit/test_nh_sys.c ../kernel/VM/nitroheap/nitroheap.c \
-        ../kernel/VM/nitroheap/classes.c nh_sys_shim.c \
-        buddy_stub.c $(filter-out ../user/libc/libc.c,$(LIBC_SRC))
+../kernel/VM/nitroheap/classes.c nh_sys_shim.c \
+buddy_stub.c $(filter-out ../user/libc/libc.c,$(LIBC_SRC))
+	$(CC) $(CFLAGS) $^ -o $@
+
+test_nh_stats: unit/test_nh_stats.c ../kernel/VM/nitroheap/nitroheap.c \
+../kernel/VM/nitroheap/classes.c nh_sys_shim.c \
+buddy_stub.c $(filter-out ../user/libc/libc.c,$(LIBC_SRC))
 	$(CC) $(CFLAGS) $^ -o $@
 
 test_hal: unit/test_hal.c ../kernel/hal.c ../kernel/hal_async.c ../kernel/regx.c $(LIBC_SRC)

--- a/tests/unit/test_nh_stats.c
+++ b/tests/unit/test_nh_stats.c
@@ -1,0 +1,45 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include "../../include/nitroheap_shim.h"
+#include "../../include/nitroheap_sys.h"
+#include "../../include/nitroheap_stats.h"
+#include "../../kernel/VM/nitroheap/nitroheap.h"
+
+void smp_stub_set_cpu_index(uint32_t idx);
+
+int main(void) {
+    smp_stub_set_cpu_index(0);
+    nitroheap_init();
+
+    nh_part_stats_summary stats;
+    nh_heapctl_get_stats_args args = {
+        .part_id = 0,
+        .include_per_cpu = 0,
+        .user_buf = &stats,
+        .user_buf_len = sizeof(stats),
+    };
+
+    int ret = sys_heapctl(NH_HEAPCTL_GET_STATS, &args, sizeof(args));
+    assert(ret == 0);
+    assert(stats.bytes_inuse == 0);
+    assert(stats.allocs == 0);
+    assert(stats.frees == 0);
+
+    void* p = mallocx(64, NH_PRESET_BALANCED);
+    assert(p);
+    ret = sys_heapctl(NH_HEAPCTL_GET_STATS, &args, sizeof(args));
+    assert(ret == 0);
+    assert(stats.bytes_inuse >= 64);
+    assert(stats.allocs >= 1);
+
+    dallocx(p, 0);
+    ret = sys_heapctl(NH_HEAPCTL_GET_STATS, &args, sizeof(args));
+    assert(ret == 0);
+    assert(stats.bytes_inuse == 0);
+    assert(stats.frees >= 1);
+
+    printf("nh stats tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- track allocation statistics for the default nitroheap partition
- expose stats via a new `sys_heapctl` GET_STATS handler
- add unit test exercising the stats syscall

## Testing
- `make test_nh_stats`
- `./test_nh_stats`
- `./test_nh_classes`
- `./test_nitroheap`
- `./test_nh_sys`


------
https://chatgpt.com/codex/tasks/task_b_689e9a583f7c833394e29840b9eeabe0