### PR TITLE
Add basic NH_MOVABLE handle support to nitroheap

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ CFLAGS=-Wall -Wextra -std=gnu11 \
 
 LIBC_SRC=../user/libc/libc.c thread_stub.c smp_stub.c gdt_stub.c kprintf_stub.c vmm_stub.c ../kernel/uaccess.c
 
-UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2 test_regx_load test_nh_classes test_nh_sys test_nh_stats
+UNIT_TESTS=test_ipc test_pmm test_login test_ftp test_login_keyboard test_net test_gdt test_nosm test_nosfs test_regx test_thread test_nitroheap test_hal test_macho2 test_regx_load test_nh_classes test_nh_sys test_nh_stats test_nh_handles
 
 all: $(UNIT_TESTS)
 	for t in $(UNIT_TESTS); do ./$$t; done
@@ -60,9 +60,14 @@ test_nh_classes: unit/test_nh_classes.c ../kernel/VM/nitroheap/classes.c $(LIBC_
 test_nh_sys: unit/test_nh_sys.c ../kernel/VM/nitroheap/nitroheap.c \
 ../kernel/VM/nitroheap/classes.c nh_sys_shim.c \
 buddy_stub.c $(filter-out ../user/libc/libc.c,$(LIBC_SRC))
-	$(CC) $(CFLAGS) $^ -o $@
+	        $(CC) $(CFLAGS) $^ -o $@
 
 test_nh_stats: unit/test_nh_stats.c ../kernel/VM/nitroheap/nitroheap.c \
+../kernel/VM/nitroheap/classes.c nh_sys_shim.c \
+buddy_stub.c $(filter-out ../user/libc/libc.c,$(LIBC_SRC))
+	        $(CC) $(CFLAGS) $^ -o $@
+
+test_nh_handles: unit/test_nh_handles.c ../kernel/VM/nitroheap/nitroheap.c \
 ../kernel/VM/nitroheap/classes.c nh_sys_shim.c \
 buddy_stub.c $(filter-out ../user/libc/libc.c,$(LIBC_SRC))
 	$(CC) $(CFLAGS) $^ -o $@

--- a/tests/nh_sys_shim.c
+++ b/tests/nh_sys_shim.c
@@ -1,4 +1,5 @@
 #include "../include/nitroheap_sys.h"
+#include "../include/nitroheap_shim.h"
 #include <stddef.h>
 
 void* mallocx(size_t size, nh_flags_t flags) {
@@ -18,4 +19,23 @@ void* rallocx(void* p, size_t size, nh_flags_t flags) {
     nh_alloc_resp resp;
     if (sys_nh_realloc(&req, &resp) != 0) return NULL;
     return resp.ptr;
+}
+
+nh_handle_t halloc(size_t size, nh_flags_t flags) {
+    nh_halloc_req req = { .size = size, .flags = flags };
+    nh_halloc_resp resp;
+    if (sys_nh_halloc(&req, &resp) != 0) return 0;
+    return resp.handle;
+}
+
+void* hptr(nh_handle_t h) {
+    nh_hptr_req req = { .handle = h };
+    nh_alloc_resp resp;
+    if (sys_nh_hptr(&req, &resp) != 0) return NULL;
+    return resp.ptr;
+}
+
+int hfree(nh_handle_t h) {
+    nh_hfree_req req = { .handle = h };
+    return sys_nh_hfree(&req);
 }

--- a/tests/unit/test_nh_handles.c
+++ b/tests/unit/test_nh_handles.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "../../include/nitroheap_shim.h"
+#include "../../kernel/VM/nitroheap/nitroheap.h"
+
+void smp_stub_set_cpu_index(uint32_t idx);
+
+int main(void) {
+    smp_stub_set_cpu_index(0);
+    nitroheap_init();
+
+    nh_handle_t h = halloc(64, NH_PRESET_BALANCED);
+    assert(h != 0);
+    void* p = hptr(h);
+    assert(p);
+    memset(p, 0x5A, 64);
+    assert(hfree(h) == 0);
+
+    printf("nh handle tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- support NH_MOVABLE allocations using a simple handle table
- expose halloc/hptr/hfree through the shim
- add unit test for handle syscalls

## Testing
- `make test_nh_handles test_nh_classes test_nh_sys test_nh_stats test_nitroheap`
- `./test_nh_handles`
- `./test_nh_classes`
- `./test_nh_sys`
- `./test_nh_stats`
- `./test_nitroheap`


------
https://chatgpt.com/codex/tasks/task_b_689eabfb210c83339e6b1f28ac78bf11