### PR TITLE
Log kernel output only to serial console

### DIFF
--- a/docs/SERIAL_CONSOLE.md
+++ b/docs/SERIAL_CONSOLE.md
@@ -4,11 +4,10 @@ This short guide explains how to capture kernel logs over the COM1 serial port.
 
 ## Overview
 
-NitrOS now uses the `/dev/console` device as the primary display for kernel
-logs and the login agent.  The first serial port still mirrors console output,
-providing a convenient way to capture logs remotely or when no framebuffer is
-available.
-The port runs at **38400** baud using 8 data bits, no parity, and one stop bit (8N1).
+All kernel messages are emitted exclusively over the first serial port (COM1),
+leaving the `/dev/console` device for userland such as the login agent.
+Nothing is mirrored to the framebuffer by the kernel. The port runs at
+**38400** baud using 8 data bits, no parity, and one stop bit (8N1).
 
 ## Using QEMU
 

--- a/kernel/n2_main.c
+++ b/kernel/n2_main.c
@@ -375,9 +375,6 @@ void n2_main(bootinfo_t *bootinfo) {
         }
     }
 
-    /* Hand over the display to userland once login is launched. */
-    serial_set_mirror_to_tty(0);
-
     /* If login still isn't available, fall back to launching init from the
        filesystem so the user at least gets a prompt. */
     if (!n2_agent_get("login")) {

--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -1,6 +1,5 @@
 #include <stdarg.h>
 #include "drivers/IO/serial.h"
-#include "drivers/IO/tty.h"
 #include "klib/stdio.h"
 #include "panic.h"
 
@@ -11,7 +10,9 @@
  * and avoids duplicate symbol definitions when linking.
  */
 void kcons_putc(int c) {
-    tty_putc((char)c);
+    if (c == '\n')
+        serial_write('\r');
+    serial_write((char)c);
 }
 
 int kprintf(const char *fmt, ...) {

--- a/nosm/drivers/IO/serial.c
+++ b/nosm/drivers/IO/serial.c
@@ -35,7 +35,12 @@ static int serial_empty(void) {
     return inb(COM1 + 5) & 0x20;
 }
 
-static bool mirror_to_tty = true;
+/*
+ * Mirror kernel serial output to the on-screen TTY by default.  The kernel
+ * now reserves the TTY for userland so disable mirroring unless explicitly
+ * enabled.
+ */
+static bool mirror_to_tty = false;
 
 void serial_set_mirror_to_tty(int enable) { mirror_to_tty = (enable != 0); }
 


### PR DESCRIPTION
## Summary
- Route kernel printf output directly to the serial port
- Disable default serial mirroring to the framebuffer and remove redundant handoff
- Clarify serial console documentation to reflect serial-only kernel logs

## Testing
- `make -C tests`
- `make kernel`


------
https://chatgpt.com/codex/tasks/task_b_689ec3ede5c883338653bb0185e32e81