### PR TITLE
Track backlog metrics in NitroHeap stats

### DIFF
--- a/tests/unit/test_nh_stats.c
+++ b/tests/unit/test_nh_stats.c
@@ -27,18 +27,35 @@ int main(void) {
     assert(stats.allocs == 0);
     assert(stats.frees == 0);
 
+    void* hold64 = mallocx(64, NH_PRESET_BALANCED);
     void* p = mallocx(64, NH_PRESET_BALANCED);
-    assert(p);
+    assert(hold64 && p);
     ret = sys_heapctl(NH_HEAPCTL_GET_STATS, &args, sizeof(args));
     assert(ret == 0);
-    assert(stats.bytes_inuse >= 64);
-    assert(stats.allocs >= 1);
+    assert(stats.bytes_inuse >= 128);
+    assert(stats.allocs >= 2);
 
     dallocx(p, 0);
     ret = sys_heapctl(NH_HEAPCTL_GET_STATS, &args, sizeof(args));
     assert(ret == 0);
-    assert(stats.bytes_inuse == 0);
+    assert(stats.bytes_inuse >= 64);
     assert(stats.frees >= 1);
+    assert(stats.quarantine_backlog >= 1);
+    assert(stats.remote_free_backlog == 0);
+
+    void* hold32 = mallocx(32, NH_PRESET_BALANCED);
+    void* x = mallocx(32, NH_PRESET_BALANCED);
+    assert(hold32 && x);
+    smp_stub_set_cpu_index(1);
+    dallocx(x, 0); // cross-CPU free
+    smp_stub_set_cpu_index(0);
+    ret = sys_heapctl(NH_HEAPCTL_GET_STATS, &args, sizeof(args));
+    assert(ret == 0);
+    assert(stats.bytes_inuse >= 96);
+    assert(stats.remote_free_backlog >= 1);
+
+    dallocx(hold32, 0);
+    dallocx(hold64, 0);
 
     printf("nh stats tests passed\n");
     return 0;


### PR DESCRIPTION
## Summary
- Report quarantine and remote-free backlog counts in `sys_heapctl` stats
- Add unit tests covering new NitroHeap telemetry

## Testing
- `make -C tests test_nh_stats && ./tests/test_nh_stats`
- `make -C tests test_nitroheap && ./tests/test_nitroheap`
- `make -C tests test_nh_sys && ./tests/test_nh_sys`
- `make -C tests test_nh_classes && ./tests/test_nh_classes`


------
https://chatgpt.com/codex/tasks/task_b_689ea0a118bc8333b97819aa3b28e9de