### PR TITLE
Add extensible syscall registry

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -255,6 +255,7 @@ void n2_main(bootinfo_t *bootinfo) {
     const bootinfo_framebuffer_t *fb = (const bootinfo_framebuffer_t *)&bootinfo->fb;
     video_init(fb);
     tty_init();
+    syscalls_init();
     devfs_init();
     ps2_init();
     {

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -14,5 +14,9 @@ typedef struct {
     uint64_t r11;
 } syscall_regs_t;
 
+typedef long (*syscall_fn_t)(syscall_regs_t *regs);
+
+int  n2_syscall_register(uint32_t num, syscall_fn_t fn);
+void syscalls_init(void);
 long isr_syscall_handler(syscall_regs_t *regs);
 void devfs_init(void);


### PR DESCRIPTION
## Summary
- Introduce dynamic syscall table and registration API
- Register open/read/write/close plus clock_gettime, lseek, and rename handlers
- Initialize syscall registry during kernel startup

## Testing
- `make kernel`
- `gcc -I include -I kernel -I tests -O2 tests/unit/test_nh_sys.c tests/nh_sys_shim.c kernel/VM/nitroheap/nitroheap.c kernel/VM/nitroheap/classes.c kernel/VM/pmm_buddy.c kernel/VM/pmm.c kernel/arch/CPU/smp.c kernel/klib/string.c kernel/klib/stdio.c -o /tmp/test_nh && /tmp/test_nh` *(fails: undefined reference to `smp_stub_set_cpu_index` and other symbols)*

------
https://chatgpt.com/codex/tasks/task_b_689e9d01df3483339b4545b51979fa8a