### PR TITLE
Use /dev/console for login

### DIFF
--- a/docs/SERIAL_CONSOLE.md
+++ b/docs/SERIAL_CONSOLE.md
@@ -4,8 +4,10 @@ This short guide explains how to capture kernel logs over the COM1 serial port.
 
 ## Overview
 
-The kernel initializes a basic driver for the first serial port at boot.
-All log messages printed to the VGA console are also sent to COM1.
+NitrOS now uses the `/dev/console` device as the primary display for kernel
+logs and the login agent.  The first serial port still mirrors console output,
+providing a convenient way to capture logs remotely or when no framebuffer is
+available.
 The port runs at **38400** baud using 8 data bits, no parity, and one stop bit (8N1).
 
 ## Using QEMU


### PR DESCRIPTION
## Summary
- Route login I/O through `/dev/console` with serial fallback
- Document `/dev/console` as primary display for logs and login

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_b_689ea10fedd0833398d30691cacfe683