### PR TITLE
Initialize TTY with framebuffer for login

### DIFF
--- a/tests/unit/test_login.c
+++ b/tests/unit/test_login.c
@@ -17,6 +17,8 @@ ipc_queue_t upd_queue;
 ipc_queue_t fs_queue;
 
 /* Stubs for TTY input/output used by the login server */
+void tty_init(void) {}
+void tty_enable_framebuffer(int enable) { (void)enable; }
 void tty_clear(void) {}
 void tty_putc_noserial(char c) { (void)c; }
 int tty_getchar(void) {

--- a/tests/unit/test_login_keyboard.c
+++ b/tests/unit/test_login_keyboard.c
@@ -17,6 +17,8 @@ ipc_queue_t upd_queue;
 ipc_queue_t fs_queue;
 
 /* Stubs for TTY input/output used by the login server */
+void tty_init(void) {}
+void tty_enable_framebuffer(int enable) { (void)enable; }
 void tty_clear(void) {}
 void tty_putc_noserial(char c) { (void)c; }
 int tty_getchar(void) {

--- a/user/agents/login/login.c
+++ b/user/agents/login/login.c
@@ -57,7 +57,11 @@ static void read_line(char *buf, size_t sz, int echo_asterisk) {
 /* Public entry point for the login server. */
 void login_server(void *fs_q, uint32_t self_id) {
     (void)fs_q; (void)self_id;
-
+    /* Ensure the TTY is initialized and prefer the linear framebuffer so the
+     * login prompt is always visible even when legacy VGA text memory is
+     * absent. */
+    tty_init();
+    tty_enable_framebuffer(1);
     tty_clear();
     put_str("[login] server starting\n");
 


### PR DESCRIPTION
## Summary
- Initialize TTY and enable framebuffer in the login server so the prompt appears even without legacy VGA
- Update unit tests with stubs for the new TTY init and framebuffer calls

## Testing
- `make test_login test_login_keyboard`
- `./test_login && ./test_login_keyboard`


------
https://chatgpt.com/codex/tasks/task_b_689eca8f31b0833383394de4efbafc84