### PR TITLE
Ensure login agent writes to TTY

### DIFF
--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -354,14 +354,23 @@ void n2_main(bootinfo_t *bootinfo) {
         thread_yield();
 
     if (!n2_agent_get("login")) {
-        for (uint32_t i = 0; i < bootinfo->module_count; ++i) {
-            const char *m = bootinfo->modules[i].name;
-            if (!m) continue;
-            if (!strcmp(m, "login.mo2") || !strcmp(m, "agents/login.mo2")) {
-                load_agent(bootinfo->modules[i].base,
-                           bootinfo->modules[i].size,
-                           m, MAX_PRIORITY);
-                break;
+        /* Prefer loading the login agent from the filesystem so custom
+           builds in user/agents take effect even if boot modules are
+           stale. */
+        int tid = agent_loader_run_from_path("agents/login.mo2", MAX_PRIORITY);
+        if (tid < 0)
+            tid = agent_loader_run_from_path("login.mo2", MAX_PRIORITY);
+        if (tid < 0) {
+            /* Fall back to any copy bundled as a boot module. */
+            for (uint32_t i = 0; i < bootinfo->module_count; ++i) {
+                const char *m = bootinfo->modules[i].name;
+                if (!m) continue;
+                if (!strcmp(m, "login.mo2") || !strcmp(m, "agents/login.mo2")) {
+                    load_agent(bootinfo->modules[i].base,
+                               bootinfo->modules[i].size,
+                               m, MAX_PRIORITY);
+                    break;
+                }
             }
         }
     }

--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -19,10 +19,11 @@ static void put_str(const char *s) {
     if (console) {
         fwrite(s, 1, strlen(s), console);
         fflush(console);
-    } else if (NOS && NOS->puts) {
-        NOS->puts(s);
     } else {
+        /* Prefer the graphical TTY when no /dev/console handle is available. */
         tty_write(s);
+        if (NOS && NOS->puts)
+            NOS->puts(s);
     }
 }
 


### PR DESCRIPTION
## Summary
- Prefer the filesystem login agent by loading `agents/login.mo2` before falling back to any bundled boot modules

## Testing
- `make test_login test_login_keyboard`
- `./test_login && ./test_login_keyboard`


------
https://chatgpt.com/codex/tasks/task_b_689eadcf40e08333a075c38fbe3a09e7