### PR TITLE
Add SATA-backed storage and NOSFS disk formatting

### DIFF
--- a/include/nosfs.h
+++ b/include/nosfs.h
@@ -101,5 +101,6 @@ int    nosfs_load_device(nosfs_fs_t *fs, uint32_t start_lba);
 
 extern int block_read(uint32_t lba, uint8_t *buf, size_t count);
 extern int block_write(uint32_t lba, const uint8_t *buf, size_t count);
+extern int block_use_sata(void);
 
 #endif // NOSFS_H

--- a/nosm/drivers/IO/block.c
+++ b/nosm/drivers/IO/block.c
@@ -1,27 +1,74 @@
 #include "block.h"
+#include "sata.h"
 #include <string.h>
+
+/*
+ * Simple pluggable block backend.
+ * By default a small RAM disk is used so unit tests and early boot
+ * continue to function even when no physical disk is present.  The
+ * backend can be switched to the SATA driver by calling
+ * block_use_sata(), which attempts to initialise the real device and
+ * swaps the read/write function pointers if successful.
+ */
 
 static uint8_t storage[BLOCK_DEVICE_BLOCKS * BLOCK_SIZE];
 
-void block_init(void) {
-    memset(storage, 0, sizeof(storage));
-}
-
-int block_read(uint32_t lba, uint8_t *buf, size_t count) {
+static int ramdisk_read(uint32_t lba, uint8_t *buf, size_t count)
+{
     if (lba + count > BLOCK_DEVICE_BLOCKS)
         return -1;
     memcpy(buf, &storage[lba * BLOCK_SIZE], count * BLOCK_SIZE);
     return (int)count;
 }
 
-int block_write(uint32_t lba, const uint8_t *buf, size_t count) {
+static int ramdisk_write(uint32_t lba, const uint8_t *buf, size_t count)
+{
     if (lba + count > BLOCK_DEVICE_BLOCKS)
         return -1;
     memcpy(&storage[lba * BLOCK_SIZE], buf, count * BLOCK_SIZE);
     return (int)count;
 }
 
-int block_handle_ipc(ipc_message_t *msg) {
+/* Function pointers to the active backend. */
+static int (*read_fn)(uint32_t, uint8_t *, size_t)  = ramdisk_read;
+static int (*write_fn)(uint32_t, const uint8_t *, size_t) = ramdisk_write;
+
+/* Weak SATA hooks so tests link even without the real driver. */
+__attribute__((weak)) int sata_init(void) { return -1; }
+__attribute__((weak)) int sata_read_block(uint32_t lba, uint8_t *buf, size_t cnt)
+{ (void)lba; (void)buf; (void)cnt; return -1; }
+__attribute__((weak)) int sata_write_block(uint32_t lba, const uint8_t *buf, size_t cnt)
+{ (void)lba; (void)buf; (void)cnt; return -1; }
+
+void block_init(void)
+{
+    memset(storage, 0, sizeof(storage));
+    read_fn  = ramdisk_read;
+    write_fn = ramdisk_write;
+}
+
+int block_use_sata(void)
+{
+    if (sata_init() == 0) {
+        read_fn  = sata_read_block;
+        write_fn = sata_write_block;
+        return 0;
+    }
+    return -1;
+}
+
+int block_read(uint32_t lba, uint8_t *buf, size_t count)
+{
+    return read_fn(lba, buf, count);
+}
+
+int block_write(uint32_t lba, const uint8_t *buf, size_t count)
+{
+    return write_fn(lba, buf, count);
+}
+
+int block_handle_ipc(ipc_message_t *msg)
+{
     if (!msg)
         return -1;
     switch (msg->type) {

--- a/nosm/drivers/IO/block.h
+++ b/nosm/drivers/IO/block.h
@@ -9,6 +9,7 @@
 #define BLOCK_DEVICE_BLOCKS 2048
 
 void block_init(void);
+int  block_use_sata(void);
 int  block_read(uint32_t lba, uint8_t *buf, size_t count);
 int  block_write(uint32_t lba, const uint8_t *buf, size_t count);
 

--- a/nosm/drivers/IO/sata.c
+++ b/nosm/drivers/IO/sata.c
@@ -1,15 +1,88 @@
 #include "sata.h"
-#include "block.h"
+#include "io.h"
 
-int sata_init(void) {
-    /* In a real driver, PCI enumeration and AHCI setup would happen here. */
+/* Minimal PIO-based ATA driver.  Only supports 28-bit LBA and
+ * sector sized transfers (512 bytes).  It is intentionally small and
+ * synchronous as it is primarily used by the block layer to provide
+ * disk backed storage for NOSFS.
+ */
+
+#define ATA_IO_BASE     0x1F0
+#define ATA_REG_DATA    0
+#define ATA_REG_ERROR   1
+#define ATA_REG_SECCNT  2
+#define ATA_REG_LBA0    3
+#define ATA_REG_LBA1    4
+#define ATA_REG_LBA2    5
+#define ATA_REG_HDSEL   6
+#define ATA_REG_CMD     7
+#define ATA_REG_STATUS  7
+
+#define ATA_CMD_READ    0x20
+#define ATA_CMD_WRITE   0x30
+
+static int ata_wait_ready(void)
+{
+    uint8_t status;
+    do {
+        status = inb(ATA_IO_BASE + ATA_REG_STATUS);
+    } while (status & 0x80); /* BSY */
+    if (status & 0x01)       /* ERR */
+        return -1;
     return 0;
 }
 
-int sata_read_block(uint32_t lba, uint8_t *buf, size_t count) {
-    return block_read(lba, buf, count);
+int sata_init(void)
+{
+    /* Poll the status port to see if a device responds.  This is a very
+     * light‑weight check but suffices for our purposes.  If the port
+     * returns 0xFF it typically indicates no device.
+     */
+    if (inb(ATA_IO_BASE + ATA_REG_STATUS) == 0xFF)
+        return -1;
+    return ata_wait_ready();
 }
 
-int sata_write_block(uint32_t lba, const uint8_t *buf, size_t count) {
-    return block_write(lba, buf, count);
+int sata_read_block(uint32_t lba, uint8_t *buf, size_t count)
+{
+    if (!buf)
+        return -1;
+    for (size_t i = 0; i < count; ++i) {
+        if (ata_wait_ready() < 0)
+            return -1;
+        outb(ATA_IO_BASE + ATA_REG_HDSEL, 0xE0 | ((lba >> 24) & 0x0F));
+        outb(ATA_IO_BASE + ATA_REG_SECCNT, 1);
+        outb(ATA_IO_BASE + ATA_REG_LBA0, (uint8_t)(lba));
+        outb(ATA_IO_BASE + ATA_REG_LBA1, (uint8_t)(lba >> 8));
+        outb(ATA_IO_BASE + ATA_REG_LBA2, (uint8_t)(lba >> 16));
+        outb(ATA_IO_BASE + ATA_REG_CMD, ATA_CMD_READ);
+        if (ata_wait_ready() < 0)
+            return -1;
+        insw(ATA_IO_BASE + ATA_REG_DATA, buf + i * 512, 256);
+        lba++;
+    }
+    return (int)count;
+}
+
+int sata_write_block(uint32_t lba, const uint8_t *buf, size_t count)
+{
+    if (!buf)
+        return -1;
+    for (size_t i = 0; i < count; ++i) {
+        if (ata_wait_ready() < 0)
+            return -1;
+        outb(ATA_IO_BASE + ATA_REG_HDSEL, 0xE0 | ((lba >> 24) & 0x0F));
+        outb(ATA_IO_BASE + ATA_REG_SECCNT, 1);
+        outb(ATA_IO_BASE + ATA_REG_LBA0, (uint8_t)(lba));
+        outb(ATA_IO_BASE + ATA_REG_LBA1, (uint8_t)(lba >> 8));
+        outb(ATA_IO_BASE + ATA_REG_LBA2, (uint8_t)(lba >> 16));
+        outb(ATA_IO_BASE + ATA_REG_CMD, ATA_CMD_WRITE);
+        if (ata_wait_ready() < 0)
+            return -1;
+        outsw(ATA_IO_BASE + ATA_REG_DATA, buf + i * 512, 256);
+        if (ata_wait_ready() < 0)
+            return -1;
+        lba++;
+    }
+    return (int)count;
 }

--- a/tests/unit/test_nosfs.c
+++ b/tests/unit/test_nosfs.c
@@ -36,6 +36,11 @@ int main(void) {
 
     /* Save to mock device and reload */
     assert(nosfs_save_device(&fs, 0) > 0);
+    uint8_t sb[NOSFS_BLOCK_SIZE];
+    assert(block_read(0, sb, 1) == 1);
+    nosfs_superblock_t *super = (nosfs_superblock_t *)sb;
+    assert(super->magic == NOSFS_MAGIC);
+
     nosfs_fs_t fs2;
     assert(nosfs_load_device(&fs2, 0) == 0);
     char buf2[4];


### PR DESCRIPTION
## Summary
- add pluggable block layer with optional SATA backend and helper to enable it
- persist NOSFS volumes with a superblock and teach server to load from disks
- extend NOSFormatU to initialize disks with NOSFS structures and document with tests

## Testing
- `make test_nosfs`


------
https://chatgpt.com/codex/tasks/task_b_689e9d55db7083338c2026aa4d4de6f9